### PR TITLE
Include clarifying answers in learning strategy generation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -438,6 +438,7 @@ export const generateLearningStrategy = onCall(
       businessGoal,
       audienceProfile,
       projectConstraints,
+      clarifyingAnswers = [],
       personaCount = 3,
     } = req.data || {};
 
@@ -469,14 +470,17 @@ export const generateLearningStrategy = onCall(
   "rationale": "why this modality fits"
 }`;
 
-    const prompt = 
+    const prompt =
       `You are a Senior Instructional Designer. Using the provided information, recommend the most effective training modality${personaInstruction}. ` +
       `Return a JSON object with the structure:${returnStructure} ` +
       `Do not include code fences or extra formatting.\n\n` +
       `Project Brief: ${projectBrief}\n` +
       `Business Goal: ${businessGoal}\n` +
       `Audience Profile: ${audienceProfile}\n` +
-      `Project Constraints: ${projectConstraints}`;
+      `Project Constraints: ${projectConstraints}` +
+      (clarifyingAnswers.length
+        ? `\nClarifying Answers: ${clarifyingAnswers.join(" | ")}`
+        : "");
 
     const { text } = await ai.generate(prompt);
 

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -110,6 +110,7 @@ const InitiativesNew = () => {
         businessGoal,
         audienceProfile,
         projectConstraints,
+        clarifyingAnswers,
         personaCount: 0,
       });
       const data = result.data;


### PR DESCRIPTION
## Summary
- pass clarifying question responses when generating the learning strategy
- update backend prompt to factor user-provided clarifying answers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68955bdba12c832ba9c47b5fc243fa92