### PR TITLE
chore: use gemini 2.5 pro model

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4,7 +4,7 @@ import process from "process";
 import functions from "firebase-functions";
 import nodemailer from "nodemailer";
 import admin from "firebase-admin";
-import { gemini15Pro, googleAI } from "@genkit-ai/googleai";
+import { gemini, googleAI } from "@genkit-ai/googleai";
 import { genkit } from "genkit";
 import { onCall, HttpsError, onRequest } from "firebase-functions/v2/https";
 
@@ -105,7 +105,7 @@ export const generateTrainingPlan = onCall(
 
       const ai = genkit({
         plugins: [googleAI({ apiKey: key })],
-        model: gemini15Pro,
+        model: gemini('gemini-2.5-pro'),
       });
 
       const trainingPlanFlow = ai.defineFlow(
@@ -153,7 +153,7 @@ export const generateStudyMaterial = onCall(
 
       const ai = genkit({
         plugins: [googleAI({ apiKey: key })],
-        model: gemini15Pro,
+        model: gemini('gemini-2.5-pro'),
       });
 
       const promptTemplate = `Create a comprehensive study guide on "${topic}" for high school or college students.  Include the following:
@@ -215,7 +215,7 @@ export const generateCourseOutline = onCall(
       // Initialize GenKit instance with the Google AI plugin using the secret API key.
       const ai = genkit({
         plugins: [googleAI({ apiKey: key })],
-        model: gemini15Pro,
+        model: gemini('gemini-2.5-pro'),
       });
 
       // Build the prompt template using the provided topic.
@@ -278,7 +278,7 @@ export const generateAssessment = onCall(
 
       const ai = genkit({
         plugins: [googleAI({ apiKey: key })],
-        model: gemini15Pro,
+        model: gemini('gemini-2.5-pro'),
       });
 
       const promptTemplate = `Create an assessment and answer key/rubric on the topic of "${topic}".  The assessment should evaluate understanding of the key concepts related to this topic.
@@ -331,7 +331,7 @@ export const generateLessonContent = onCall(
 
       const ai = genkit({
         plugins: [googleAI({ apiKey: key })],
-        model: gemini15Pro, // Or your preferred model
+        model: gemini('gemini-2.5-pro'), // Or your preferred model
       });
 
       const promptTemplate = `Create comprehensive lesson content on the topic: "${topic}".
@@ -392,7 +392,7 @@ export const generateStoryboard = onCall(
 
       const ai = genkit({
         plugins: [googleAI({ apiKey: key })],
-        model: gemini15Pro, 
+        model: gemini('gemini-2.5-pro'),
       });
 
       const promptTemplate = `Create a detailed and engaging e-learning storyboard on the topic: "${topic}".

--- a/src/ai.js
+++ b/src/ai.js
@@ -1,12 +1,12 @@
 // src/ai.js
 import { genkit } from 'genkit';
-import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
+import { gemini, googleAI } from '@genkit-ai/googleai';
 
 // The googleAI plugin should automatically pick up your API key from your environment.
 // (Ensure your .env file contains REACT_APP_GOOGLE_GENAI_API_KEY if using Create React App.)
 const ai = genkit({
   plugins: [googleAI()],
-  model: gemini15Flash, // set the default model
+  model: gemini('gemini-2.5-pro'), // set the default model
 });
 
 // Define a flow for generating a course outline.


### PR DESCRIPTION
## Summary
- switch frontend Genkit default model to Gemini 2.5 Pro
- update backend Cloud Functions to instantiate Genkit with Gemini 2.5 Pro

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e69e8dc84832baf5bdafabfedfc67