### PR TITLE
Generate persona avatars with OpenAI

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7,6 +7,9 @@ import admin from "firebase-admin";
 import { gemini, googleAI } from "@genkit-ai/googleai";
 import { genkit } from "genkit";
 import { onCall, HttpsError, onRequest } from "firebase-functions/v2/https";
+import OpenAI from "openai";
+import crypto from "crypto";
+import { Buffer } from "buffer";
 
 // Initialize Firebase Admin (if not already initialized)
 if (!admin.apps.length) {
@@ -93,6 +96,7 @@ export const generateInvitation = functions.https.onCall(async (data, context) =
   await db.collection("invitations").add(invitationData);
   return { invitationCode };
 });
+
 
 export const generateTrainingPlan = onCall(
   { secrets: ["GOOGLE_GENAI_API_KEY"] },
@@ -701,3 +705,43 @@ export const sendEmailReply = functions.https.onCall(async (callData) => {
     return { success: false, error: error.message };
   }
 });
+
+export const generateAvatar = onCall(
+  { secrets: ["OPENAI_API_KEY"] },
+  async (request) => {
+    const { name, motivation = "", challenges = "" } = request.data || {};
+    if (!name) {
+      throw new HttpsError("invalid-argument", "name is required");
+    }
+
+    const seed = `${name}|${motivation}|${challenges}`;
+    const hash = crypto.createHash("md5").update(seed).digest("hex");
+    const bucket = admin.storage().bucket();
+    const file = bucket.file(`avatars/${hash}.png`);
+
+    try {
+      const [exists] = await file.exists();
+      if (exists) {
+        const [buffer] = await file.download();
+        return { avatar: `data:image/png;base64,${buffer.toString("base64")}` };
+      }
+
+      const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const prompt = `Professional, illustrative social media style character portrait of ${name}. Motivation: ${motivation}. Challenges: ${challenges}.`;
+      const response = await client.images.generate({
+        model: "gpt-image-1",
+        prompt,
+        size: "512x512",
+        response_format: "b64_json",
+      });
+
+      const b64 = response.data[0].b64_json;
+      const buffer = Buffer.from(b64, "base64");
+      await file.save(buffer, { contentType: "image/png" });
+      return { avatar: `data:image/png;base64,${b64}` };
+    } catch (error) {
+      console.error("Error generating avatar:", error);
+      throw new HttpsError("internal", "Failed to generate avatar");
+    }
+  }
+);

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,7 +19,8 @@
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^6.3.1",
     "genkit": "^1.0.4",
-    "nodemailer": "^6.10.0"
+    "nodemailer": "^6.10.0",
+    "openai": "^4.0.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0",

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -32,6 +32,10 @@ const InitiativesNew = () => {
     functionsInstance,
     "generateLearnerPersona",
   );
+  const generateAvatarCallable = httpsCallable(
+    functionsInstance,
+    "generateAvatar",
+  );
 
   const handleFileUpload = (e) => {
     const file = e.target.files[0];
@@ -137,7 +141,9 @@ const InitiativesNew = () => {
         audienceProfile,
         projectConstraints,
       });
-      setPersona(result.data);
+      const personaData = result.data;
+      const avatarResp = await generateAvatarCallable(personaData);
+      setPersona({ ...personaData, avatar: avatarResp.data.avatar });
     } catch (err) {
       console.error("Error generating persona:", err);
       setPersonaError(err.message || "Error generating persona.");


### PR DESCRIPTION
## Summary
- add a callable Cloud Function `generateAvatar` that uses OpenAI images API and caches results in Cloud Storage
- update Initiatives workflow to request avatars from the new function and embed the returned image
- remove the Multiavatar dependency from the client

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `npm --prefix functions install` *(fails: 403 Forbidden for openai)*

------
https://chatgpt.com/codex/tasks/task_e_689569150548832b8002ae45d6830943