### PR TITLE
Remove avatar reroll and randomize persona name

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -522,9 +522,10 @@ export const generateLearnerPersona = onCall(
       model: gemini("gemini-1.5-pro"),
     });
 
-    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona. Return a JSON object exactly like this, no code fences:
+    const randomSeed = Math.random().toString(36).substring(2, 8);
+    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona with a distinct, randomly chosen name. Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
 
-{
+{ 
   "name": "Name",
   "motivation": "text",
   "challenges": "text"

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -32,10 +32,6 @@ const InitiativesNew = () => {
     functionsInstance,
     "generateLearnerPersona",
   );
-  const rerollAvatarCallable = httpsCallable(
-    functionsInstance,
-    "rerollPersonaAvatar",
-  );
 
   const handleFileUpload = (e) => {
     const file = e.target.files[0];
@@ -143,21 +139,6 @@ const InitiativesNew = () => {
     } catch (err) {
       console.error("Error generating persona:", err);
       setPersonaError(err.message || "Error generating persona.");
-    } finally {
-      setPersonaLoading(false);
-    }
-  };
-
-  const handleRerollAvatar = async () => {
-    if (!persona) return;
-    setPersonaLoading(true);
-    setPersonaError("");
-    try {
-      const result = await rerollAvatarCallable({ persona });
-      setPersona((prev) => ({ ...prev, avatar: result.data.avatar }));
-    } catch (err) {
-      console.error("Error regenerating avatar:", err);
-      setPersonaError(err.message || "Error regenerating avatar.");
     } finally {
       setPersonaLoading(false);
     }
@@ -298,13 +279,6 @@ const InitiativesNew = () => {
                   }
                   rows="2"
                 />
-                <button
-                  onClick={handleRerollAvatar}
-                  disabled={personaLoading}
-                  className="generator-button"
-                >
-                  {personaLoading ? "Generating..." : "Re-roll Avatar"}
-                </button>
                 <button
                   onClick={handleGeneratePersona}
                   disabled={personaLoading}


### PR DESCRIPTION
## Summary
- remove obsolete re-roll avatar functionality from InitiativesNew component
- add random seed to learner persona generator to ensure a new name when replacing persona

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm --prefix functions test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68953dc6996c832b840946cd0d1c751a