### PR TITLE
feat: add retry logic for avatar generation

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,14 +15,16 @@
   "main": "index.js",
   "dependencies": {
     "@genkit-ai/googleai": "^1.0.4",
+    "@genkit-ai/vertexai": "^1.0.4",
     "@google-cloud/firestore": "^7.11.0",
-    "@google-cloud/vertexai": "^1.9.3",
+    "data-urls": "^5.0.0",
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^6.3.1",
     "genkit": "^1.0.4",
     "nodemailer": "^6.10.0"
   },
   "devDependencies": {
+    "@types/data-urls": "^5.0.0",
     "firebase-functions-test": "^3.1.0",
     "genkit-cli": "^1.0.4"
   },


### PR DESCRIPTION
## Summary
- switch to Genkit's Vertex model `imagegeneration@002` for avatar creation
- decode generated image data URLs and attach a single avatar per persona

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@genkit-ai%2fvertexai)


------
https://chatgpt.com/codex/tasks/task_e_6894d3a7c3d0832ba4102529c1064485