### PR TITLE
feat: refine project brief workflow

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6,6 +6,7 @@ import nodemailer from "nodemailer";
 import admin from "firebase-admin";
 import { gemini, googleAI } from "@genkit-ai/googleai";
 import { genkit } from "genkit";
+import { GoogleGenerativeAI } from "@google/generative-ai";
 import { onCall, HttpsError, onRequest } from "firebase-functions/v2/https";
 
 // Initialize Firebase Admin (if not already initialized)
@@ -34,8 +35,18 @@ const transporter = nodemailer.createTransport({
 });
 
 function parseJsonFromText(text) {
-  const fenceMatch = text.match(/```(?:json)?\n([\s\S]*?)\n```/i);
-  const jsonString = fenceMatch ? fenceMatch[1] : text;
+  // Extract JSON content even if it's wrapped in Markdown code fences
+  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  const raw = fenceMatch ? fenceMatch[1] : text;
+
+  // Locate the first JSON object within the raw text
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error("No JSON object found in text");
+  }
+
+  const jsonString = raw.slice(start, end + 1);
   return JSON.parse(jsonString);
 }
 
@@ -406,6 +417,11 @@ export const generateProjectBrief = onRequest(
         res.status(500).json({ error: "Invalid AI response format." });
         return;
       }
+      if (!json.projectBrief) {
+        console.error("AI response missing projectBrief field:", json);
+        res.status(500).json({ error: "AI response missing project brief." });
+        return;
+      }
       res.status(200).json(json);
     } catch (error) {
       console.error("Error generating project brief:", error);
@@ -452,6 +468,41 @@ export const generateLearningStrategy = onRequest(
         res.status(500).json({ error: "Invalid AI response format." });
         return;
       }
+
+      if (!strategy.modalityRecommendation || !strategy.learnerPersonas) {
+        console.error("AI response missing expected fields:", strategy);
+        res.status(500).json({ error: "AI response missing learning strategy fields." });
+        return;
+      }
+
+      if (Array.isArray(strategy.learnerPersonas)) {
+        const genAI = new GoogleGenerativeAI(key);
+        const imageModel = genAI.getGenerativeModel({ model: "imagegeneration" });
+
+        async function generateAvatar(persona) {
+          const prompt = `Create a modern corporate vector style avatar of a learner persona named ${persona.name}. Their motivation is ${persona.motivation} and their challenges are ${persona.challenges}.`;
+          try {
+            const result = await imageModel.generateContent({
+              contents: [{ role: "user", parts: [{ text: prompt }] }],
+            });
+            const data =
+              result.response?.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+            return data ? `data:image/png;base64,${data}` : null;
+          } catch (err) {
+            console.error("Avatar generation failed for persona", persona.name, err);
+            const seed = encodeURIComponent(persona.name);
+            return `https://api.dicebear.com/8.x/adventurer-neutral/svg?seed=${seed}`;
+          }
+        }
+
+        strategy.learnerPersonas = await Promise.all(
+          strategy.learnerPersonas.map(async (p) => ({
+            ...p,
+            avatar: await generateAvatar(p),
+          }))
+        );
+      }
+
       res.status(200).json(strategy);
     } catch (error) {
       console.error("Error generating learning strategy:", error);

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -7,8 +7,13 @@ const InitiativesNew = () => {
   const [sourceMaterial, setSourceMaterial] = useState("");
   const [projectConstraints, setProjectConstraints] = useState("");
   const [projectBrief, setProjectBrief] = useState("");
+  const [clarifyingQuestions, setClarifyingQuestions] = useState([]);
+  const [clarifyingAnswers, setClarifyingAnswers] = useState([]);
+  const [strategy, setStrategy] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [nextLoading, setNextLoading] = useState(false);
   const [error, setError] = useState("");
+  const [nextError, setNextError] = useState("");
 
   const functionUrl =
     "https://us-central1-thoughtify-web-bb1ea.cloudfunctions.net/generateProjectBrief";
@@ -29,6 +34,9 @@ const InitiativesNew = () => {
     setLoading(true);
     setError("");
     setProjectBrief("");
+    setClarifyingQuestions([]);
+    setClarifyingAnswers([]);
+    setStrategy(null);
     try {
       const response = await fetch(functionUrl, {
         method: "POST",
@@ -44,7 +52,12 @@ const InitiativesNew = () => {
         throw new Error(`HTTP ${response.status}`);
       }
       const data = await response.json();
+      if (!data.projectBrief) {
+        throw new Error("No project brief returned.");
+      }
       setProjectBrief(data.projectBrief);
+      setClarifyingQuestions(data.clarifyingQuestions || []);
+      setClarifyingAnswers(data.clarifyingQuestions?.map(() => "") || []);
     } catch (err) {
       console.error("Error generating project brief:", err);
       setError(err.message || "Error generating project brief.");
@@ -61,6 +74,48 @@ const InitiativesNew = () => {
     a.download = "project-brief.txt";
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const handleAnswerChange = (index, value) => {
+    setClarifyingAnswers((prev) => {
+      const updated = [...prev];
+      updated[index] = value;
+      return updated;
+    });
+  };
+
+  const handleNext = async () => {
+    setNextLoading(true);
+    setNextError("");
+    setStrategy(null);
+    try {
+      const response = await fetch(
+        "https://us-central1-thoughtify-web-bb1ea.cloudfunctions.net/generateLearningStrategy",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            projectBrief,
+            businessGoal,
+            audienceProfile,
+            projectConstraints,
+          }),
+        }
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      if (!data.modalityRecommendation || !data.learnerPersonas) {
+        throw new Error("No learning strategy returned.");
+      }
+      setStrategy(data);
+    } catch (err) {
+      console.error("Error generating learning strategy:", err);
+      setNextError(err.message || "Error generating learning strategy.");
+    } finally {
+      setNextLoading(false);
+    }
   };
 
   return (
@@ -109,10 +164,74 @@ const InitiativesNew = () => {
       {projectBrief && (
         <div className="generator-result">
           <h3>Project Brief</h3>
-          <pre>{projectBrief}</pre>
+          <textarea
+            className="generator-input"
+            value={projectBrief}
+            onChange={(e) => setProjectBrief(e.target.value)}
+            rows="10"
+          />
           <button onClick={handleDownload} className="generator-button">
             Download Brief
           </button>
+          {clarifyingQuestions.length > 0 && (
+            <div>
+              <h4>Clarifying Questions</h4>
+              {clarifyingQuestions.map((q, idx) => (
+                <div key={idx}>
+                  <p>{q}</p>
+                  <textarea
+                    className="generator-input"
+                    value={clarifyingAnswers[idx] || ""}
+                    onChange={(e) => handleAnswerChange(idx, e.target.value)}
+                    rows="2"
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          <button
+            onClick={handleNext}
+            disabled={nextLoading}
+            className="generator-button"
+          >
+            {nextLoading ? "Generating..." : "Next Step"}
+          </button>
+          {nextError && <p className="generator-error">{nextError}</p>}
+        </div>
+      )}
+      {strategy && (
+        <div className="generator-result">
+          <h3>Learning Strategy</h3>
+          <p>
+            <strong>Modality Recommendation:</strong> {strategy.modalityRecommendation}
+          </p>
+          <p>
+            <strong>Rationale:</strong> {strategy.rationale}
+          </p>
+          {strategy.learnerPersonas && strategy.learnerPersonas.length > 0 && (
+            <div>
+              <h4>Learner Personas</h4>
+              <ul>
+                {strategy.learnerPersonas.map((p, idx) => (
+                  <li
+                    key={idx}
+                    style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+                  >
+                    {p.avatar && (
+                      <img
+                        src={p.avatar}
+                        alt={`${p.name} avatar`}
+                        style={{ width: "40px", height: "40px", borderRadius: "50%" }}
+                      />
+                    )}
+                    <span>
+                      <strong>{p.name}</strong>: {p.motivation}; {p.challenges}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow editing the generated project brief and capture clarifying question responses
- add a next-step flow to produce a learning strategy with learner personas
- generate modern corporate-style avatars for each persona using Google's `imagegeneration` model with DiceBear fallback
- fix Google AI avatar generation by removing unsupported response MIME type

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689238d057c0832b816a553982f80f1c