### PR TITLE
Add landing signup bar and animated node background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,33 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 200%;
+  height: 200%;
+  background:
+    radial-gradient(circle, rgba(255, 255, 255, 0.3) 2px, transparent 3px) 0 0/60px 60px,
+    radial-gradient(circle, rgba(255, 255, 255, 0.15) 2px, transparent 3px) 30px 30px/60px 60px;
+  animation: nodesMove 25s linear infinite;
+  opacity: 0.3;
+  z-index: -1;
+  pointer-events: none;
+}
+
+@keyframes nodesMove {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-60px);
+  }
 }
 
 .page-container {
@@ -33,4 +60,30 @@ body {
 .success-message {
   color: #64ffda;
   font-weight: 500;
+}
+
+.signup-bar {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 40px auto 0;
+  max-width: 600px;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  border-radius: 6px;
+  flex-wrap: wrap;
+}
+
+.signup-input {
+  flex: 1;
+  min-width: 140px;
+}
+
+.signup-button {
+  background-color: #8C259E !important;
+  font-weight: bold;
+}
+
+.signup-button:hover {
+  background-color: #FB852A !important;
 }

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -13,11 +13,10 @@ import "../App.css"; // Ensure styling is still applied
 
 export default function ComingSoonPage() {
   const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
-  // Using one form hook for the email subscription form.
   const {
-    register: registerSubscription,
-    handleSubmit: handleSubscriptionSubmit,
-    reset: resetSubscription,
+    register: registerSignup,
+    handleSubmit: handleSignupSubmit,
+    reset: resetSignup,
   } = useForm();
 
   // Separate hook for the inquiry form.
@@ -31,11 +30,9 @@ export default function ComingSoonPage() {
 
   const onEmailSubmit = async (data) => {
     try {
-      // Save the subscription data to the "emailList" collection.
       await addDoc(collection(db, "emailList"), data);
       setSubmitted(true);
 
-      // Extract and default values from the data
       const name = data.name || "Unknown Name";
       const email = data.email || "unknown@example.com";
       const businessName = data.businessName || "Unknown Business";
@@ -82,7 +79,7 @@ export default function ComingSoonPage() {
         throw new Error(`Failed to send xAPI statement: ${JSON.stringify(lrsResponseData)}`);
       }
       
-      resetSubscription();
+      resetSignup();
     } catch (error) {
       console.error("Error adding email: ", error);
     }
@@ -152,40 +149,6 @@ export default function ComingSoonPage() {
         Our AI-fueled tools and assessments help organizations of any size design impactful, future-ready learning and development initiatives.
       </p>
       
-      {/* Email Subscription */}
-      <Card className="glass-card">
-        <CardContent>
-          {submitted ? (
-            <p className="success-message">Thank you for signing up! We&apos;ll keep you updated.</p>
-          ) : (
-            <form onSubmit={handleSubscriptionSubmit(onEmailSubmit)} className="form">
-              <label className="form-label">Join our mailing list:</label>
-              <Input
-                type="text"
-                placeholder="Your Name"
-                {...registerSubscription("name", { required: true })}
-                className="input"
-              />
-              <Input
-                type="text"
-                placeholder="Business Name"
-                {...registerSubscription("businessName", { required: true })}
-                className="input"
-              />
-              <Input
-                type="email"
-                placeholder="Enter your email"
-                {...registerSubscription("email", { required: true })}
-                className="input"
-              />
-              <Button type="submit" className="button">Subscribe</Button>
-            </form>
-          )}
-        </CardContent>
-      </Card>
-
-      <br /><br />
-
       {/* Inquiry Form */}
       <Card className="glass-card">
         <CardContent>
@@ -279,6 +242,31 @@ export default function ComingSoonPage() {
           </div>
         </CardContent>
       </Card>
+
+      {submitted && (
+        <p className="success-message">Thank you for signing up! We&apos;ll keep you updated.</p>
+      )}
+
+      <form
+        onSubmit={handleSignupSubmit(onEmailSubmit)}
+        className="signup-bar"
+      >
+        <Input
+          type="text"
+          placeholder="Your Name"
+          {...registerSignup("name", { required: true })}
+          className="input signup-input"
+        />
+        <Input
+          type="email"
+          placeholder="Your Email"
+          {...registerSignup("email", { required: true })}
+          className="input signup-input"
+        />
+        <Button type="submit" className="signup-button">
+          Sign Up
+        </Button>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace early subscription card with a slim signup bar after CTA links
- animate subtle node grid in the page background using pure CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7bb47ad0832ba5cdbe0d7327f0d3