### PR TITLE
feat: add tabbed learner persona management

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -29,6 +29,30 @@ if (!admin.apps.length) {
 
 const db = admin.firestore();
 
+const FIRST_NAMES = [
+  "Anika", "Leo", "Maya", "Jonah", "Sophia", "Ethan", "Lila",
+  "Noah", "Ava", "Mason", "Isla", "Liam", "Zoe", "Kai",
+  "Emma", "Lucas", "Aria", "Owen", "Mila", "Finn",
+];
+
+const LAST_NAMES = [
+  "Fischer", "Kim", "Gupta", "O'Neill", "Rodriguez", "Chen",
+  "Patel", "Johnson", "Khan", "Liu", "Garcia", "Singh",
+  "Lopez", "Mori", "Smith", "Williams", "Brown", "Davis",
+  "Martinez", "Wilson",
+];
+
+function generateUniqueName(existing = []) {
+  const used = new Set(existing.map((n) => n.toLowerCase()));
+  for (let i = 0; i < 100; i++) {
+    const first = FIRST_NAMES[crypto.randomInt(0, FIRST_NAMES.length)];
+    const last = LAST_NAMES[crypto.randomInt(0, LAST_NAMES.length)];
+    const name = `${first} ${last}`;
+    if (!used.has(name.toLowerCase())) return name;
+  }
+  return `Learner ${crypto.randomInt(1000, 9999)}`;
+}
+
 // Retrieve the API key from environment variables (using Firebase secrets)
 // Make sure you have set the secret via:
 //    firebase functions:secrets:set GOOGLE_GENAI_API_KEY "your_api_key"
@@ -481,6 +505,11 @@ export const generateLearnerPersona = onCall(
       businessGoal,
       audienceProfile,
       projectConstraints,
+      existingMotivationKeywords = [],
+      existingChallengeKeywords = [],
+      refreshField,
+      personaName,
+      existingNames = [],
     } = req.data || {};
 
     if (!projectBrief) {
@@ -496,13 +525,59 @@ export const generateLearnerPersona = onCall(
     });
 
     const randomSeed = Math.random().toString(36).substring(2, 8);
-    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona with a distinct, randomly chosen name. Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
+    const finalName = personaName || generateUniqueName(existingNames);
+
+    // Refresh motivations or challenges only
+    if (refreshField === "motivation" || refreshField === "challenges") {
+      const personaContext = finalName
+        ? `The persona's name is ${finalName}. Write each option's "text" as a third-person sentence about ${finalName}.`
+        : "Write each option's \"text\" as a third-person sentence about the learner persona.";
+      const listPrompt = `You are a Senior Instructional Designer. ${personaContext} Based on the project information below, list three fresh learner ${
+        refreshField
+      } options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) that captures the theme — do not use generic terms like "general" or "other" — and a "text" field written in full sentences. Avoid the following ${
+        refreshField
+      } keywords: ${
+        refreshField === "motivation"
+          ? existingMotivationKeywords.join(", ") || "none"
+          : existingChallengeKeywords.join(", ") || "none"
+      }.
+
+Project Brief: ${projectBrief}
+Business Goal: ${businessGoal}
+Audience Profile: ${audienceProfile}
+Project Constraints: ${projectConstraints}`;
+
+      const { text } = await ai.generate(listPrompt);
+
+      let data;
+      try {
+        data = parseJsonFromText(text);
+      } catch (err) {
+        console.error("Failed to parse AI response:", err, text);
+        throw new HttpsError("internal", "Invalid AI response format.");
+      }
+
+      if (refreshField === "motivation") {
+        return { motivationOptions: data.options || [] };
+      }
+      return { challengeOptions: data.options || [] };
+    }
+
+    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona named ${finalName}. For both the primary motivation and the primary challenge:
+- Provide a short, specific keyword (1-3 words) that summarizes the item. Avoid generic labels such as "general" or "other".
+- Provide a full-sentence description in a "text" field written about ${finalName} in third person using their name.
+Also supply exactly two alternative options for motivations and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" is also a full-sentence description about ${finalName}. Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
 
 {
   "name": "Name",
-  "motivation": "text",
-  "challenges": "text"
+  "motivation": {"keyword": "short", "text": "full"},
+  "motivationOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}],
+  "challenges": {"keyword": "short", "text": "full"},
+  "challengeOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}]
 }
+
+Avoid motivation keywords: ${existingMotivationKeywords.join(", ") || "none"}.
+Avoid challenge keywords: ${existingChallengeKeywords.join(", ") || "none"}.
 
 Project Brief: ${projectBrief}
 Business Goal: ${businessGoal}
@@ -519,6 +594,7 @@ Project Constraints: ${projectConstraints}`;
       throw new HttpsError("internal", "Invalid AI response format.");
     }
 
+    persona.name = finalName;
     return persona;
   }
 );

--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -112,3 +112,44 @@
   border-radius: 50%;
   margin-bottom: 10px;
 }
+
+.persona-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.persona-tab {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: inherit;
+}
+
+.persona-tab.active {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.persona-tab-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+
+.persona-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px 0;
+}
+
+.persona-options p {
+  width: 100%;
+  margin: 0;
+}

--- a/src/components/CustomDashboard.css
+++ b/src/components/CustomDashboard.css
@@ -26,7 +26,25 @@
     transition: background 0.3s;
   }
   
-  .todo-list li:hover {
-    background: #a742b2;
-  }
+.todo-list li:hover {
+  background: #a742b2;
+}
+
+.ai-tools-access {
+  margin-top: 20px;
+}
+
+.ai-tools-button {
+  background: #007bff;
+  color: #fff;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.ai-tools-button:hover {
+  background: #0056b3;
+}
   

--- a/src/components/CustomDashboard.jsx
+++ b/src/components/CustomDashboard.jsx
@@ -10,6 +10,7 @@ import {
   getDocs,
   doc,
   getDoc,
+  setDoc,
 } from "firebase/firestore";
 import { onAuthStateChanged, signOut } from "firebase/auth";
 import { app, auth } from "../firebase";
@@ -75,7 +76,23 @@ const CustomDashboard = () => {
             setDisplayName(profileData.businessName || profileData.name || "Your Business");
           } catch (err) {
             console.error("Error fetching profile:", err);
-            setError("No profile data found.");
+            // If no profile exists, create a default one so the user can proceed.
+            try {
+              await setDoc(
+                doc(db, "profiles", user.uid),
+                {
+                  name: user.displayName || "",
+                  businessName: "",
+                  businessEmail: user.email || "",
+                  uid: user.uid,
+                },
+                { merge: true }
+              );
+              setDisplayName(user.displayName || "Your Business");
+            } catch (creationErr) {
+              console.error("Error creating default profile:", creationErr);
+              setError("No profile data found.");
+            }
           }
         } catch (err) {
           console.error("Error fetching invitation or profile data:", err);
@@ -133,6 +150,14 @@ const CustomDashboard = () => {
           </li>
           {/* Additional to-do items can be added here */}
         </ul>
+      </div>
+      <div className="ai-tools-access">
+        <button
+          onClick={() => navigate("/ai-tools")}
+          className="ai-tools-button"
+        >
+          Go to AI Tools
+        </button>
       </div>
     </div>
   );

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -9,6 +9,35 @@ import {
 import { useSearchParams } from "react-router-dom";
 import "./AIToolsGenerators.css";
 
+const formatKeyword = (kw = "") =>
+  kw ? kw.charAt(0).toUpperCase() + kw.slice(1) : "";
+
+const normalizePersona = (p = {}) => ({
+  ...p,
+  motivation:
+    typeof p.motivation === "string"
+      ? { keyword: "General", text: p.motivation }
+      : {
+          keyword: formatKeyword(p.motivation?.keyword) || "General",
+          text: p.motivation?.text || "",
+        },
+  challenges:
+    typeof p.challenges === "string"
+      ? { keyword: "General", text: p.challenges }
+      : {
+          keyword: formatKeyword(p.challenges?.keyword) || "General",
+          text: p.challenges?.text || "",
+        },
+  motivationOptions: (p.motivationOptions || []).map((o) => ({
+    ...o,
+    keyword: formatKeyword(o.keyword),
+  })),
+  challengeOptions: (p.challengeOptions || []).map((o) => ({
+    ...o,
+    keyword: formatKeyword(o.keyword),
+  })),
+});
+
 const InitiativesNew = () => {
   const [businessGoal, setBusinessGoal] = useState("");
   const [audienceProfile, setAudienceProfile] = useState("");
@@ -29,7 +58,22 @@ const InitiativesNew = () => {
   const [nextError, setNextError] = useState("");
   const [personaError, setPersonaError] = useState("");
 
-  const [persona, setPersona] = useState(null);
+  const [personas, setPersonas] = useState([]);
+  const [activePersonaIndex, setActivePersonaIndex] = useState(0);
+  const [editingPersona, setEditingPersona] = useState(null);
+  const [usedMotivationKeywords, setUsedMotivationKeywords] = useState([]);
+  const [usedChallengeKeywords, setUsedChallengeKeywords] = useState([]);
+
+  const addUsedMotivation = (keywords = []) => {
+    setUsedMotivationKeywords((prev) =>
+      Array.from(new Set([...prev, ...keywords.filter(Boolean)]))
+    );
+  };
+  const addUsedChallenge = (keywords = []) => {
+    setUsedChallengeKeywords((prev) =>
+      Array.from(new Set([...prev, ...keywords.filter(Boolean)]))
+    );
+  };
 
   const [searchParams] = useSearchParams();
   const initiativeId = searchParams.get("initiativeId") || "default";
@@ -55,9 +99,22 @@ const InitiativesNew = () => {
 
     loadPersonas(uid, initiativeId)
       .then((items) => {
-        if (items.length > 0) {
-          setPersona(items[0]);
-        }
+        const normalized = items.map((p) => normalizePersona(p));
+        setPersonas(normalized);
+        setActivePersonaIndex(0);
+        // populate used keyword sets
+        normalized.forEach((p) => {
+          const mKeys = [
+            p.motivation?.keyword,
+            ...(p.motivationOptions || []).map((o) => o.keyword),
+          ].filter(Boolean);
+          const cKeys = [
+            p.challenges?.keyword,
+            ...(p.challengeOptions || []).map((o) => o.keyword),
+          ].filter(Boolean);
+          addUsedMotivation(mKeys);
+          addUsedChallenge(cKeys);
+        });
       })
       .catch((err) => console.error("Error loading personas:", err));
   }, [initiativeId]);
@@ -88,7 +145,9 @@ const InitiativesNew = () => {
     setClarifyingQuestions([]);
     setClarifyingAnswers([]);
     setStrategy(null);
-    setPersona(null);
+    setPersonas([]);
+    setActivePersonaIndex(0);
+    setEditingPersona(null);
 
     try {
       const { data } = await generateProjectBrief({
@@ -153,7 +212,9 @@ const InitiativesNew = () => {
     setNextLoading(true);
     setNextError("");
     setStrategy(null);
-    setPersona(null);
+    setPersonas([]);
+    setActivePersonaIndex(0);
+    setEditingPersona(null);
 
     try {
       const { data } = await generateLearningStrategy({
@@ -182,39 +243,73 @@ const InitiativesNew = () => {
     }
   };
 
-  const handleGeneratePersona = async () => {
+  const currentPersona = personas[activePersonaIndex] || null;
+
+  const handleGeneratePersona = async (action = "add") => {
     setPersonaLoading(true);
     setPersonaError("");
     try {
-      // 1) AI generates persona JSON (name/motivation/challenges)
+      const existingNames = personas
+        .filter((_, i) => !(action === "replace" && i === activePersonaIndex))
+        .map((p) => p.name);
       const personaRes = await generateLearnerPersona({
         projectBrief,
         businessGoal,
         audienceProfile,
         projectConstraints,
+        existingMotivationKeywords: usedMotivationKeywords,
+        existingChallengeKeywords: usedChallengeKeywords,
+        existingNames,
       });
-      const personaData = personaRes.data;
+      const personaData = normalizePersona(personaRes.data);
       if (!personaData?.name) {
         throw new Error("Persona generation returned no name.");
       }
 
-      // 2) Use that AI persona to generate avatar image
       const avatarRes = await generateAvatar({
         name: personaData.name,
-        motivation: personaData.motivation || "",
-        challenges: personaData.challenges || "",
+        motivation: personaData.motivation?.text || "",
+        challenges: personaData.challenges?.text || "",
       });
 
-      const uid = auth.currentUser?.uid;
       const personaToSave = {
         ...personaData,
         avatar: avatarRes?.data?.avatar || null,
       };
+      // record used keywords
+      addUsedMotivation([
+        personaToSave.motivation?.keyword,
+        ...(personaToSave.motivationOptions || []).map((o) => o.keyword),
+      ]);
+      addUsedChallenge([
+        personaToSave.challenges?.keyword,
+        ...(personaToSave.challengeOptions || []).map((o) => o.keyword),
+      ]);
+      const uid = auth.currentUser?.uid;
       if (uid) {
-        const id = await savePersona(uid, initiativeId, personaToSave);
-        setPersona({ id, ...personaToSave });
+        if (action === "replace" && currentPersona) {
+          const id = currentPersona.id;
+          await savePersona(uid, initiativeId, { ...personaToSave, id });
+          setPersonas((prev) =>
+            prev.map((p, i) => (i === activePersonaIndex ? { id, ...personaToSave } : p))
+          );
+        } else {
+          const id = await savePersona(uid, initiativeId, personaToSave);
+          const newPersona = { id, ...personaToSave };
+          const newIndex = personas.length;
+          setPersonas((prev) => [...prev, newPersona]);
+          setActivePersonaIndex(newIndex);
+        }
       } else {
-        setPersona(personaToSave);
+        if (action === "replace" && currentPersona) {
+          setPersonas((prev) =>
+            prev.map((p, i) => (i === activePersonaIndex ? { ...personaToSave } : p))
+          );
+        } else {
+          const newIndex = personas.length;
+          setPersonas((prev) => [...prev, personaToSave]);
+          setActivePersonaIndex(newIndex);
+        }
       }
     } catch (err) {
       console.error("Error generating persona:", err);
@@ -225,14 +320,104 @@ const InitiativesNew = () => {
   };
 
   const handlePersonaFieldChange = (field, value) => {
-    setPersona((prev) => {
-      const updated = { ...prev, [field]: value };
-      const uid = auth.currentUser?.uid;
-      if (uid) {
-        savePersona(uid, initiativeId, updated);
+    setEditingPersona((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const selectMotivationOption = (opt) => {
+    setEditingPersona((prev) => ({ ...prev, motivation: opt }));
+  };
+  const selectChallengeOption = (opt) => {
+    setEditingPersona((prev) => ({ ...prev, challenges: opt }));
+  };
+
+  const refreshOptions = async (field) => {
+    if (!editingPersona) return;
+    setPersonaLoading(true);
+    setPersonaError("");
+    if (field === "motivation") {
+      setEditingPersona((prev) => ({ ...prev, motivationOptions: [] }));
+    } else {
+      setEditingPersona((prev) => ({ ...prev, challengeOptions: [] }));
+    }
+    try {
+      const { data } = await generateLearnerPersona({
+        projectBrief,
+        businessGoal,
+        audienceProfile,
+        projectConstraints,
+        existingMotivationKeywords: usedMotivationKeywords,
+        existingChallengeKeywords: usedChallengeKeywords,
+        refreshField: field,
+        personaName: editingPersona.name,
+      });
+      if (field === "motivation") {
+        const opts = (data.motivationOptions || []).map((o) => ({
+          ...o,
+          keyword: formatKeyword(o.keyword),
+        }));
+        if (opts.length === 0) {
+          setPersonaError("No new options available.");
+        } else {
+          addUsedMotivation(opts.map((o) => o.keyword));
+          setEditingPersona((prev) => ({ ...prev, motivationOptions: opts }));
+        }
+      } else {
+        const opts = (data.challengeOptions || []).map((o) => ({
+          ...o,
+          keyword: formatKeyword(o.keyword),
+        }));
+        if (opts.length === 0) {
+          setPersonaError("No new options available.");
+        } else {
+          addUsedChallenge(opts.map((o) => o.keyword));
+          setEditingPersona((prev) => ({ ...prev, challengeOptions: opts }));
+        }
       }
-      return updated;
-    });
+    } catch (err) {
+      console.error("Error generating options:", err);
+      setPersonaError(err?.message || "Error generating options.");
+    } finally {
+      setPersonaLoading(false);
+    }
+  };
+
+  const handleSavePersonaEdits = async () => {
+    if (!editingPersona) return;
+    const uid = auth.currentUser?.uid;
+    try {
+      if (uid) {
+        await savePersona(uid, initiativeId, editingPersona);
+      }
+      setPersonas((prev) =>
+        prev.map((p, i) => (i === activePersonaIndex ? editingPersona : p))
+      );
+      setEditingPersona(null);
+    } catch (err) {
+      console.error("Error saving persona:", err);
+      setPersonaError(err?.message || "Error saving persona.");
+    }
+  };
+
+  const handleRegenerateAvatar = async () => {
+    if (!editingPersona) return;
+    setPersonaLoading(true);
+    setPersonaError("");
+    try {
+      const avatarRes = await generateAvatar({
+        name: editingPersona.name,
+        motivation: editingPersona.motivation?.text || "",
+        challenges: editingPersona.challenges?.text || "",
+      });
+      setEditingPersona((prev) => ({
+        ...prev,
+        avatar: avatarRes?.data?.avatar || null,
+      }));
+    } catch (err) {
+      console.error("Error generating avatar:", err);
+      setPersonaError(err?.message || "Error generating avatar.");
+    } finally {
+      setPersonaLoading(false);
+    }
   };
 
   return (
@@ -325,10 +510,10 @@ const InitiativesNew = () => {
           </p>
 
           <div>
-            <h4>Learner Persona</h4>
-            {!persona && (
+            <h4>Learner Personas</h4>
+            {personas.length === 0 && (
               <button
-                onClick={handleGeneratePersona}
+                onClick={() => handleGeneratePersona("add")}
                 disabled={personaLoading}
                 className="generator-button"
               >
@@ -336,47 +521,206 @@ const InitiativesNew = () => {
               </button>
             )}
 
-            {persona && (
-              <div className="persona-card">
-                {persona.avatar && (
-                  <img
-                    src={persona.avatar}
-                    alt={`${persona.name} avatar`}
-                    className="persona-avatar"
-                  />
+            {personas.length > 0 && (
+              <div>
+                {personas.length > 1 && (
+                  <div className="persona-tabs">
+                    {personas.map((p, i) => (
+                      <button
+                        key={p.id || i}
+                        type="button"
+                        onClick={() => {
+                          setActivePersonaIndex(i);
+                          setEditingPersona(null);
+                        }}
+                        className={`persona-tab ${i === activePersonaIndex ? "active" : ""}`}
+                      >
+                        {p.avatar && (
+                          <img
+                            src={p.avatar}
+                            alt={`${p.name} avatar`}
+                            className="persona-tab-avatar"
+                          />
+                        )}
+                        <span>{p.name}</span>
+                      </button>
+                    ))}
+                  </div>
                 )}
 
-                <input
-                  className="generator-input"
-                  value={persona.name}
-                  onChange={(e) => handlePersonaFieldChange("name", e.target.value)}
-                />
-                <textarea
-                  className="generator-input"
-                  value={persona.motivation}
-                  onChange={(e) => handlePersonaFieldChange("motivation", e.target.value)}
-                  rows={2}
-                />
-                <textarea
-                  className="generator-input"
-                  value={persona.challenges}
-                  onChange={(e) => handlePersonaFieldChange("challenges", e.target.value)}
-                  rows={2}
-                />
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                  <button
-                    onClick={handleGeneratePersona}
-                    disabled={personaLoading}
-                    className="generator-button"
-                    type="button"
-                  >
-                    {personaLoading ? "Generating..." : "Replace Persona"}
-                  </button>
-                </div>
+                {currentPersona && (
+                  <div className="persona-card">
+                    {editingPersona ? (
+                      <>
+                        {editingPersona.avatar && (
+                          <img
+                            src={editingPersona.avatar}
+                            alt={`${editingPersona.name} avatar`}
+                            className="persona-avatar"
+                          />
+                        )}
+                        <input
+                          className="generator-input"
+                          value={editingPersona.name}
+                          onChange={(e) => handlePersonaFieldChange("name", e.target.value)}
+                        />
+                        <p>
+                          <strong>Motivation - {editingPersona.motivation?.keyword}</strong>
+                        </p>
+                        <textarea
+                          className="generator-input"
+                          value={editingPersona.motivation?.text || ""}
+                          onChange={(e) =>
+                            handlePersonaFieldChange("motivation", {
+                              ...editingPersona.motivation,
+                              text: e.target.value,
+                            })
+                          }
+                          rows={2}
+                        />
+                        <div className="persona-options">
+                          {editingPersona.motivationOptions?.length > 0 && (
+                            <>
+                              <p>Other possible motivations...</p>
+                              {editingPersona.motivationOptions.map((opt) => (
+                                <button
+                                  key={opt.keyword}
+                                  type="button"
+                                  onClick={() => selectMotivationOption(opt)}
+                                  className="generator-button"
+                                >
+                                  {opt.keyword}
+                                </button>
+                              ))}
+                            </>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => refreshOptions("motivation")}
+                            className="generator-button"
+                          >
+                            Generate more
+                          </button>
+                        </div>
+                        <p>
+                          <strong>Challenges - {editingPersona.challenges?.keyword}</strong>
+                        </p>
+                        <textarea
+                          className="generator-input"
+                          value={editingPersona.challenges?.text || ""}
+                          onChange={(e) =>
+                            handlePersonaFieldChange("challenges", {
+                              ...editingPersona.challenges,
+                              text: e.target.value,
+                            })
+                          }
+                          rows={2}
+                        />
+                        <div className="persona-options">
+                          {editingPersona.challengeOptions?.length > 0 && (
+                            <>
+                              <p>Other possible challenges...</p>
+                              {editingPersona.challengeOptions.map((opt) => (
+                                <button
+                                  key={opt.keyword}
+                                  type="button"
+                                  onClick={() => selectChallengeOption(opt)}
+                                  className="generator-button"
+                                >
+                                  {opt.keyword}
+                                </button>
+                              ))}
+                            </>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => refreshOptions("challenges")}
+                            className="generator-button"
+                          >
+                            Generate more
+                          </button>
+                        </div>
+                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                          <button
+                            onClick={handleRegenerateAvatar}
+                            disabled={personaLoading}
+                            className="generator-button"
+                            type="button"
+                          >
+                            {personaLoading ? "Generating..." : "Regenerate Avatar"}
+                          </button>
+                          <button
+                            onClick={handleSavePersonaEdits}
+                            disabled={personaLoading}
+                            className="generator-button"
+                            type="button"
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={() => setEditingPersona(null)}
+                            className="generator-button"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        {currentPersona.avatar && (
+                          <img
+                            src={currentPersona.avatar}
+                            alt={`${currentPersona.name} avatar`}
+                            className="persona-avatar"
+                          />
+                        )}
+                        <h5>{currentPersona.name}</h5>
+                        <p>
+                          <strong>Motivation - {currentPersona.motivation?.keyword}:</strong> {currentPersona.motivation?.text}
+                        </p>
+                        <p>
+                          <strong>Challenges - {currentPersona.challenges?.keyword}:</strong> {currentPersona.challenges?.text}
+                        </p>
+                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                          <button
+                            onClick={() =>
+                              setEditingPersona(
+                                JSON.parse(JSON.stringify(currentPersona))
+                              )
+                            }
+                            className="generator-button"
+                            type="button"
+                          >
+                            Edit Persona
+                          </button>
+                          <button
+                            onClick={() => handleGeneratePersona("replace")}
+                            disabled={personaLoading}
+                            className="generator-button"
+                            type="button"
+                          >
+                            {personaLoading ? "Generating..." : "Replace Persona"}
+                          </button>
+                          {personas.length < 3 && (
+                            <button
+                              onClick={() => handleGeneratePersona("add")}
+                              disabled={personaLoading}
+                              className="generator-button"
+                              type="button"
+                            >
+                              {personaLoading ? "Generating..." : "Add Persona"}
+                            </button>
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+
+                {personaError && <p className="generator-error">{personaError}</p>}
               </div>
             )}
-
-            {personaError && <p className="generator-error">{personaError}</p>}
           </div>
         </div>
       )}

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 const NavBar = () => {
   return (
     <nav className="navbar">
@@ -6,7 +8,9 @@ const NavBar = () => {
           <a href="#home" className="nav-link">Home</a>
         </li>
         <li className="nav-item">
-          <a href="#tools" className="nav-link">Tools</a>
+          <Link to="/ai-tools" className="nav-link">
+            Tools
+          </Link>
         </li>
         <li className="nav-item">
           <a href="#pricing" className="nav-link">Pricing</a>


### PR DESCRIPTION
## Summary
- Support up to three learner personas with tabbed navigation
- Show persona details in read-only cards with edit, replace, and add options
- Ensure unique persona motivations and challenges with refreshable alternative suggestions
- Personalize alternative motivation and challenge options so each suggestion references the persona by name
- Generate distinctive learner names by filtering out previously used names before calling the AI

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68978c2bc2d0832bb669be2d2ca082c7