### PR TITLE
Generate Learning Design Document instead of learning path

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -837,7 +837,7 @@ export const generateHierarchicalOutline = onCall(
   }
 );
 
-export const generateLearningPath = onCall(
+export const generateLearningDesignDocument = onCall(
   { region: "us-central1", secrets: ["GOOGLE_GENAI_API_KEY"] },
   async (req) => {
     const {
@@ -880,20 +880,20 @@ export const generateLearningPath = onCall(
 
       const baseInfo = `Project Brief: ${projectBrief}\nBusiness Goal: ${businessGoal}\nAudience Profile: ${audienceProfile}\nProject Constraints: ${projectConstraints}\nSelected Learning Approach: ${selectedModality}\nCourse Outline:\n${courseOutline}\nLearning Objectives:\n${lines.join("\n")}`;
 
-      const prompt = `You are a Senior Instructional Designer. Using the information below, create a learning path that maps the flow of modules, showing sequencing, branching, and dependencies. Return the diagram in Mermaid flowchart syntax.\n\n${baseInfo}`;
+      const prompt = `You are a Senior Instructional Designer. Using the information below, create a comprehensive Learning Design Document that serves as the single source of truth for the project. Include the following sections: 1. Front Matter & Executive Summary (Project Title, Version Control table, Project Overview, Key Stakeholders) 2. Audience Analysis (Learner Demographics, Prior Knowledge & Skills, Learner Motivation, Technical Environment, Learner Personas) 3. Business Goals & Learning Objectives (Business Goal, Terminal Learning Objective, Enabling Learning Objectives) 4. Instructional Strategy (Delivery Modality, Instructional Approach, Tone & Style, Interaction Strategy) 5. Curriculum Blueprint (Hierarchical Outline, Objective Mapping, Content Summary, Estimated Seat Time) 6. Assessment & Evaluation Strategy (Formative Assessment, Summative Assessment, Evaluation Plan for Kirkpatrick Levels 1-4, xAPI Strategy if applicable). Present the document in clear markdown with headings and subheadings.\n\n${baseInfo}`;
 
-      const flow = ai.defineFlow("learningPathFlow", async () => {
+      const flow = ai.defineFlow("learningDesignDocumentFlow", async () => {
         const { text } = await ai.generate(prompt);
         return text;
       });
 
-      const diagram = await flow();
-      return { diagram };
+      const document = await flow();
+      return { document };
     } catch (error) {
-      console.error("Error generating learning path:", error);
+      console.error("Error generating learning design document:", error);
       throw new HttpsError(
         "internal",
-        "Failed to generate learning path."
+        "Failed to generate learning design document."
       );
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "@testing-library/user-event": "^14.6.1",
     "firebase": "^11.2.0",
     "genkit": "^1.0.4",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.1.5",
-    "tailwindcss": "^4.0.3",
-    "prop-types": "^15.8.1"
+    "tailwindcss": "^4.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/HierarchicalOutlineGenerator.jsx
+++ b/src/components/HierarchicalOutlineGenerator.jsx
@@ -101,7 +101,7 @@ const HierarchicalOutlineGenerator = ({
               className="generator-button"
               style={{ marginTop: 10 }}
             >
-              Visualize Learning Path
+              Generate Learning Design Document
             </button>
           )}
         </>

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -13,7 +13,7 @@ import {
 import { useSearchParams } from "react-router-dom";
 import LearningObjectivesGenerator from "./LearningObjectivesGenerator.jsx";
 import HierarchicalOutlineGenerator from "./HierarchicalOutlineGenerator.jsx";
-import LearningPathVisualizer from "./LearningPathVisualizer.jsx";
+import LearningDesignDocument from "./LearningDesignDocument.jsx";
 import { useProject } from "../context/ProjectContext.jsx";
 import "./AIToolsGenerators.css";
 
@@ -86,7 +86,7 @@ const InitiativesNew = () => {
   const [usedMotivationKeywords, setUsedMotivationKeywords] = useState([]);
   const [usedChallengeKeywords, setUsedChallengeKeywords] = useState([]);
 
-  const { learningObjectives, courseOutline, setLearningPath } = useProject();
+  const { learningObjectives, courseOutline, setLearningDesignDocument } = useProject();
 
   const projectBriefRef = useRef(null);
   const nextButtonRef = useRef(null);
@@ -122,7 +122,7 @@ const InitiativesNew = () => {
           setClarifyingAnswers(data.clarifyingAnswers || []);
           setStrategy(data.strategy || null);
           setSelectedModality(data.selectedModality || "");
-          setLearningPath(data.learningPath || "");
+          setLearningDesignDocument(data.learningDesignDocument || "");
         }
       })
       .catch((err) => console.error("Error loading initiative:", err));
@@ -147,7 +147,7 @@ const InitiativesNew = () => {
         });
       })
       .catch((err) => console.error("Error loading personas:", err));
-  }, [initiativeId, setLearningPath]);
+  }, [initiativeId, setLearningDesignDocument]);
 
   useEffect(() => {
     if (!projectBriefRef.current || !nextButtonRef.current) return;
@@ -1252,7 +1252,7 @@ const InitiativesNew = () => {
       )}
 
       {step === 8 && (
-        <LearningPathVisualizer
+        <LearningDesignDocument
           projectBrief={projectBrief}
           businessGoal={businessGoal}
           audienceProfile={audienceProfile}

--- a/src/context/ProjectContext.jsx
+++ b/src/context/ProjectContext.jsx
@@ -11,7 +11,7 @@ export const ProjectProvider = ({ children }) => {
   const [storyboard, setStoryboard] = useState("");
   const [assessment, setAssessment] = useState("");
   const [learningObjectives, setLearningObjectives] = useState(null);
-  const [learningPath, setLearningPath] = useState("");
+  const [learningDesignDocument, setLearningDesignDocument] = useState("");
 
   const value = {
     courseOutline,
@@ -28,8 +28,8 @@ export const ProjectProvider = ({ children }) => {
     setAssessment,
     learningObjectives,
     setLearningObjectives,
-    learningPath,
-    setLearningPath,
+    learningDesignDocument,
+    setLearningDesignDocument,
   };
 
   return (


### PR DESCRIPTION
## Summary
- Remove learning path visualizer and Mermaid dependency.
- Add Learning Design Document generator with Firebase function and React component.
- Save design document in project context for final step.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899045fb5fc832bbc57e60f1c5c3825