### PR TITLE
feat: add navigation bar and footer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -462,3 +462,61 @@ body::before {
   color: #fff;
   text-decoration: underline;
 }
+
+/* Navigation bar */
+.navbar {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 10px 20px;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.nav-link:hover {
+  color: #FB852A;
+}
+
+/* Footer */
+.footer {
+  margin-top: auto;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 20px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.footer-links,
+.footer-social {
+  display: flex;
+  gap: 20px;
+}
+
+.footer-link {
+  color: #EDE0DE;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.footer-link:hover {
+  color: #fff;
+  text-decoration: underline;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,8 @@ import LeadershipAssessmentWizard from "./components/LeadershipAssessmentWizard"
 import CustomDashboard from "./components/CustomDashboard";
 import ComingSoonPage from "./pages/ComingSoonPage";
 import Login from "./components/Login";
+import NavBar from "./components/NavBar";
+import Footer from "./components/Footer";
 import "./App.css";
 
 export default function App() {
@@ -48,6 +50,7 @@ export default function App() {
 
   return (
     <Router>
+      <NavBar />
       <Routes>
         <Route path="/login" element={<Login />} />
           <Route path="/" element={<ComingSoonPage />} />
@@ -86,6 +89,7 @@ export default function App() {
         </Route>
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
+      <Footer />
     </Router>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router-dom";
+
+const Footer = () => {
+  return (
+    <footer className="footer">
+      <div className="footer-links">
+        <Link to="/privacy" className="footer-link">Privacy Policy</Link>
+        <Link to="/terms" className="footer-link">Terms of Service</Link>
+      </div>
+      <div className="footer-social">
+        <a
+          href="https://twitter.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="footer-link"
+        >
+          Twitter
+        </a>
+        <a
+          href="https://linkedin.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="footer-link"
+        >
+          LinkedIn
+        </a>
+        <a
+          href="https://github.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="footer-link"
+        >
+          GitHub
+        </a>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;
+

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+
+const NavBar = () => {
+  return (
+    <nav className="navbar">
+      <ul className="nav-list">
+        <li className="nav-item">
+          <Link to="/" className="nav-link">Home</Link>
+        </li>
+        <li className="nav-item">
+          <Link to="/ai-tools" className="nav-link">Tools</Link>
+        </li>
+        <li className="nav-item">
+          <Link to="/pricing" className="nav-link">Pricing</Link>
+        </li>
+        <li className="nav-item">
+          <Link to="/contact" className="nav-link">Contact</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default NavBar;
+


### PR DESCRIPTION
## Summary
- redesign nav bar into full-width header with horizontal links
- turn footer links into structured bottom bar
- add global styles for nav and footer hover states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68900fc11c78832bbd28dde06decebd5