### PR TITLE
feat: use Imagen 4 Fast for avatar generation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -482,7 +482,7 @@ export const generateLearningStrategy = onRequest(
           process.env.GCP_PROJECT;
         const location = process.env.GOOGLE_CLOUD_REGION || "us-central1";
         const vertexAI = new VertexAI({ project, location });
-        const imageModel = vertexAI.getGenerativeModel({ model: "imagen-3.0" });
+        const imageModel = vertexAI.getGenerativeModel({ model: "imagen-4.0-fast-generate-preview-06-06" });
 
         async function generateAvatar(persona) {
           const prompt = `Create a modern corporate vector style avatar of a learner persona named ${persona.name}. Their motivation is ${persona.motivation} and their challenges are ${persona.challenges}.`;
@@ -500,12 +500,14 @@ export const generateLearningStrategy = onRequest(
           }
         }
 
-        strategy.learnerPersonas = await Promise.all(
-          strategy.learnerPersonas.map(async (p) => ({
+        const personasWithAvatars = [];
+        for (const p of strategy.learnerPersonas) {
+          personasWithAvatars.push({
             ...p,
             avatar: await generateAvatar(p),
-          }))
-        );
+          });
+        }
+        strategy.learnerPersonas = personasWithAvatars;
       }
 
       res.status(200).json(strategy);


### PR DESCRIPTION
## Summary
- upgrade Vertex AI avatar generation to Imagen 4 Fast preview model
- serialize avatar generation requests to avoid exceeding rate limits

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893afa7f050832bbbd0401c820c8485