### PR TITLE
feat: add content asset phase

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import StudyMaterialGenerator from "./components/StudyMaterialGenerator";
 import AssessmentGenerator from "./components/AssessmentGenerator";
 import LessonContentGenerator from "./components/LessonContentGenerator";
 import StoryboardGenerator from "./components/StoryboardGenerator";
+import ContentAssetGenerator from "./components/ContentAssetGenerator";
 import InitiativesNew from "./components/InitiativesNew";
 import InitiativesList from "./components/InitiativesList";
 import LeadershipAssessmentWizard from "./components/LeadershipAssessmentWizard";
@@ -95,6 +96,7 @@ export default function App() {
           <Route path="assessment" element={<AssessmentGenerator />} />
           <Route path="lesson-content" element={<LessonContentGenerator />} />
           <Route path="storyboard" element={<StoryboardGenerator />} />
+          <Route path="content-assets" element={<ContentAssetGenerator />} />
         </Route>
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>

--- a/src/components/AIToolsLayout.jsx
+++ b/src/components/AIToolsLayout.jsx
@@ -30,6 +30,9 @@ const AIToolsLayout = () => {
             <li>
               <Link to="storyboard">Storyboard Generator</Link>
             </li>
+            <li>
+              <Link to="content-assets">Content & Asset Generator</Link>
+            </li>
           </ul>
         </nav>
       </aside>

--- a/src/components/ContentAssetGenerator.jsx
+++ b/src/components/ContentAssetGenerator.jsx
@@ -4,6 +4,8 @@ import { app } from "../firebase.js";
 import { useProject } from "../context/ProjectContext.jsx";
 import "./AIToolsGenerators.css";
 
+const TOTAL_STEPS = 9;
+
 const ContentAssetGenerator = () => {
   const {
     learningDesignDocument,
@@ -57,6 +59,7 @@ const ContentAssetGenerator = () => {
 
   return (
     <div className="generator-container">
+      <div className="progress-indicator">Step 9 of {TOTAL_STEPS}</div>
       <h2>Content & Asset Generator</h2>
       <button
         onClick={handleGenerate}

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -55,7 +55,7 @@ const normalizePersona = (p = {}) => ({
 });
 
 const InitiativesNew = () => {
-  const TOTAL_STEPS = 8;
+  const TOTAL_STEPS = 9;
   const [step, setStep] = useState(1);
   const [businessGoal, setBusinessGoal] = useState("");
   const [audienceProfile, setAudienceProfile] = useState("");

--- a/src/components/LearningDesignDocument.jsx
+++ b/src/components/LearningDesignDocument.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { getFunctions, httpsCallable } from "firebase/functions";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { app, auth } from "../firebase.js";
 import { saveInitiative } from "../utils/initiatives.js";
 import { useProject } from "../context/ProjectContext.jsx";
@@ -19,6 +19,7 @@ const LearningDesignDocument = ({
   onBack,
 }) => {
   const { learningDesignDocument, setLearningDesignDocument } = useProject();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const functions = getFunctions(app, "us-central1");
@@ -74,6 +75,16 @@ const LearningDesignDocument = ({
         style={{ marginBottom: 10 }}
       >
         Back to Step 7
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          navigate(`/ai-tools/content-assets?initiativeId=${initiativeId}`)
+        }
+        className="generator-button"
+        style={{ marginBottom: 10, marginLeft: 10 }}
+      >
+        Next: Content & Assets
       </button>
       <h3>Learning Design Document</h3>
       {!learningDesignDocument && !error && (


### PR DESCRIPTION
## Summary
- add sidebar entry and route for Content & Asset Generator
- link Learning Design Document to new Content & Assets step
- expand initiative wizard to 9 steps with new progress indicators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68994b17e51c832b89fc64c8f79b397d