### PR TITLE
Add multi-step signup form and improve mobile form styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -340,7 +340,7 @@ body::before {
 }
 
 .success-message {
-  color: #64ffda;
+  color: #000;
   font-weight: 500;
 }
 
@@ -359,15 +359,41 @@ body::before {
 .signup-input {
   flex: 1;
   min-width: 140px;
+  padding: 12px 16px;
+  font-size: 1rem;
 }
 
 .signup-button {
   background-color: #8C259E !important;
   font-weight: bold;
+  padding: 12px 16px;
+  font-size: 1rem;
+}
+
+.signup-label {
+  text-align: left;
+  font-weight: 500;
 }
 
 .signup-button:hover {
   background-color: #FB852A !important;
+}
+
+.input,
+.textarea,
+.button {
+  padding: 12px 16px;
+  font-size: 1rem;
+}
+
+@media (max-width: 480px) {
+  .signup-input,
+  .signup-button,
+  .input,
+  .textarea,
+  .button {
+    min-height: 48px;
+  }
 }
 
 .signup-overlay {

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -33,6 +33,7 @@ export default function ComingSoonPage({ openSignupModal }) {
 
   const [submitted, setSubmitted] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const [signupStep, setSignupStep] = useState(1);
   const [variant] = useState(() => (Math.random() < 0.5 ? "A" : "B"));
 
   const sliderItems = [
@@ -86,6 +87,7 @@ export default function ComingSoonPage({ openSignupModal }) {
       openSignupModal();
     }
     setShowModal(true);
+    setSignupStep(1);
   };
 
   const headline =
@@ -158,8 +160,9 @@ const onEmailSubmit = async (data) => {
       );
     }
 
-    // 6) Clear the form
+    // 6) Clear the form and reset step
     resetSignup();
+    setSignupStep(1);
   } catch (error) {
     console.error("Error adding email or sending xAPI:", error);
   }
@@ -278,6 +281,14 @@ const onEmailSubmit = async (data) => {
           </div>
         </div>
       </section>
+
+      <div className="core-benefits-cta">
+        <h2>{headline}</h2>
+        <p>Get exclusive insights. Be the first to know when we launch.</p>
+        <Button className="join-mailing-button" onClick={handleJoinClick}>
+          Join Mailing List
+        </Button>
+      </div>
 
       <section className="benefits-section">
         <h2 className="benefits-headline">Reclaim Your Time. Amplify Your Genius.</h2>
@@ -405,14 +416,6 @@ const onEmailSubmit = async (data) => {
         </CardContent>
       </Card>
 
-      <div className="core-benefits-cta">
-        <h2>{headline}</h2>
-        <p>Get exclusive insights. Be the first to know when we launch.</p>
-        <Button className="join-mailing-button" onClick={handleJoinClick}>
-          Get Started for Free
-        </Button>
-      </div>
-
       <section id="pricing" className="final-cta">
         <h2 className="final-cta-headline">Ready to Revolutionize Your Workflow?</h2>
         <div className="final-cta-actions">
@@ -426,11 +429,20 @@ const onEmailSubmit = async (data) => {
       </section>
 
       {showModal && (
-        <div className="signup-overlay" onClick={() => setShowModal(false)}>
+        <div
+          className="signup-overlay"
+          onClick={() => {
+            setShowModal(false);
+            setSignupStep(1);
+          }}
+        >
           <div className="signup-modal" onClick={(e) => e.stopPropagation()}>
             <button
               className="close-button"
-              onClick={() => setShowModal(false)}
+              onClick={() => {
+                setShowModal(false);
+                setSignupStep(1);
+              }}
               aria-label="Close"
             >
               &times;
@@ -444,24 +456,59 @@ const onEmailSubmit = async (data) => {
                 onSubmit={handleSignupSubmit(onEmailSubmit)}
                 className="signup-form"
               >
-                <Input
-                  type="text"
-                  placeholder="Your Name"
-                  {...registerSignup("name", { required: true })}
-                  className="input signup-input"
-                />
-                <Input
-                  type="email"
-                  placeholder="Your Email"
-                  {...registerSignup("email", { required: true })}
-                  className="input signup-input"
-                />
-                <Button type="submit" className="signup-button">
-                  Get Started for Free
-                </Button>
-                <p className="privacy-notice">
-                  We respect your privacy; see our <Link to="/privacy">privacy policy</Link> for details.
-                </p>
+                {signupStep === 1 ? (
+                  <>
+                    <label htmlFor="signup-name" className="signup-label">
+                      Name
+                    </label>
+                    <Input
+                      id="signup-name"
+                      type="text"
+                      placeholder="Your Name"
+                      {...registerSignup("name", { required: true })}
+                      className="input signup-input"
+                    />
+                    <label htmlFor="signup-email" className="signup-label">
+                      Email
+                    </label>
+                    <Input
+                      id="signup-email"
+                      type="email"
+                      placeholder="Your Email"
+                      {...registerSignup("email", { required: true })}
+                      className="input signup-input"
+                    />
+                    <Button
+                      type="button"
+                      className="signup-button"
+                      onClick={() => setSignupStep(2)}
+                    >
+                      Next
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <label
+                      htmlFor="signup-business"
+                      className="signup-label"
+                    >
+                      Business Name
+                    </label>
+                    <Input
+                      id="signup-business"
+                      type="text"
+                      placeholder="Business Name"
+                      {...registerSignup("businessName")}
+                      className="input signup-input"
+                    />
+                    <Button type="submit" className="signup-button">
+                      Join Mailing List
+                    </Button>
+                    <p className="privacy-notice">
+                      We respect your privacy; see our <Link to="/privacy">privacy policy</Link> for details.
+                    </p>
+                  </>
+                )}
               </form>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Move mailing list call-to-action beneath workflow video and update its button copy to invite users to join the mailing list
- Add labels and black text to the signup modal to match its white background and improve accessibility
- Style success feedback and labels in CSS to ensure dark text and comfortable tap targets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891050acf84832bb7b9f141d023399a