### PR TITLE
Generate learner personas individually with avatar controls

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -72,15 +72,15 @@
     font-size: 1.75rem;
   }
   
-  .generator-result pre {
+.generator-result pre {
     white-space: pre-wrap;
     word-wrap: break-word;
     font-size: 16px;
     line-height: 1.5;
     margin: 0;
-  }
-  
-  /* Spinner styling */
+}
+
+/* Spinner styling */
 .spinner {
   display: inline-block;
   width: 40px;
@@ -96,4 +96,19 @@
   to {
     transform: rotate(360deg);
   }
+}
+
+.persona-card {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 20px;
+  border-radius: 12px;
+  margin-top: 20px;
+  text-align: center;
+}
+
+.persona-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- Allow requesting learning strategy without personas by adding `personaCount` parameter
- Add callable functions to generate a single learner persona and reroll its avatar
- Update Initiatives wizard with card interface to generate, edit, replace, and reroll personas one at a time
- Style persona card and avatar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894ce6c468c832ba1bfc4bb3d67eeea