### PR TITLE
Add analytics cookie consent, update privacy policy, and add tools CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,13 +14,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-18M1BPL5F3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-18M1BPL5F3');
-</script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.css
+++ b/src/App.css
@@ -199,6 +199,35 @@ body::before {
   }
 }
 
+/* Cookie consent banner */
+.cookie-consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.9);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1000;
+}
+
+.cookie-consent-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cookie-consent button {
+  background-color: #FB852A;
+  border: none;
+  color: #fff;
+}
+
+.cookie-consent button.decline {
+  background-color: #555;
+}
+
 .workflow-step {
   flex: 1;
   background: rgba(0, 0, 0, 0.25);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
 import "./App.css";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
+import CookieConsent from "./components/CookieConsent";
 
 export default function App() {
   const [user, setUser] = useState(null);
@@ -92,6 +93,7 @@ export default function App() {
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
       <Footer />
+      <CookieConsent />
     </Router>
   );
 }

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { getAnalyticsConsent, setAnalyticsConsent } from "../utils/analytics.js";
+
+const CookieConsent = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = getAnalyticsConsent();
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    setAnalyticsConsent("granted");
+    setVisible(false);
+  };
+
+  const decline = () => {
+    setAnalyticsConsent("denied");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="cookie-consent">
+      <p>
+        We use cookies for analytics to improve your experience. Read our
+        <Link to="/privacy"> privacy policy</Link> for more details.
+      </p>
+      <div className="cookie-consent-actions">
+        <button onClick={accept}>Accept</button>
+        <button className="decline" onClick={decline}>Decline</button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsent;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,15 @@ import './index.css'
 import App from './App.jsx'
 import { ProjectProvider } from "./context/ProjectContext.jsx";
 import PropTypes from "prop-types";
+import { initAnalytics, getAnalyticsConsent } from "./utils/analytics.js";
 
 // Ensure PropTypes is available globally for any components expecting it
 window.PropTypes = PropTypes;
+
+const consent = getAnalyticsConsent();
+if (consent === 'granted') {
+  initAnalytics();
+}
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -367,6 +367,9 @@ const onEmailSubmit = async (data) => {
         >
           ›
         </button>
+        <Link to="/ai-tools">
+          <Button className="button">Try Our Free Tools</Button>
+        </Link>
       </section>
 
       <section className="founder-section">

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,12 +1,23 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import { getAnalyticsConsent, setAnalyticsConsent } from "../utils/analytics.js";
 
 export default function PrivacyPolicy() {
+  const [consent, setConsent] = useState(getAnalyticsConsent());
+
+  const updateConsent = (value) => {
+    setAnalyticsConsent(value);
+    setConsent(value);
+  };
+
   return (
     <div className="privacy-policy">
       <h1>Privacy Policy</h1>
       <p>
         Thoughtify respects your privacy. This policy explains how we collect,
         use, and safeguard your information when you interact with our site.
+        We comply with the General Data Protection Regulation (GDPR) and the
+        California Consumer Privacy Act (CCPA).
       </p>
       <h2>Information We Collect</h2>
       <p>
@@ -17,6 +28,25 @@ export default function PrivacyPolicy() {
       <p>
         Your information is used to respond to messages, send updates, and
         improve our services. We do not sell your personal data.
+      </p>
+      <h2>Cookies and Analytics</h2>
+      <p>
+        We use Google Analytics to understand how visitors use our site. Analytics
+        cookies are only set after you give consent. You can change your
+        preference at any time below.
+      </p>
+      <p>
+        Current analytics preference: {consent === "granted" ? "Enabled" : "Disabled"}.
+      </p>
+      <div className="cookie-consent-actions">
+        <button onClick={() => updateConsent("granted")}>Enable Analytics</button>
+        <button className="decline" onClick={() => updateConsent("denied")}>Disable Analytics</button>
+      </div>
+      <h2>Your Rights</h2>
+      <p>
+        Depending on your location, you may have rights to access, correct, or
+        delete your personal data and to opt out of certain processing. To
+        exercise these rights, please <Link to="/">contact us</Link>.
       </p>
       <h2>Contact Us</h2>
       <p>

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,0 +1,30 @@
+const GA_ID = 'G-18M1BPL5F3';
+
+export function initAnalytics() {
+  if (window.gtag) return;
+
+  const script = document.createElement('script');
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+  script.async = true;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){window.dataLayer.push(arguments);}
+  window.gtag = gtag;
+  gtag('js', new Date());
+  gtag('config', GA_ID);
+}
+
+export function getAnalyticsConsent() {
+  return localStorage.getItem('analytics_consent');
+}
+
+export function setAnalyticsConsent(value) {
+  localStorage.setItem('analytics_consent', value);
+  if (value === 'granted') {
+    window[`ga-disable-${GA_ID}`] = false;
+    initAnalytics();
+  } else {
+    window[`ga-disable-${GA_ID}`] = true;
+  }
+}


### PR DESCRIPTION
## Summary
- add cookie consent banner with analytics opt-in/out
- load Google Analytics only after consent
- expand privacy policy with GDPR/CCPA info and cookie preference controls
- add Try Our Free Tools button linking to `/ai-tools`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891408e53cc832b815536f219913efb