### PR TITLE
Add multi-step signup form and improve mobile form styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -359,15 +359,36 @@ body::before {
 .signup-input {
   flex: 1;
   min-width: 140px;
+  padding: 12px 16px;
+  font-size: 1rem;
 }
 
 .signup-button {
   background-color: #8C259E !important;
   font-weight: bold;
+  padding: 12px 16px;
+  font-size: 1rem;
 }
 
 .signup-button:hover {
   background-color: #FB852A !important;
+}
+
+.input,
+.textarea,
+.button {
+  padding: 12px 16px;
+  font-size: 1rem;
+}
+
+@media (max-width: 480px) {
+  .signup-input,
+  .signup-button,
+  .input,
+  .textarea,
+  .button {
+    min-height: 48px;
+  }
 }
 
 .signup-overlay {

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -33,6 +33,7 @@ export default function ComingSoonPage({ openSignupModal }) {
 
   const [submitted, setSubmitted] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const [signupStep, setSignupStep] = useState(1);
   const [variant] = useState(() => (Math.random() < 0.5 ? "A" : "B"));
 
   const sliderItems = [
@@ -86,6 +87,7 @@ export default function ComingSoonPage({ openSignupModal }) {
       openSignupModal();
     }
     setShowModal(true);
+    setSignupStep(1);
   };
 
   const headline =
@@ -158,8 +160,9 @@ const onEmailSubmit = async (data) => {
       );
     }
 
-    // 6) Clear the form
+    // 6) Clear the form and reset step
     resetSignup();
+    setSignupStep(1);
   } catch (error) {
     console.error("Error adding email or sending xAPI:", error);
   }
@@ -426,11 +429,20 @@ const onEmailSubmit = async (data) => {
       </section>
 
       {showModal && (
-        <div className="signup-overlay" onClick={() => setShowModal(false)}>
+        <div
+          className="signup-overlay"
+          onClick={() => {
+            setShowModal(false);
+            setSignupStep(1);
+          }}
+        >
           <div className="signup-modal" onClick={(e) => e.stopPropagation()}>
             <button
               className="close-button"
-              onClick={() => setShowModal(false)}
+              onClick={() => {
+                setShowModal(false);
+                setSignupStep(1);
+              }}
               aria-label="Close"
             >
               &times;
@@ -444,24 +456,44 @@ const onEmailSubmit = async (data) => {
                 onSubmit={handleSignupSubmit(onEmailSubmit)}
                 className="signup-form"
               >
-                <Input
-                  type="text"
-                  placeholder="Your Name"
-                  {...registerSignup("name", { required: true })}
-                  className="input signup-input"
-                />
-                <Input
-                  type="email"
-                  placeholder="Your Email"
-                  {...registerSignup("email", { required: true })}
-                  className="input signup-input"
-                />
-                <Button type="submit" className="signup-button">
-                  Get Started for Free
-                </Button>
-                <p className="privacy-notice">
-                  We respect your privacy; see our <Link to="/privacy">privacy policy</Link> for details.
-                </p>
+                {signupStep === 1 ? (
+                  <>
+                    <Input
+                      type="text"
+                      placeholder="Your Name"
+                      {...registerSignup("name", { required: true })}
+                      className="input signup-input"
+                    />
+                    <Input
+                      type="email"
+                      placeholder="Your Email"
+                      {...registerSignup("email", { required: true })}
+                      className="input signup-input"
+                    />
+                    <Button
+                      type="button"
+                      className="signup-button"
+                      onClick={() => setSignupStep(2)}
+                    >
+                      Next
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Input
+                      type="text"
+                      placeholder="Business Name"
+                      {...registerSignup("businessName")}
+                      className="input signup-input"
+                    />
+                    <Button type="submit" className="signup-button">
+                      Get Started for Free
+                    </Button>
+                    <p className="privacy-notice">
+                      We respect your privacy; see our <Link to="/privacy">privacy policy</Link> for details.
+                    </p>
+                  </>
+                )}
               </form>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Limit signup form's initial fields to name and email and collect extra business details in a second step.
- Reset signup step on open/submit and close modal to streamline flow.
- Increase input and button sizes for touch-friendly form controls on small screens.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891050acf84832bb7b9f141d023399a