### PR TITLE
Add progress indicators and scroll cues to initiative flow

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -63,6 +63,7 @@
     max-height: 750px;
     overflow-y: auto;
     text-align: left;
+    position: relative;
   }
   
   .generator-result h3 {
@@ -152,4 +153,29 @@
 .persona-options p {
   width: 100%;
   margin: 0;
+}
+
+.progress-indicator {
+  font-weight: bold;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.scroll-hint {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.next-step-fixed {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- show step progress at top of project brief and learning strategy cards
- hint when next-step button is below fold and offer fixed next-step button once questions answered

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897e0c84b9c832b9b34c05e45db1d12