### PR TITLE
feat: enrich persona demographics

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -527,25 +527,51 @@ export const generateLearnerPersona = onCall(
     const randomSeed = Math.random().toString(36).substring(2, 8);
     const finalName = personaName || generateUniqueName(existingNames);
 
-    // Refresh motivations or challenges only
-    if (refreshField === "motivation" || refreshField === "challenges") {
-      const personaContext = finalName
-        ? `The persona's name is ${finalName}. Write each option's "text" as a third-person sentence about ${finalName}.`
-        : "Write each option's \"text\" as a third-person sentence about the learner persona.";
-      const listPrompt = `You are a Senior Instructional Designer. ${personaContext} Based on the project information below, list three fresh learner ${
-        refreshField
-      } options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) that captures the theme — do not use generic terms like "general" or "other" — and a "text" field written in full sentences. Avoid the following ${
-        refreshField
-      } keywords: ${
-        refreshField === "motivation"
-          ? existingMotivationKeywords.join(", ") || "none"
-          : existingChallengeKeywords.join(", ") || "none"
-      }.
+    // Refresh field options only
+    const refreshableFields = [
+      "motivation",
+      "challenges",
+      "ageRange",
+      "educationLevel",
+      "techProficiency",
+      "learningPreferences",
+    ];
+    if (refreshField && refreshableFields.includes(refreshField)) {
+      let listPrompt;
+      if (refreshField === "motivation" || refreshField === "challenges") {
+        const personaContext = finalName
+          ? `The persona's name is ${finalName}. Write each option's "text" as a third-person sentence about ${finalName}.`
+          : "Write each option's \"text\" as a third-person sentence about the learner persona.";
+        listPrompt = `You are a Senior Instructional Designer. ${personaContext} Based on the project information below, list three fresh learner ${
+          refreshField
+        } options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) that captures the theme — do not use generic terms like "general" or "other" — and a "text" field written in full sentences. Avoid the following ${
+          refreshField
+        } keywords: ${
+          refreshField === "motivation"
+            ? existingMotivationKeywords.join(", ") || "none"
+            : existingChallengeKeywords.join(", ") || "none"
+        }.
 
 Project Brief: ${projectBrief}
 Business Goal: ${businessGoal}
 Audience Profile: ${audienceProfile}
 Project Constraints: ${projectConstraints}`;
+      } else {
+        const fieldDescriptions = {
+          ageRange: "age range (e.g., '25-34')",
+          educationLevel: "education level (e.g., 'Bachelor's degree')",
+          techProficiency: "tech proficiency level (e.g., 'Intermediate')",
+          learningPreferences: "learning preference in a short phrase",
+        };
+        listPrompt = `You are a Senior Instructional Designer. Based on the project information below, list three fresh learner ${
+          fieldDescriptions[refreshField]
+        } options in JSON with an array called "options". Each option must be a concise phrase.
+
+Project Brief: ${projectBrief}
+Business Goal: ${businessGoal}
+Audience Profile: ${audienceProfile}
+Project Constraints: ${projectConstraints}`;
+      }
 
       const { text } = await ai.generate(listPrompt);
 
@@ -560,16 +586,34 @@ Project Constraints: ${projectConstraints}`;
       if (refreshField === "motivation") {
         return { motivationOptions: data.options || [] };
       }
-      return { challengeOptions: data.options || [] };
+      if (refreshField === "challenges") {
+        return { challengeOptions: data.options || [] };
+      }
+      const key = `${refreshField}Options`;
+      return { [key]: data.options || [] };
     }
 
