### PR TITLE
feat: add hero section with cta options

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,115 @@ body::before {
   margin-bottom: 20px;
 }
 
+.hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  text-align: center;
+  width: 90%;
+  max-width: 1200px;
+  margin: 60px auto;
+}
+
+.hero-title {
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: #f5eef6;
+  text-shadow: 2px 2px 10px rgba(140, 37, 158, 0.8);
+  line-height: 1.2;
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: #EDE0DE;
+  margin-top: 10px;
+}
+
+.hero-image {
+  width: 100%;
+  max-width: 500px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+@media (min-width: 768px) {
+  .hero {
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .hero-content {
+    flex: 1;
+  }
+
+  .hero-image {
+    flex: 1;
+  }
+
+  .hero-title {
+    font-size: 3rem;
+  }
+}
+
+.cta-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin: 60px auto;
+  padding: 40px 20px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 800px;
+}
+
+.cta-primary {
+  background-color: #FB852A;
+  color: #fff;
+  padding: 15px 30px;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transition: background-color 0.3s;
+}
+
+.cta-primary:hover {
+  background-color: #ff9a40;
+}
+
+.cta-secondary {
+  color: #EDE0DE;
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.3s;
+}
+
+.cta-secondary:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.video-section {
+  margin: 60px auto;
+  text-align: center;
+  width: 90%;
+  max-width: 800px;
+  padding: 40px 20px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+}
+
+.video-placeholder {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
 .success-message {
   color: #64ffda;
   font-weight: 500;

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -184,17 +184,45 @@ const onEmailSubmit = async (data) => {
   };
 
   return (
-    <div className="page-container">
-      <h1 className="main-title">Thoughtify Training</h1>
-      <h1 className="main-title">Coming Soon</h1>
-      <p className="subtitle">
-        Our AI-fueled tools and assessments help organizations of any size design impactful, future-ready learning and development initiatives.
-      </p>
-      
-      {/* Inquiry Form */}
-      <Card className="glass-card">
-        <CardContent>
-          <form onSubmit={handleInquirySubmit(onInquirySubmit)} className="form">
+    <>
+      <section className="hero">
+        <div className="hero-content">
+          <h1 className="hero-title">
+            Stop Drowning in Content. Start Designing with Impact.
+          </h1>
+          <p className="hero-subtitle">
+            Thoughtify.Training is your AI partner for instructional design. Our integrated suite automates the repetitive tasks, freeing you to focus on the strategic and creative work you love.
+          </p>
+        </div>
+        <img
+          src="https://placehold.co/600x400?text=Thoughtify"
+          alt="Thoughtify Training illustration"
+          className="hero-image"
+        />
+      </section>
+
+      <section className="cta-section">
+        <a href="#workflow-video" className="cta-primary">
+          Watch the 2-Minute Workflow
+        </a>
+        <Link to="/ai-tools" className="cta-secondary">
+          Or, start building now →
+        </Link>
+      </section>
+
+      <section id="workflow-video" className="video-section">
+        <img
+          src="https://placehold.co/800x450?text=Workflow+Video"
+          alt="Workflow video placeholder"
+          className="video-placeholder"
+        />
+      </section>
+
+      <div className="page-container">
+        {/* Inquiry Form */}
+        <Card className="glass-card">
+          <CardContent>
+            <form onSubmit={handleInquirySubmit(onInquirySubmit)} className="form">
             <label className="form-label">Have a question? Reach out to us:</label>
             <Input
               type="text"
@@ -333,6 +361,7 @@ const onEmailSubmit = async (data) => {
         </div>
       )}
     </div>
+  </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add modern hero section to ComingSoonPage with bold headline and subheadline
- style new hero layout with responsive flexbox and placeholder image
- add CTA buttons and workflow video placeholder under hero

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fd916ec2c832bbc18324145353818