### PR TITLE
feat: add tabbed learner persona management

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -29,6 +29,30 @@ if (!admin.apps.length) {
 
 const db = admin.firestore();
 
+const FIRST_NAMES = [
+  "Anika", "Leo", "Maya", "Jonah", "Sophia", "Ethan", "Lila",
+  "Noah", "Ava", "Mason", "Isla", "Liam", "Zoe", "Kai",
+  "Emma", "Lucas", "Aria", "Owen", "Mila", "Finn",
+];
+
+const LAST_NAMES = [
+  "Fischer", "Kim", "Gupta", "O'Neill", "Rodriguez", "Chen",
+  "Patel", "Johnson", "Khan", "Liu", "Garcia", "Singh",
+  "Lopez", "Mori", "Smith", "Williams", "Brown", "Davis",
+  "Martinez", "Wilson",
+];
+
+function generateUniqueName(existing = []) {
+  const used = new Set(existing.map((n) => n.toLowerCase()));
+  for (let i = 0; i < 100; i++) {
+    const first = FIRST_NAMES[crypto.randomInt(0, FIRST_NAMES.length)];
+    const last = LAST_NAMES[crypto.randomInt(0, LAST_NAMES.length)];
+    const name = `${first} ${last}`;
+    if (!used.has(name.toLowerCase())) return name;
+  }
+  return `Learner ${crypto.randomInt(1000, 9999)}`;
+}
+
 // Retrieve the API key from environment variables (using Firebase secrets)
 // Make sure you have set the secret via:
 //    firebase functions:secrets:set GOOGLE_GENAI_API_KEY "your_api_key"
@@ -481,6 +505,11 @@ export const generateLearnerPersona = onCall(
       businessGoal,
       audienceProfile,
       projectConstraints,
+      existingMotivationKeywords = [],
+      existingChallengeKeywords = [],
+      refreshField,
+      personaName,
+      existingNames = [],
     } = req.data || {};
 
     if (!projectBrief) {
@@ -496,13 +525,59 @@ export const generateLearnerPersona = onCall(
     });
 
     const randomSeed = Math.random().toString(36).substring(2, 8);
-    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona with a distinct, randomly chosen name. Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
+    const finalName = personaName || generateUniqueName(existingNames);
+
+    // Refresh motivations or challenges only
+    if (refreshField === "motivation" || refreshField === "challenges") {
+      const personaContext = finalName
+        ? `The persona's name is ${finalName}. Write each option's "text" as a third-person sentence about ${finalName}.`
+        : "Write each option's \"text\" as a third-person sentence about the learner persona.";
+      const listPrompt = `You are a Senior Instructional Designer. ${personaContext} Based on the project information below, list three fresh learner ${
+        refreshField
+      } options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) that captures the theme — do not use generic terms like "general" or "other" — and a "text" field written in full sentences. Avoid the following ${
+        refreshField
+      } keywords: ${
+        refreshField === "motivation"
+          ? existingMotivationKeywords.join(", ") || "none"
+          : existingChallengeKeywords.join(", ") || "none"
+      }.
+
+Project Brief: ${projectBrief}
+Business Goal: ${businessGoal}
+Audience Profile: ${audienceProfile}
+Project Constraints: ${projectConstraints}`;
+
+      const { text } = await ai.generate(listPrompt);
+
+      let data;
+      try {
+        data = parseJsonFromText(text);
+      } catch (err) {
+        console.error("Failed to parse AI response:", err, text);
+        throw new HttpsError("internal", "Invalid AI response format.");
+      }
+
+      if (refreshField === "motivation") {
+        return { motivationOptions: data.options || [] };
+      }
+      return { challengeOptions: data.options || [] };
+    }
+
+    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona named ${finalName}. For both the primary motivation and the primary challenge:
+- Provide a short, specific keyword (1-3 words) that summarizes the item. Avoid generic labels such as "general" or "other".
+- Provide a full-sentence description in a "text" field written about ${finalName} in third person using their name.
+Also supply exactly two alternative options for motivations and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" is also a full-sentence description about ${finalName}. Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
 
 {
   "name": "Name",
-  "motivation": "text",
-  "challenges": "text"
+  "motivation": {"keyword": "short", "text": "full"},
+  "motivationOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}],
+  "challenges": {"keyword": "short", "text": "full"},
+  "challengeOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}]
 }
+
+Avoid motivation keywords: ${existingMotivationKeywords.join(", ") || "none"}.
+Avoid challenge keywords: ${existingChallengeKeywords.join(", ") || "none"}.
 
 Project Brief: ${projectBrief}
 Business Goal: ${businessGoal}
@@ -519,6 +594,7 @@ Project Constraints: ${projectConstraints}`;
       throw new HttpsError("internal", "Invalid AI response format.");
     }
 
+    persona.name = finalName;
     return persona;
   }
 );

--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -112,3 +112,44 @@
   border-radius: 50%;
   margin-bottom: 10px;
 }
+
+.persona-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.persona-tab {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: inherit;
+}
+
+.persona-tab.active {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.persona-tab-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+
+.persona-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px 0;
+}
+
+.persona-options p {
+  width: 100%;
+  margin: 0;
+}

--- a/src/components/CustomDashboard.css
+++ b/src/components/CustomDashboard.css
@@ -26,7 +26,25 @@
     transition: background 0.3s;
   }
   
-  .todo-list li:hover {
-    background: #a742b2;
-  }
+.todo-list li:hover {
+  background: #a742b2;
+}
+
+.ai-tools-access {
+  margin-top: 20px;
+}
+
+.ai-tools-button {
+  background: #007bff;
+  color: #fff;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.ai-tools-button:hover {
+  background: #0056b3;
+}
   

--- a/src/components/CustomDashboard.jsx
+++ b/src/components/CustomDashboard.jsx
@@ -10,6 +10,7 @@ import {
   getDocs,
   doc,
   getDoc,
+  setDoc,
 } from "firebase/firestore";
 import { onAuthStateChanged, signOut } from "firebase/auth";
 import { app, auth } from "../firebase";
@@ -75,7 +76,23 @@ const CustomDashboard = () => {
             setDisplayName(profileData.businessName || profileData.name || "Your Business");
           } catch (err) {
             console.error("Error fetching profile:", err);
-            setError("No profile data found.");
+            // If no profile exists, create a default one so the user can proceed.
+            try {
+              await setDoc(
+                doc(db, "profiles", user.uid),
+                {
+                  name: user.displayName || "",
+                  businessName: "",
+                  businessEmail: user.email || "",
+                  uid: user.uid,
+                },
+                { merge: true }
+              );
+              setDisplayName(user.displayName || "Your Business");
+            } catch (creationErr) {
+              console.error("Error creating default profile:", creationErr);
+              setError("No profile data found.");
+            }
           }
         } catch (err) {
           console.error("Error fetching invitation or profile data:", err);
@@ -133,6 +150,14 @@ const CustomDashboard = () => {
           </li>
           {/* Additional to-do items can be added here */}
         </ul>
+      </div>
+      <div className="ai-tools-access">
+        <button
+          onClick={() => navigate("/ai-tools")}
+          className="ai-tools-button"
+        >
+          Go to AI Tools
+        </button>
       </div>
     </div>
   );

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 const NavBar = () => {
   return (
     <nav className="navbar">
@@ -6,7 +8,9 @@ const NavBar = () => {
           <a href="#home" className="nav-link">Home</a>
         </li>
         <li className="nav-item">
-          <a href="#tools" className="nav-link">Tools</a>
+          <Link to="/ai-tools" className="nav-link">
+            Tools
+          </Link>
         </li>
         <li className="nav-item">
           <a href="#pricing" className="nav-link">Pricing</a>


### PR DESCRIPTION
## Summary
- Support up to three learner personas with tabbed navigation and deletion controls
- Show persona details in read-only cards with edit, replace, and add options
- Ensure unique persona motivations and challenges with refreshable alternative suggestions
- Personalize alternative motivation and challenge options so each suggestion references the persona by name
- Generate distinctive learner names by filtering out previously used names before calling the AI

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68978c2bc2d0832bb669be2d2ca082c7