### PR TITLE
feat: refine project brief workflow

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -34,7 +34,8 @@ const transporter = nodemailer.createTransport({
 });
 
 function parseJsonFromText(text) {
-  const fenceMatch = text.match(/```(?:json)?\n([\s\S]*?)\n```/i);
+  // Extract JSON content even if it's wrapped in Markdown code fences
+  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
   const jsonString = fenceMatch ? fenceMatch[1] : text;
   return JSON.parse(jsonString);
 }
@@ -452,6 +453,16 @@ export const generateLearningStrategy = onRequest(
         res.status(500).json({ error: "Invalid AI response format." });
         return;
       }
+
+      if (Array.isArray(strategy.learnerPersonas)) {
+        strategy.learnerPersonas = strategy.learnerPersonas.map((p) => ({
+          ...p,
+          avatar: `https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=${encodeURIComponent(
+            p.name
+          )}`,
+        }));
+      }
+
       res.status(200).json(strategy);
     } catch (error) {
       console.error("Error generating learning strategy:", error);


### PR DESCRIPTION
## Summary
- allow editing the generated project brief and capture clarifying question responses
- add a next-step flow to produce a learning strategy with learner personas
- generate human-like illustrated avatars for each persona and display them with the learning strategy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689238d057c0832b816a553982f80f1c