### PR TITLE
feat: add landing CTA with analytics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import { onAuthStateChanged } from "firebase/auth";
 import { auth } from "./firebase";
 import AIToolsLayout from "./components/AIToolsLayout";
-import ComingSoonPage from "./pages/ComingSoonPage";
+import LandingPage from "./pages/LandingPage";
 import AdminLogin from "./pages/AdminLogin";
 import AdminDashboard from "./pages/AdminDashboard";
 import CourseOutlineGenerator from "./components/CourseOutlineGenerator";
@@ -50,7 +50,7 @@ export default function App() {
     <Router>
       <Routes>
         <Route path="/login" element={<Login />} />
-        <Route path="/" element={<ComingSoonPage />} />
+        <Route path="/" element={<LandingPage />} />
         <Route
           path="/admin-login"
           element={

--- a/src/coreBenefits.css
+++ b/src/coreBenefits.css
@@ -1,0 +1,20 @@
+.core-benefits-cta {
+  width: 100%;
+  padding: 4rem 1rem;
+  background-color: #f5f5f5;
+  text-align: center;
+}
+
+.join-mailing-button {
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background-color: #8c259e;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.join-mailing-button:hover {
+  background-color: #7a208a;
+}

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import "../coreBenefits.css";
+import { app } from "../firebase";
+import { getAnalytics, logEvent } from "firebase/analytics";
+
+export default function LandingPage({ openSignupModal }) {
+  const [variant] = useState(() => (Math.random() < 0.5 ? "A" : "B"));
+
+  useEffect(() => {
+    const analytics = getAnalytics(app);
+    logEvent(analytics, "headline_variant_view", { variant });
+  }, [variant]);
+
+  const handleJoinClick = () => {
+    const analytics = getAnalytics(app);
+    logEvent(analytics, "join_mailing_list_click", { variant });
+    if (openSignupModal) {
+      openSignupModal();
+    }
+  };
+
+  const headline =
+    variant === "A"
+      ? "Stay ahead with Thoughtify updates"
+      : "Join Thoughtify's learning revolution";
+
+  return (
+    <div className="landing-page">
+      {/* Existing benefits grid would be rendered above this section */}
+      <div className="core-benefits-cta">
+        <h2>{headline}</h2>
+        <p>Get exclusive insights and be the first to know when we launch.</p>
+        <button className="join-mailing-button" onClick={handleJoinClick}>
+          Join our mailing list
+        </button>
+      </div>
+    </div>
+  );
+}
+
+LandingPage.propTypes = {
+  openSignupModal: PropTypes.func,
+};


### PR DESCRIPTION
## Summary
- add landing page component with analytics and A/B headline
- style full-width CTA via coreBenefits.css
- route root path to new landing page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7f51ed64832bb7260efd0fcab265