### PR TITLE
feat: add hero section with cta options, workflow demo, and founder story

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,283 @@ body::before {
   margin-bottom: 20px;
 }
 
+.hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  text-align: center;
+  width: 90%;
+  max-width: 1200px;
+  margin: 60px auto;
+}
+
+.hero-title {
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: #f5eef6;
+  text-shadow: 2px 2px 10px rgba(140, 37, 158, 0.8);
+  line-height: 1.2;
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: #EDE0DE;
+  margin-top: 10px;
+}
+
+.hero-image {
+  width: 100%;
+  max-width: 500px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+@media (min-width: 768px) {
+  .hero {
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .hero-content {
+    flex: 1;
+  }
+
+  .hero-image {
+    flex: 1;
+  }
+
+  .hero-title {
+    font-size: 3rem;
+  }
+}
+
+.cta-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin: 60px auto;
+  padding: 40px 20px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 800px;
+}
+
+.cta-primary {
+  background-color: #FB852A;
+  color: #fff;
+  padding: 15px 30px;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transition: background-color 0.3s;
+}
+
+.cta-primary:hover {
+  background-color: #ff9a40;
+}
+
+.cta-secondary {
+  color: #EDE0DE;
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.3s;
+}
+
+.cta-secondary:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
+
+.workflow-section {
+  margin: 60px auto;
+  text-align: center;
+  width: 90%;
+  max-width: 800px;
+  padding: 40px 20px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+}
+
+.workflow-headline {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #f5eef6;
+  margin-bottom: 30px;
+}
+
+.workflow-video {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.workflow-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 30px;
+}
+
+@media (min-width: 768px) {
+  .workflow-steps {
+    flex-direction: row;
+  }
+}
+
+.workflow-step {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.step-number {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 10px;
+  background-color: #FB852A;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.step-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #f5eef6;
+}
+
+.step-description {
+  font-size: 0.95rem;
+  color: #EDE0DE;
+}
+
+.info-slider {
+  position: relative;
+  overflow: hidden;
+  margin: 60px auto;
+  width: 90%;
+  max-width: 800px;
+  padding: 40px 20px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.slider-track {
+  display: flex;
+  transition: transform 0.5s ease;
+}
+
+.slide {
+  min-width: 100%;
+  box-sizing: border-box;
+}
+
+.slide-image {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  margin-bottom: 20px;
+}
+
+.slide-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin-bottom: 10px;
+  color: #f5eef6;
+}
+
+.slide-description {
+  font-size: 1rem;
+  color: #EDE0DE;
+}
+
+.slider-button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  padding: 10px;
+  cursor: pointer;
+  border-radius: 50%;
+}
+
+.slider-button:hover {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.slider-button.prev {
+  left: 10px;
+}
+
+.slider-button.next {
+  right: 10px;
+}
+
+.founder-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  margin: 60px auto;
+  width: 90%;
+  max-width: 800px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 40px 20px;
+  border-radius: 8px;
+}
+
+.founder-photo {
+  width: 100%;
+  max-width: 300px;
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.founder-content {
+  max-width: 500px;
+}
+
+.founder-headline {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #f5eef6;
+  margin-bottom: 10px;
+}
+
+.founder-text {
+  font-size: 1rem;
+  color: #EDE0DE;
+}
+
+@media (min-width: 768px) {
+  .founder-section {
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .founder-content {
+    margin-left: 40px;
+  }
+}
+
 .success-message {
   color: #64ffda;
   font-weight: 500;

--- a/src/coreBenefits.css
+++ b/src/coreBenefits.css
@@ -1,12 +1,70 @@
-.core-benefits-cta {
-    width: 100%;
-    padding: 4rem 1rem;
-    box-sizing: border-box;
-    background-color: #f5f5f5;
-    text-align: center;
-    color: #000;
-    margin-top: 2rem;
+.benefits-section {
+  margin: 60px auto;
+  padding: 40px 20px;
+  width: 90%;
+  max-width: 1000px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+}
+
+.benefits-headline {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #f5eef6;
+  margin-bottom: 40px;
+}
+
+.benefits-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+}
+
+@media (min-width: 768px) {
+  .benefits-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
+}
+
+@media (min-width: 1024px) {
+  .benefits-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.benefit-item {
+  background: rgba(0, 0, 0, 0.25);
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.benefit-icon {
+  font-size: 2rem;
+  margin-bottom: 10px;
+}
+
+.benefit-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #f5eef6;
+}
+
+.benefit-description {
+  font-size: 0.95rem;
+  color: #EDE0DE;
+}
+
+.core-benefits-cta {
+  width: 100%;
+  padding: 4rem 1rem;
+  box-sizing: border-box;
+  background-color: #f5f5f5;
+  text-align: center;
+  color: #000;
+  margin-top: 2rem;
+}
 
 .join-mailing-button {
   margin-top: 1rem;

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -15,9 +15,7 @@ import "../App.css";
 import "../coreBenefits.css";
 
 export default function ComingSoonPage({ openSignupModal }) {
-  console.log("VITE_XAPI_BASIC_AUTH raw:", import.meta.env.VITE_XAPI_BASIC_AUTH);
-const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
-console.log("LRS_AUTH header:", LRS_AUTH);
+  const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
   const {
     register: registerSignup,
     handleSubmit: handleSignupSubmit,
@@ -34,6 +32,44 @@ console.log("LRS_AUTH header:", LRS_AUTH);
   const [submitted, setSubmitted] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [variant] = useState(() => (Math.random() < 0.5 ? "A" : "B"));
+
+  const sliderItems = [
+    {
+      title: "Course Outline Generator",
+      description: "Lays the foundation for your entire project.",
+      image: "https://placehold.co/800x400?text=Course+Outline+Generator",
+    },
+    {
+      title: "Lesson Content Generator",
+      description: "Builds upon your outline to create engaging material.",
+      image: "https://placehold.co/800x400?text=Lesson+Content+Generator",
+    },
+    {
+      title: "Study Material Generator",
+      description: "Creates reinforcement assets from your core content.",
+      image: "https://placehold.co/800x400?text=Study+Material+Generator",
+    },
+    {
+      title: "E-Learning Storyboard Generator",
+      description:
+        "Translates your lessons into a visual plan for development.",
+      image: "https://placehold.co/800x400?text=Storyboard+Generator",
+    },
+    {
+      title: "Assessment Generator",
+      description:
+        "Checks for understanding by creating questions tied directly to your learning objectives.",
+      image: "https://placehold.co/800x400?text=Assessment+Generator",
+    },
+  ];
+
+  const [currentSlide, setCurrentSlide] = useState(0);
+
+  const nextSlide = () =>
+    setCurrentSlide((prev) => (prev + 1) % sliderItems.length);
+
+  const prevSlide = () =>
+    setCurrentSlide((prev) => (prev - 1 + sliderItems.length) % sliderItems.length);
 
   useEffect(() => {
     const analytics = getAnalytics(app);
@@ -111,7 +147,6 @@ const onEmailSubmit = async (data) => {
     } else {
       lrsResponseData = await lrsResponse.text();
     }
-    console.log("xAPI raw response:", lrsResponseData);
 
     // 5) Handle HTTP errors
     if (!lrsResponse.ok) {
@@ -170,7 +205,6 @@ const onEmailSubmit = async (data) => {
       });
 
       const lrsResponseData = await lrsResponse.json();
-      console.log("xAPI Response:", lrsResponseData);
 
       if (!lrsResponse.ok) {
         console.error("SCORM Cloud LRS Error:", lrsResponseData);
@@ -184,17 +218,154 @@ const onEmailSubmit = async (data) => {
   };
 
   return (
-    <div className="page-container">
-      <h1 className="main-title">Thoughtify Training</h1>
-      <h1 className="main-title">Coming Soon</h1>
-      <p className="subtitle">
-        Our AI-fueled tools and assessments help organizations of any size design impactful, future-ready learning and development initiatives.
-      </p>
-      
-      {/* Inquiry Form */}
-      <Card className="glass-card">
-        <CardContent>
-          <form onSubmit={handleInquirySubmit(onInquirySubmit)} className="form">
+    <>
+      <section className="hero">
+        <div className="hero-content">
+          <h1 className="hero-title">
+            Stop Drowning in Content. Start Designing with Impact.
+          </h1>
+          <p className="hero-subtitle">
+            Thoughtify.Training is your AI partner for instructional design. Our integrated suite automates the repetitive tasks, freeing you to focus on the strategic and creative work you love.
+          </p>
+        </div>
+        <img
+          src="https://placehold.co/600x400?text=Thoughtify"
+          alt="Thoughtify Training illustration"
+          className="hero-image"
+        />
+      </section>
+
+      <section className="cta-section">
+        <a href="#workflow-video" className="cta-primary">
+          Watch the 2-Minute Workflow
+        </a>
+        <Link to="/ai-tools" className="cta-secondary">
+          Or, start building now →
+        </Link>
+      </section>
+
+      <section id="workflow-video" className="workflow-section">
+        <h2 className="workflow-headline">
+          Go from Idea to Assessment in Minutes, Not Weeks.
+        </h2>
+        <img
+          src="https://placehold.co/800x450?text=Workflow+Video"
+          alt="Workflow demo placeholder"
+          className="workflow-video"
+        />
+        <div className="workflow-steps">
+          <div className="workflow-step">
+            <div className="step-number">1</div>
+            <h3 className="step-title">Define Your Outline</h3>
+            <p className="step-description">
+              Instantly generate a pedagogically sound structure for any topic.
+            </p>
+          </div>
+          <div className="workflow-step">
+            <div className="step-number">2</div>
+            <h3 className="step-title">Generate Your Content</h3>
+            <p className="step-description">
+              Transform your outline into rich lesson content, study materials, and storyboards with a single click.
+            </p>
+          </div>
+          <div className="workflow-step">
+            <div className="step-number">3</div>
+            <h3 className="step-title">Create Your Assessments</h3>
+            <p className="step-description">
+              Automatically create relevant, objective-based questions from your generated content.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="benefits-section">
+        <h2 className="benefits-headline">Reclaim Your Time. Amplify Your Genius.</h2>
+        <div className="benefits-grid">
+          <div className="benefit-item">
+            <span className="benefit-icon" role="img" aria-label="clock">⏰</span>
+            <h3 className="benefit-title">Slash Development Time</h3>
+            <p className="benefit-description">
+              Cut down on the manual labor of writing and structuring content. Ship projects faster.
+            </p>
+          </div>
+          <div className="benefit-item">
+            <span className="benefit-icon" role="img" aria-label="lightbulb">💡</span>
+            <h3 className="benefit-title">Eliminate Writer&apos;s Block</h3>
+            <p className="benefit-description">
+              Instantly generate creative ideas, examples, and scenarios so you can start with a powerful draft, not a blank page.
+            </p>
+          </div>
+          <div className="benefit-item">
+            <span className="benefit-icon" role="img" aria-label="target">🎯</span>
+            <h3 className="benefit-title">Ensure Instructional Soundness</h3>
+            <p className="benefit-description">
+              Build on outlines and content grounded in solid learning principles, ensuring consistency and quality.
+            </p>
+          </div>
+          <div className="benefit-item">
+            <span className="benefit-icon" role="img" aria-label="upward arrow">⬆️</span>
+            <h3 className="benefit-title">Focus on High-Value Work</h3>
+            <p className="benefit-description">
+              Automate the tedious tasks and free yourself to focus on learning strategy, creative design, and stakeholder management.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="info-slider">
+        <div
+          className="slider-track"
+          style={{ transform: `translateX(-${currentSlide * 100}%)` }}
+        >
+          {sliderItems.map((item, index) => (
+            <div className="slide" key={index}>
+              <img
+                src={item.image}
+                alt={item.title}
+                className="slide-image"
+              />
+              <h3 className="slide-title">{item.title}</h3>
+              <p className="slide-description">{item.description}</p>
+            </div>
+          ))}
+        </div>
+        <button
+          className="slider-button prev"
+          onClick={prevSlide}
+          aria-label="Previous"
+        >
+          ‹
+        </button>
+        <button
+          className="slider-button next"
+          onClick={nextSlide}
+          aria-label="Next"
+        >
+          ›
+        </button>
+      </section>
+
+      <section className="founder-section">
+        <img
+          src="https://placehold.co/400x400?text=Jonny+Davis"
+          alt="Photo of Jonny Davis"
+          className="founder-photo"
+        />
+        <div className="founder-content">
+          <h2 className="founder-headline">
+            Built by an Instructional Designer, for Instructional Designers.
+          </h2>
+          <p className="founder-text">
+            My name is Jonny Davis, and I&apos;ve spent over a decade in the trenches of instructional design. I built Thoughtify to solve the challenges I faced every day: tight deadlines, repetitive work, and not enough time for deep, creative thinking. This platform isn&apos;t just code; it&apos;s a reflection of my passion for creating better learning experiences. I built it for me, and now I&apos;m sharing it with you.
+          </p>
+        </div>
+      </section>
+
+      <div className="page-container">
+        {/* Inquiry Form */}
+        <Card className="glass-card">
+          <CardContent>
+            <form onSubmit={handleInquirySubmit(onInquirySubmit)} className="form">
             <label className="form-label">Have a question? Reach out to us:</label>
             <Input
               type="text"
@@ -333,6 +504,7 @@ const onEmailSubmit = async (data) => {
         </div>
       )}
     </div>
+  </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add modern hero section to ComingSoonPage with bold headline and subheadline
- style hero layout with responsive flexbox and placeholder image
- add CTA buttons and workflow demo section with 3-step graphic
- introduce core benefits section with four-column icon grid
- showcase AI tool highlights in a new slider with navigation controls
- expand slider to include study material and storyboard generators
- spotlight creator background with new Founder's Story section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fd916ec2c832bbc18324145353818