### PR TITLE
Add testimonials section

### DIFF
--- a/src/components/Testimonials.css
+++ b/src/components/Testimonials.css
@@ -1,0 +1,38 @@
+.testimonials {
+  display: grid;
+  gap: 2rem;
+  margin: 4rem auto;
+  max-width: 800px;
+  padding: 0 1rem;
+}
+
+.testimonial {
+  text-align: center;
+  padding: 1.5rem;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.testimonial-logo {
+  max-height: 40px;
+  margin-bottom: 0.75rem;
+}
+
+.testimonial-quote {
+  font-style: italic;
+  color: #333;
+  margin-bottom: 0.75rem;
+}
+
+.testimonial-author {
+  color: #555;
+}
+
+.testimonial-name {
+  font-weight: 600;
+}
+
+.testimonial-title {
+  font-weight: 400;
+}

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -1,0 +1,44 @@
+import "./Testimonials.css";
+
+const testimonialsData = [
+  {
+    quote: "Thoughtify transformed how our team approaches content creation.",
+    name: "Jamie Lee",
+    title: "Senior Instructional Designer",
+    logo: "https://placehold.co/100x40?text=Logo1",
+  },
+  {
+    quote: "A must-have tool for anyone serious about learning design.",
+    name: "Riley Morgan",
+    title: "Training Consultant",
+    logo: "https://placehold.co/100x40?text=Logo2",
+  },
+  {
+    quote: "The efficiency gains have been incredible.",
+    name: "Alex Rivera",
+    title: "L&D Manager",
+  },
+];
+
+export default function Testimonials() {
+  return (
+    <section className="testimonials">
+      {testimonialsData.map((item, idx) => (
+        <div className="testimonial" key={idx}>
+          {item.logo && (
+            <img
+              src={item.logo}
+              alt={`${item.name} logo`}
+              className="testimonial-logo"
+            />
+          )}
+          <blockquote className="testimonial-quote">&ldquo;{item.quote}&rdquo;</blockquote>
+          <p className="testimonial-author">
+            <span className="testimonial-name">{item.name}</span>,{' '}
+            <span className="testimonial-title">{item.title}</span>
+          </p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -10,6 +10,7 @@ import { Input } from "../components/ui/input";
 import { Textarea } from "../components/ui/textarea";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import Testimonials from "../components/Testimonials";
 
 import "../App.css";
 import "../coreBenefits.css";
@@ -311,6 +312,8 @@ const onEmailSubmit = async (data) => {
           </div>
         </div>
       </section>
+
+      <Testimonials />
 
       <section className="info-slider">
         <div


### PR DESCRIPTION
## Summary
- create reusable `Testimonials` component to highlight quotes with names, titles, and optional logos
- style testimonials for consistent spacing and contrast
- embed testimonials below the benefits section on the Coming Soon page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901f5c0980832b89064b954a8a6684