### PR TITLE
Auto-generate learning path and bundle Mermaid

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
+    "@mermaid-js/mermaid": "^10.9.1",
     "firebase": "^11.2.0",
     "genkit": "^1.0.4",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- Auto-generate learning paths on mount when none exists and remove manual trigger.
- Bundle Mermaid and render diagrams after learning path updates for consistent visualization.
- Show raw diagram code only when render errors occur.
- Parse learning path data before rendering to gracefully handle Mermaid syntax errors.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899045fb5fc832bbc57e60f1c5c3825