-    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona named ${finalName}. For both the primary motivation and the primary challenge:
-- Provide a short, specific keyword (1-3 words) that summarizes the item. Avoid generic labels such as "general" or "other".
-- Provide a full-sentence description in a "text" field written about ${finalName} in third person using their name.
-Also supply exactly two alternative options for motivations and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" is also a full-sentence description about ${finalName}. Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
+    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona named ${finalName}. Provide:
+- "ageRange": the typical age range as a string (e.g., "25-34") and "ageRangeOptions" with exactly two alternatives.
+- "educationLevel": a concise education description and "educationLevelOptions" with two alternatives.
+- "techProficiency": the learner's technology skill level and "techProficiencyOptions" with two alternatives.
+- "learningPreferences": one full-sentence about ${finalName}'s preferred learning style and "learningPreferencesOptions" with two alternative full-sentence options about ${finalName}.
+- For both the primary motivation and the primary challenge:
+  - Provide a short, specific keyword (1-3 words) that summarizes the item. Avoid generic labels such as "general" or "other".
+  - Provide a full-sentence description in a "text" field written about ${finalName} in third person using their name.
+  - Also supply exactly two alternative options for motivations and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" is also a full-sentence description about ${finalName}.
+Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
 
 {
   "name": "Name",
+  "ageRange": "25-34",
+  "ageRangeOptions": ["18-24", "35-44"],
+  "educationLevel": "Bachelor's degree",
+  "educationLevelOptions": ["High school diploma", "Master's degree"],
+  "techProficiency": "Intermediate",
+  "techProficiencyOptions": ["Beginner", "Advanced"],
+  "learningPreferences": "Full sentence about Name",
+  "learningPreferencesOptions": ["Full sentence about Name", "Full sentence about Name"],
   "motivation": {"keyword": "short", "text": "full"},
   "motivationOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}],
   "challenges": {"keyword": "short", "text": "full"},
@@ -738,11 +782,20 @@ export const generateAvatar = onCall(
     // NOTE: no "secrets" needed anymore
   },
   async (request) => {
-    const { name, motivation = "", challenges = "" } = request.data || {};
+    const {
+      name,
+      motivation = "",
+      challenges = "",
+      ageRange = "",
+      techProficiency = "",
+      educationLevel = "",
+      learningPreferences = "",
+      seedExtra = "",
+    } = request.data || {};
     if (!name) throw new HttpsError("invalid-argument", "name is required");
 
     // deterministic seed + cache key
-    const seed = `${name}|${motivation}|${challenges}`;
+    const seed = `${name}|${motivation}|${challenges}|${ageRange}|${techProficiency}|${educationLevel}|${learningPreferences}|${seedExtra}`;
     const hash = crypto.createHash("md5").update(seed).digest("hex");
 
     const bucket = admin.storage().bucket(BUCKET_NAME);
@@ -757,10 +810,18 @@ export const generateAvatar = onCall(
     }
 
     // 2) Generate new SVG with DiceBear (notionists)
+    const ageColors = {
+      "18-24": "#E9F0FF",
+      "25-34": "#F9EAFF",
+      "35-44": "#FFF3D6",
+      "45-54": "#E8FFF3",
+      "55+": "#FDEEEF",
+    };
+    const backgroundColor = ageColors[ageRange] ? [ageColors[ageRange]] : ["#E9F0FF", "#F9EAFF", "#FFF3D6", "#E8FFF3", "#FDEEEF"];
     const svg = createAvatar(notionists, {
       seed,
       radius: 50, // rounded avatar
-      backgroundColor: ["#E9F0FF", "#F9EAFF", "#FFF3D6", "#E8FFF3", "#FDEEEF"],
+      backgroundColor,
       // backgroundType: "gradientLinear", // uncomment for gradient backgrounds
     }).toString();
 

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -18,6 +18,14 @@ const formatKeyword = (kw = "") =>
 
 const normalizePersona = (p = {}) => ({
   ...p,
+  ageRange: p.ageRange || "",
+  ageRangeOptions: p.ageRangeOptions || [],
+  educationLevel: p.educationLevel || "",
+  educationLevelOptions: p.educationLevelOptions || [],
+  techProficiency: p.techProficiency || "",
+  techProficiencyOptions: p.techProficiencyOptions || [],
+  learningPreferences: p.learningPreferences || "",
+  learningPreferencesOptions: p.learningPreferencesOptions || [],
   motivation:
     typeof p.motivation === "string"
       ? { keyword: "General", text: p.motivation }
@@ -341,6 +349,10 @@ const InitiativesNew = () => {
         name: personaData.name,
         motivation: personaData.motivation?.text || "",
         challenges: personaData.challenges?.text || "",
+        ageRange: personaData.ageRange || "",
+        techProficiency: personaData.techProficiency || "",
+        educationLevel: personaData.educationLevel || "",
+        learningPreferences: personaData.learningPreferences || "",
       });
 
       const personaToSave = {
@@ -394,22 +406,16 @@ const InitiativesNew = () => {
     setEditingPersona((prev) => ({ ...prev, [field]: value }));
   };
 
-  const selectMotivationOption = (opt) => {
-    setEditingPersona((prev) => ({ ...prev, motivation: opt }));
-  };
-  const selectChallengeOption = (opt) => {
-    setEditingPersona((prev) => ({ ...prev, challenges: opt }));
+  const selectOption = (field, opt) => {
+    setEditingPersona((prev) => ({ ...prev, [field]: opt }));
   };
 
   const refreshOptions = async (field) => {
     if (!editingPersona) return;
     setPersonaLoading(true);
     setPersonaError("");
-    if (field === "motivation") {
-      setEditingPersona((prev) => ({ ...prev, motivationOptions: [] }));
-    } else {
-      setEditingPersona((prev) => ({ ...prev, challengeOptions: [] }));
-    }
+    const optionField = `${field}Options`;
+    setEditingPersona((prev) => ({ ...prev, [optionField]: [] }));
     try {
       const { data } = await generateLearnerPersona({
         projectBrief,
@@ -421,28 +427,19 @@ const InitiativesNew = () => {
         refreshField: field,
         personaName: editingPersona.name,
       });
-      if (field === "motivation") {
-        const opts = (data.motivationOptions || []).map((o) => ({
-          ...o,
-          keyword: formatKeyword(o.keyword),
-        }));
-        if (opts.length === 0) {
-          setPersonaError("No new options available.");
-        } else {
+      let opts = data[optionField] || [];
+      if (field === "motivation" || field === "challenges") {
+        opts = opts.map((o) => ({ ...o, keyword: formatKeyword(o.keyword) }));
+        if (field === "motivation") {
           addUsedMotivation(opts.map((o) => o.keyword));
-          setEditingPersona((prev) => ({ ...prev, motivationOptions: opts }));
-        }
-      } else {
-        const opts = (data.challengeOptions || []).map((o) => ({
-          ...o,
-          keyword: formatKeyword(o.keyword),
-        }));
-        if (opts.length === 0) {
-          setPersonaError("No new options available.");
         } else {
           addUsedChallenge(opts.map((o) => o.keyword));
-          setEditingPersona((prev) => ({ ...prev, challengeOptions: opts }));
         }
+      }
+      if (opts.length === 0) {
+        setPersonaError("No new options available.");
+      } else {
+        setEditingPersona((prev) => ({ ...prev, [optionField]: opts }));
       }
     } catch (err) {
       console.error("Error generating options:", err);
@@ -478,6 +475,11 @@ const InitiativesNew = () => {
         name: editingPersona.name,
         motivation: editingPersona.motivation?.text || "",
         challenges: editingPersona.challenges?.text || "",
+        ageRange: editingPersona.ageRange || "",
+        techProficiency: editingPersona.techProficiency || "",
+        educationLevel: editingPersona.educationLevel || "",
+        learningPreferences: editingPersona.learningPreferences || "",
+        seedExtra: Date.now().toString(),
       });
       setEditingPersona((prev) => ({
         ...prev,
@@ -716,6 +718,13 @@ const InitiativesNew = () => {
 
                 {editingPersona ? (
                   <>
+                    {editingPersona.avatar && (
+                      <img
+                        src={editingPersona.avatar}
+                        alt={`${editingPersona.name} avatar`}
+                        className="persona-avatar"
+                      />
+                    )}
                     <input
                       className="generator-input"
                       value={editingPersona.name || ""}
@@ -723,6 +732,148 @@ const InitiativesNew = () => {
                         handlePersonaFieldChange("name", e.target.value)
                       }
                     />
+                    <input
+                      className="generator-input"
+                      placeholder="Age Range"
+                      value={editingPersona.ageRange || ""}
+                      onChange={(e) =>
+                        handlePersonaFieldChange("ageRange", e.target.value)
+                      }
+                    />
+                    <div className="persona-options">
+                      {editingPersona.ageRangeOptions?.length > 0 && (
+                        <>
+                          <p>Other possible age ranges...</p>
+                          {editingPersona.ageRangeOptions.map((opt) => (
+                            <button
+                              key={opt}
+                              type="button"
+                              onClick={() => selectOption("ageRange", opt)}
+                              className="generator-button"
+                            >
+                              {opt}
+                            </button>
+                          ))}
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => refreshOptions("ageRange")}
+                        className="generator-button"
+                      >
+                        Generate more
+                      </button>
+                    </div>
+                    <input
+                      className="generator-input"
+                      placeholder="Education Level"
+                      value={editingPersona.educationLevel || ""}
+                      onChange={(e) =>
+                        handlePersonaFieldChange(
+                          "educationLevel",
+                          e.target.value
+                        )
+                      }
+                    />
+                    <div className="persona-options">
+                      {editingPersona.educationLevelOptions?.length > 0 && (
+                        <>
+                          <p>Other possible education levels...</p>
+                          {editingPersona.educationLevelOptions.map((opt) => (
+                            <button
+                              key={opt}
+                              type="button"
+                              onClick={() => selectOption("educationLevel", opt)}
+                              className="generator-button"
+                            >
+                              {opt}
+                            </button>
+                          ))}
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => refreshOptions("educationLevel")}
+                        className="generator-button"
+                      >
+                        Generate more
+                      </button>
+                    </div>
+                    <input
+                      className="generator-input"
+                      placeholder="Tech Proficiency"
+                      value={editingPersona.techProficiency || ""}
+                      onChange={(e) =>
+                        handlePersonaFieldChange(
+                          "techProficiency",
+                          e.target.value
+                        )
+                      }
+                    />
+                    <div className="persona-options">
+                      {editingPersona.techProficiencyOptions?.length > 0 && (
+                        <>
+                          <p>Other possible tech proficiency levels...</p>
+                          {editingPersona.techProficiencyOptions.map((opt) => (
+                            <button
+                              key={opt}
+                              type="button"
+                              onClick={() => selectOption("techProficiency", opt)}
+                              className="generator-button"
+                            >
+                              {opt}
+                            </button>
+                          ))}
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => refreshOptions("techProficiency")}
+                        className="generator-button"
+                      >
+                        Generate more
+                      </button>
+                    </div>
+                    <textarea
+                      className="generator-input"
+                      placeholder="Learning Preferences"
+                      value={editingPersona.learningPreferences || ""}
+                      onChange={(e) =>
+                        handlePersonaFieldChange(
+                          "learningPreferences",
+                          e.target.value
+                        )
+                      }
+                      rows={2}
+                    />
+                    <div className="persona-options">
+                      {editingPersona.learningPreferencesOptions?.length > 0 && (
+                        <>
+                          <p>Other possible learning preferences...</p>
+                          {editingPersona.learningPreferencesOptions.map(
+                            (opt) => (
+                              <button
+                                key={opt}
+                                type="button"
+                                onClick={() =>
+                                  selectOption("learningPreferences", opt)
+                                }
+                                className="generator-button"
+                              >
+                                {opt}
+                              </button>
+                            )
+                          )}
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => refreshOptions("learningPreferences")}
+                        className="generator-button"
+                      >
+                        Generate more
+                      </button>
+                    </div>
                     <textarea
                       className="generator-input"
                       value={editingPersona.motivation?.text || ""}
@@ -742,7 +893,7 @@ const InitiativesNew = () => {
                             <button
                               key={opt.keyword}
                               type="button"
-                              onClick={() => selectMotivationOption(opt)}
+                              onClick={() => selectOption("motivation", opt)}
                               className="generator-button"
                             >
                               {opt.keyword}
@@ -777,7 +928,7 @@ const InitiativesNew = () => {
                             <button
                               key={opt.keyword}
                               type="button"
-                              onClick={() => selectChallengeOption(opt)}
+                              onClick={() => selectOption("challenges", opt)}
                               className="generator-button"
                             >
                               {opt.keyword}
@@ -837,6 +988,18 @@ const InitiativesNew = () => {
                       />
                     )}
                     <h5>{currentPersona.name}</h5>
+                    <p>
+                      <strong>Age Range:</strong> {currentPersona.ageRange}
+                    </p>
+                    <p>
+                      <strong>Education Level:</strong> {currentPersona.educationLevel}
+                    </p>
+                    <p>
+                      <strong>Tech Proficiency:</strong> {currentPersona.techProficiency}
+                    </p>
+                    <p>
+                      <strong>Learning Preferences:</strong> {currentPersona.learningPreferences}
+                    </p>
                     <p>
                       <strong>Motivation - {currentPersona.motivation?.keyword}:</strong> {currentPersona.motivation?.text}
                     </p>

--- a/src/utils/personas.js
+++ b/src/utils/personas.js
@@ -6,7 +6,18 @@ import { httpsCallable } from "firebase/functions";
 export async function loadPersonas(uid, initiativeId) {
   const personasRef = collection(db, "users", uid, "initiatives", initiativeId, "personas");
   const snapshot = await getDocs(personasRef);
-  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+  return snapshot.docs.map((d) => ({
+    id: d.id,
+    ageRange: "",
+    educationLevel: "",
+    techProficiency: "",
+    learningPreferences: "",
+    ageRangeOptions: [],
+    educationLevelOptions: [],
+    techProficiencyOptions: [],
+    learningPreferencesOptions: [],
+    ...d.data(),
+  }));
 }
 
 // Save a persona via callable function for server-side validation
@@ -14,7 +25,17 @@ export async function savePersona(uid, initiativeId, persona) {
   const personasRef = collection(db, "users", uid, "initiatives", initiativeId, "personas");
   const personaId = persona.id || doc(personasRef).id;
   const callable = httpsCallable(functions, "savePersona");
-  await callable({ initiativeId, personaId, persona });
+  const defaults = {
+    ageRange: "",
+    educationLevel: "",
+    techProficiency: "",
+    learningPreferences: "",
+    ageRangeOptions: [],
+    educationLevelOptions: [],
+    techProficiencyOptions: [],
+    learningPreferencesOptions: [],
+  };
+  await callable({ initiativeId, personaId, persona: { ...defaults, ...persona } });
   return personaId;
 }
 


### PR DESCRIPTION
## Summary
- extend persona schema with age range, education level, tech proficiency and learning preferences
- allow editing UI to refresh/generate alternate values and show them
- use demographic hints when generating avatars and persona data
- regenerate avatars with a nonce to bypass cache and preview updated image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68980ef88104832ba48c2514c6b275e4