### PR TITLE
Add privacy policy page and notices

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import Login from "./components/Login";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
 import "./App.css";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
 
 export default function App() {
   const [user, setUser] = useState(null);
@@ -54,6 +55,7 @@ export default function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
           <Route path="/" element={<ComingSoonPage />} />
+        <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route
           path="/admin-login"
           element={

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -399,6 +399,9 @@ const onEmailSubmit = async (data) => {
             />
             <Button type="submit" className="button">Send</Button>
           </form>
+          <p className="privacy-notice">
+            We respect your privacy; see our <Link to="/privacy">privacy policy</Link> for details.
+          </p>
         </CardContent>
       </Card>
 
@@ -456,6 +459,9 @@ const onEmailSubmit = async (data) => {
                 <Button type="submit" className="signup-button">
                   Get Started for Free
                 </Button>
+                <p className="privacy-notice">
+                  We respect your privacy; see our <Link to="/privacy">privacy policy</Link> for details.
+                </p>
               </form>
             )}
           </div>

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router-dom";
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="privacy-policy">
+      <h1>Privacy Policy</h1>
+      <p>
+        Thoughtify respects your privacy. This policy explains how we collect,
+        use, and safeguard your information when you interact with our site.
+      </p>
+      <h2>Information We Collect</h2>
+      <p>
+        We collect personal details that you choose to share, such as your name
+        and email address when signing up or sending an inquiry.
+      </p>
+      <h2>How We Use Information</h2>
+      <p>
+        Your information is used to respond to messages, send updates, and
+        improve our services. We do not sell your personal data.
+      </p>
+      <h2>Contact Us</h2>
+      <p>
+        If you have any questions about this policy, please <Link to="/">contact
+        us</Link>.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add privacy policy notices beneath inquiry and signup forms
- create dedicated PrivacyPolicy page
- register /privacy route so notices and footer link works

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f3957fb8832b9c159de504325eff