### PR TITLE
Generate persona avatars using AI image service

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -19,7 +19,9 @@
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^6.3.1",
     "genkit": "^1.0.4",
-    "nodemailer": "^6.10.0"
+    "nodemailer": "^6.10.0",
+    "openai": "^4.79.3",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0",


### PR DESCRIPTION
## Summary
- serve avatar images via a callable Cloud Function that responds to CORS requests
- use a fetch call in `InitiativesNew` to request and display avatar images
- depend on the `cors` middleware to set cross-origin headers in the function

## Testing
- `npm run lint`
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_689569150548832b8002ae45d6830943