### PR TITLE
Generate persona avatars using Multiavatar

### DIFF
--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { getFunctions, httpsCallable } from "firebase/functions";
 import { app } from "../firebase.js";
 import "./AIToolsGenerators.css";
+import multiavatar from "../utils/multiavatar.js";
 
 const InitiativesNew = () => {
   const [businessGoal, setBusinessGoal] = useState("");
@@ -137,7 +138,16 @@ const InitiativesNew = () => {
         audienceProfile,
         projectConstraints,
       });
-      setPersona(result.data);
+
+      let avatar;
+      try {
+        const svg = multiavatar(result.data.name || "");
+        avatar = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+      } catch (avatarErr) {
+        console.error("Error generating avatar:", avatarErr);
+      }
+
+      setPersona({ ...result.data, avatar });
     } catch (err) {
       console.error("Error generating persona:", err);
       setPersonaError(err.message || "Error generating persona.");

--- a/src/utils/multiavatar.js
+++ b/src/utils/multiavatar.js
@@ -1,0 +1,30 @@
+// Simplified avatar generator inspired by Multiavatar.
+// Generates deterministic SVG avatars based on a string seed.
+export default function multiavatar(seed = "") {
+  const colors = [
+    "#e57373",
+    "#64b5f6",
+    "#81c784",
+    "#ba68c8",
+    "#ffb74d",
+    "#4db6ac",
+  ];
+
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = seed.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const color = colors[Math.abs(hash) % colors.length];
+
+  const initials = seed
+    .split(" ")
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase())
+    .join("")
+    .slice(0, 2);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <circle cx="50" cy="50" r="45" fill="${color}" />
+    <text x="50" y="55" text-anchor="middle" font-size="40" fill="#fff" font-family="Arial, sans-serif">${initials}</text>
+  </svg>`;
+}


### PR DESCRIPTION
## Summary
- generate deterministic persona avatars client-side via a local Multiavatar-inspired function
- render the generated avatar in the learner persona card

## Testing
- `npm run lint`
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_689569150548832b8002ae45d6830943