### PR TITLE
feat: add hero section with cta options and workflow demo

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,169 @@ body::before {
   margin-bottom: 20px;
 }
 
+.hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  text-align: center;
+  width: 90%;
+  max-width: 1200px;
+  margin: 60px auto;
+}
+
+.hero-title {
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: #f5eef6;
+  text-shadow: 2px 2px 10px rgba(140, 37, 158, 0.8);
+  line-height: 1.2;
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: #EDE0DE;
+  margin-top: 10px;
+}
+
+.hero-image {
+  width: 100%;
+  max-width: 500px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+@media (min-width: 768px) {
+  .hero {
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .hero-content {
+    flex: 1;
+  }
+
+  .hero-image {
+    flex: 1;
+  }
+
+  .hero-title {
+    font-size: 3rem;
+  }
+}
+
+.cta-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin: 60px auto;
+  padding: 40px 20px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 800px;
+}
+
+.cta-primary {
+  background-color: #FB852A;
+  color: #fff;
+  padding: 15px 30px;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transition: background-color 0.3s;
+}
+
+.cta-primary:hover {
+  background-color: #ff9a40;
+}
+
+.cta-secondary {
+  color: #EDE0DE;
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.3s;
+}
+
+.cta-secondary:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
+
+.workflow-section {
+  margin: 60px auto;
+  text-align: center;
+  width: 90%;
+  max-width: 800px;
+  padding: 40px 20px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+}
+
+.workflow-headline {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #f5eef6;
+  margin-bottom: 30px;
+}
+
+.workflow-video {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.workflow-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 30px;
+}
+
+@media (min-width: 768px) {
+  .workflow-steps {
+    flex-direction: row;
+  }
+}
+
+.workflow-step {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.step-number {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 10px;
+  background-color: #FB852A;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.step-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #f5eef6;
+}
+
+.step-description {
+  font-size: 0.95rem;
+  color: #EDE0DE;
+}
+
 .success-message {
   color: #64ffda;
   font-weight: 500;

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -184,17 +184,71 @@ const onEmailSubmit = async (data) => {
   };
 
   return (
-    <div className="page-container">
-      <h1 className="main-title">Thoughtify Training</h1>
-      <h1 className="main-title">Coming Soon</h1>
-      <p className="subtitle">
-        Our AI-fueled tools and assessments help organizations of any size design impactful, future-ready learning and development initiatives.
-      </p>
-      
-      {/* Inquiry Form */}
-      <Card className="glass-card">
-        <CardContent>
-          <form onSubmit={handleInquirySubmit(onInquirySubmit)} className="form">
+    <>
+      <section className="hero">
+        <div className="hero-content">
+          <h1 className="hero-title">
+            Stop Drowning in Content. Start Designing with Impact.
+          </h1>
+          <p className="hero-subtitle">
+            Thoughtify.Training is your AI partner for instructional design. Our integrated suite automates the repetitive tasks, freeing you to focus on the strategic and creative work you love.
+          </p>
+        </div>
+        <img
+          src="https://placehold.co/600x400?text=Thoughtify"
+          alt="Thoughtify Training illustration"
+          className="hero-image"
+        />
+      </section>
+
+      <section className="cta-section">
+        <a href="#workflow-video" className="cta-primary">
+          Watch the 2-Minute Workflow
+        </a>
+        <Link to="/ai-tools" className="cta-secondary">
+          Or, start building now →
+        </Link>
+      </section>
+
+      <section id="workflow-video" className="workflow-section">
+        <h2 className="workflow-headline">
+          Go from Idea to Assessment in Minutes, Not Weeks.
+        </h2>
+        <img
+          src="https://placehold.co/800x450?text=Workflow+Video"
+          alt="Workflow demo placeholder"
+          className="workflow-video"
+        />
+        <div className="workflow-steps">
+          <div className="workflow-step">
+            <div className="step-number">1</div>
+            <h3 className="step-title">Define Your Outline</h3>
+            <p className="step-description">
+              Instantly generate a pedagogically sound structure for any topic.
+            </p>
+          </div>
+          <div className="workflow-step">
+            <div className="step-number">2</div>
+            <h3 className="step-title">Generate Your Content</h3>
+            <p className="step-description">
+              Transform your outline into rich lesson content, study materials, and storyboards with a single click.
+            </p>
+          </div>
+          <div className="workflow-step">
+            <div className="step-number">3</div>
+            <h3 className="step-title">Create Your Assessments</h3>
+            <p className="step-description">
+              Automatically create relevant, objective-based questions from your generated content.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div className="page-container">
+        {/* Inquiry Form */}
+        <Card className="glass-card">
+          <CardContent>
+            <form onSubmit={handleInquirySubmit(onInquirySubmit)} className="form">
             <label className="form-label">Have a question? Reach out to us:</label>
             <Input
               type="text"
@@ -333,6 +387,7 @@ const onEmailSubmit = async (data) => {
         </div>
       )}
     </div>
+  </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add modern hero section to ComingSoonPage with bold headline and subheadline
- style hero layout with responsive flexbox and placeholder image
- add CTA buttons and workflow demo section with 3-step graphic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fd916ec2c832bbc18324145353818