### PR TITLE
feat: persist learner personas per initiative

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -684,3 +684,29 @@ export const generateAvatar = onCall(
   }
 );
 
+
+export const savePersona = onCall(async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) {
+    throw new HttpsError("unauthenticated", "User must be authenticated");
+  }
+  const { initiativeId, personaId, persona } = request.data || {};
+  if (!initiativeId || !personaId || !persona) {
+    throw new HttpsError(
+      "invalid-argument",
+      "Missing initiativeId, personaId, or persona data"
+    );
+  }
+  if (!persona.name) {
+    throw new HttpsError("invalid-argument", "Persona must include a name");
+  }
+  await db
+    .collection("users")
+    .doc(uid)
+    .collection("initiatives")
+    .doc(initiativeId)
+    .collection("personas")
+    .doc(personaId)
+    .set(persona, { merge: true });
+  return { id: personaId };
+});

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,44 +1,68 @@
 // src/Login.jsx
 import { useState } from "react";
-import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+} from "firebase/auth";
 import { useNavigate } from "react-router-dom";
 import { app } from "../firebase";
 
 const Login = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
+  const [isSignup, setIsSignup] = useState(false);
   const navigate = useNavigate();
   const firebaseAuth = getAuth(app);
-console.log("login loaded");
-  const handleLogin = async (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setError("");
     try {
-      const userCredential = await signInWithEmailAndPassword(firebaseAuth, email, password);
-      const user = userCredential.user;
-      console.log("Logged in:", user);
-
-      // Get the token result to log custom claims
-      const tokenResult = await user.getIdTokenResult();
-      console.log("Token claims:", tokenResult.claims);
-
-      // Redirect based on claims (for example)
-      if (tokenResult.claims.admin) {
-        navigate("/admin-dashboard");
-      } else {
+      if (isSignup) {
+        if (password !== confirmPassword) {
+          setError("Passwords do not match.");
+          return;
+        }
+        const userCredential = await createUserWithEmailAndPassword(
+          firebaseAuth,
+          email,
+          password
+        );
+        const user = userCredential.user;
+        console.log("Signed up:", user);
         navigate("/dashboard");
+      } else {
+        const userCredential = await signInWithEmailAndPassword(
+          firebaseAuth,
+          email,
+          password
+        );
+        const user = userCredential.user;
+        console.log("Logged in:", user);
+
+        // Get the token result to log custom claims
+        const tokenResult = await user.getIdTokenResult();
+        console.log("Token claims:", tokenResult.claims);
+
+        // Redirect based on claims (for example)
+        if (tokenResult.claims.admin) {
+          navigate("/admin-dashboard");
+        } else {
+          navigate("/dashboard");
+        }
       }
     } catch (err) {
-      console.error("Login error:", err);
-      setError(err.message || "Login failed.");
+      console.error("Auth error:", err);
+      setError(err.message || "Authentication failed.");
     }
   };
 
   return (
     <div className="login-container">
-      <h2>Login</h2>
-      <form onSubmit={handleLogin} className="login-form">
+      <h2>{isSignup ? "Sign Up" : "Login"}</h2>
+      <form onSubmit={handleSubmit} className="login-form">
         <input 
           type="email"
           placeholder="Email"
@@ -46,16 +70,40 @@ console.log("login loaded");
           onChange={(e) => setEmail(e.target.value)}
           required
         />
-        <input 
+        <input
           type="password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
         />
+        {isSignup && (
+          <input
+            type="password"
+            placeholder="Confirm Password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
+        )}
         {error && <p className="error-message">{error}</p>}
-        <button type="submit" className="login-button">Login</button>
+        <button type="submit" className="login-button">
+          {isSignup ? "Sign Up" : "Login"}
+        </button>
       </form>
+      <p className="toggle-message">
+        {isSignup ? "Already have an account?" : "Don't have an account?"}{" "}
+        <button
+          type="button"
+          className="toggle-button"
+          onClick={() => {
+            setError("");
+            setIsSignup(!isSignup);
+          }}
+        >
+          {isSignup ? "Login" : "Sign Up"}
+        </button>
+      </p>
     </div>
   );
 };

--- a/src/utils/personas.js
+++ b/src/utils/personas.js
@@ -1,0 +1,25 @@
+import { db, functions } from "../firebase.js";
+import { collection, doc, getDocs, deleteDoc } from "firebase/firestore";
+import { httpsCallable } from "firebase/functions";
+
+// Load all personas for a given user's initiative
+export async function loadPersonas(uid, initiativeId) {
+  const personasRef = collection(db, "users", uid, "initiatives", initiativeId, "personas");
+  const snapshot = await getDocs(personasRef);
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+// Save a persona via callable function for server-side validation
+export async function savePersona(uid, initiativeId, persona) {
+  const personasRef = collection(db, "users", uid, "initiatives", initiativeId, "personas");
+  const personaId = persona.id || doc(personasRef).id;
+  const callable = httpsCallable(functions, "savePersona");
+  await callable({ initiativeId, personaId, persona });
+  return personaId;
+}
+
+// Delete a persona document
+export async function deletePersona(uid, initiativeId, personaId) {
+  const personaRef = doc(db, "users", uid, "initiatives", initiativeId, "personas", personaId);
+  await deleteDoc(personaRef);
+}


### PR DESCRIPTION
## Summary
- add Firestore helpers to load, save, and delete initiative personas
- expose `savePersona` Cloud Function for validation and persistence
- load and save personas in Initiatives page
- allow users to create accounts directly from the login page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689648362e8c832babda1dca5e42f174