### PR TITLE
Generate persona avatars using Multiavatar

### DIFF
--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -137,7 +137,21 @@ const InitiativesNew = () => {
         audienceProfile,
         projectConstraints,
       });
-      setPersona(result.data);
+
+      let avatar;
+      try {
+        const avatarRes = await fetch(
+          `https://api.multiavatar.com/${encodeURIComponent(
+            result.data.name,
+          )}.svg`,
+        );
+        const svg = await avatarRes.text();
+        avatar = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+      } catch (avatarErr) {
+        console.error("Error fetching avatar:", avatarErr);
+      }
+
+      setPersona({ ...result.data, avatar });
     } catch (err) {
       console.error("Error generating persona:", err);
       setPersonaError(err.message || "Error generating persona.");


### PR DESCRIPTION
## Summary
- fetch Multiavatar SVGs for generated personas and store as data URLs
- render persona avatars in the learner persona section

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689569150548832b8002ae45d6830943