### PR TITLE
feat: persist learner personas per initiative

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -684,3 +684,29 @@ export const generateAvatar = onCall(
   }
 );
 
+
+export const savePersona = onCall(async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) {
+    throw new HttpsError("unauthenticated", "User must be authenticated");
+  }
+  const { initiativeId, personaId, persona } = request.data || {};
+  if (!initiativeId || !personaId || !persona) {
+    throw new HttpsError(
+      "invalid-argument",
+      "Missing initiativeId, personaId, or persona data"
+    );
+  }
+  if (!persona.name) {
+    throw new HttpsError("invalid-argument", "Persona must include a name");
+  }
+  await db
+    .collection("users")
+    .doc(uid)
+    .collection("initiatives")
+    .doc(initiativeId)
+    .collection("personas")
+    .doc(personaId)
+    .set(persona, { merge: true });
+  return { id: personaId };
+});

--- a/src/utils/personas.js
+++ b/src/utils/personas.js
@@ -1,0 +1,25 @@
+import { db, functions } from "../firebase.js";
+import { collection, doc, getDocs, deleteDoc } from "firebase/firestore";
+import { httpsCallable } from "firebase/functions";
+
+// Load all personas for a given user's initiative
+export async function loadPersonas(uid, initiativeId) {
+  const personasRef = collection(db, "users", uid, "initiatives", initiativeId, "personas");
+  const snapshot = await getDocs(personasRef);
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+// Save a persona via callable function for server-side validation
+export async function savePersona(uid, initiativeId, persona) {
+  const personasRef = collection(db, "users", uid, "initiatives", initiativeId, "personas");
+  const personaId = persona.id || doc(personasRef).id;
+  const callable = httpsCallable(functions, "savePersona");
+  await callable({ initiativeId, personaId, persona });
+  return personaId;
+}
+
+// Delete a persona document
+export async function deletePersona(uid, initiativeId, personaId) {
+  const personaRef = doc(db, "users", uid, "initiatives", initiativeId, "personas", personaId);
+  await deleteDoc(personaRef);
+}


### PR DESCRIPTION
## Summary
- add Firestore helpers to load, save, and delete initiative personas
- expose `savePersona` Cloud Function for validation and persistence
- load and save personas in Initiatives page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689648362e8c832babda1dca5e42f174