### PR TITLE
Include clarifying Q&A in learning strategy generation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -438,6 +438,8 @@ export const generateLearningStrategy = onCall(
       businessGoal,
       audienceProfile,
       projectConstraints,
+      clarifyingQuestions = [],
+      clarifyingAnswers = [],
       personaCount = 3,
     } = req.data || {};
 
@@ -469,14 +471,20 @@ export const generateLearningStrategy = onCall(
   "rationale": "why this modality fits"
 }`;
 
-    const prompt = 
+    const prompt =
       `You are a Senior Instructional Designer. Using the provided information, recommend the most effective training modality${personaInstruction}. ` +
       `Return a JSON object with the structure:${returnStructure} ` +
       `Do not include code fences or extra formatting.\n\n` +
       `Project Brief: ${projectBrief}\n` +
       `Business Goal: ${businessGoal}\n` +
       `Audience Profile: ${audienceProfile}\n` +
-      `Project Constraints: ${projectConstraints}`;
+      `Project Constraints: ${projectConstraints}` +
+      (() => {
+        const pairs = clarifyingQuestions.map((q, i) =>
+          `Q: ${q}\nA: ${clarifyingAnswers[i] || ""}`
+        );
+        return pairs.length ? `\nClarifications:\n${pairs.join("\n")}` : "";
+      })();
 
     const { text } = await ai.generate(prompt);
 

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -110,6 +110,8 @@ const InitiativesNew = () => {
         businessGoal,
         audienceProfile,
         projectConstraints,
+        clarifyingQuestions,
+        clarifyingAnswers,
         personaCount: 0,
       });
       const data = result.data;


### PR DESCRIPTION
## Summary
- send clarifying questions alongside answers when requesting a learning strategy
- embed clarifying question-answer pairs in the backend prompt so responses have context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955bdba12c832ba9c47b5fc243fa92