### PR TITLE
Improve text contrast for hero and benefits sections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -70,6 +70,12 @@ body::before {
   margin: 60px auto;
 }
 
+.hero-content {
+  background: rgba(0, 0, 0, 0.4);
+  padding: 20px;
+  border-radius: 8px;
+}
+
 .hero-title {
   font-size: 2.5rem;
   font-weight: 600;
@@ -80,7 +86,7 @@ body::before {
 
 .hero-subtitle {
   font-size: 1.2rem;
-  color: #EDE0DE;
+  color: #FFFFFF;
   margin-top: 10px;
 }
 

--- a/src/coreBenefits.css
+++ b/src/coreBenefits.css
@@ -11,7 +11,7 @@
 .benefits-headline {
   font-size: 1.8rem;
   font-weight: 600;
-  color: #f5eef6;
+  color: #FFFFFF;
   margin-bottom: 40px;
 }
 
@@ -34,7 +34,7 @@
 }
 
 .benefit-item {
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.4);
   padding: 20px;
   border-radius: 8px;
 }


### PR DESCRIPTION
## Summary
- Add dark overlay behind hero text and switch subtitle to white for better legibility
- Darken benefit cards and headline to meet contrast guidelines

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68900d5c0364832ba0976407e7736d97