### PR TITLE
Avoid saving undefined learning objective category

### DIFF
--- a/src/components/LearningObjectivesGenerator.jsx
+++ b/src/components/LearningObjectivesGenerator.jsx
@@ -64,7 +64,7 @@ const LearningObjectivesGenerator = ({
       const result = {
         approach: data.approach,
         bloomLevel: data.bloomLevel,
-        category: data.category,
+        ...(data.category ? { category: data.category } : {}),
         terminalObjective: transform(data.terminalObjective),
         enablingObjectives: (data.enablingObjectives || []).map(transform),
       };
@@ -107,7 +107,7 @@ const LearningObjectivesGenerator = ({
         selectedModality,
         approach: learningObjectives.approach,
         bloomLevel: learningObjectives.bloomLevel,
-        category: learningObjectives.category,
+        ...(learningObjectives.category ? { category: learningObjectives.category } : {}),
         refresh: { type, index, existing: getAllTexts() },
       });
       const obj = transform(data.options || []);


### PR DESCRIPTION
## Summary
- prevent undefined `category` from being saved in learning objectives by conditionally including the field
- apply same conditional when rerolling objectives

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e64a7ee0832bac5be85c7c178cbb