### PR TITLE
fix: add CORS headers for project brief

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -365,9 +365,12 @@ The lesson content should be well-structured, accurate, and engaging.  Prioritiz
 export const generateProjectBrief = onRequest(
   { secrets: ["GOOGLE_GENAI_API_KEY"] },
   async (req, res) => {
+    // Handle CORS for browser requests
     res.set("Access-Control-Allow-Origin", "*");
     res.set("Access-Control-Allow-Headers", "Content-Type");
+    res.set("Access-Control-Allow-Methods", "POST, OPTIONS");
     if (req.method === "OPTIONS") {
+      // Send response to preflight requests
       res.status(204).send("");
       return;
     }


### PR DESCRIPTION
## Summary
- fix generateProjectBrief cloud function CORS handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689238d057c0832b816a553982f80f1c