### PR TITLE
Refactor initiative flow into guided four-step process

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -63,6 +63,7 @@
     max-height: 750px;
     overflow-y: auto;
     text-align: left;
+    position: relative;
   }
   
   .generator-result h3 {
@@ -153,3 +154,10 @@
   width: 100%;
   margin: 0;
 }
+
+.progress-indicator {
+  font-weight: bold;
+  margin-bottom: 10px;
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- simplify interface into four discrete steps with labeled fields, optional clarifications, and read-only brief
- support editing/downloading brief and navigating to learner personas in final step
- remove previous scroll hint and fixed next-step button styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897e0c84b9c832b9b34c05e45db1d12