### PR TITLE
feat: persist generated content assets

### DIFF
--- a/src/utils/initiatives.js
+++ b/src/utils/initiatives.js
@@ -27,6 +27,21 @@ export async function saveInitiative(uid, initiativeId, data) {
   return initiativeId;
 }
 
+export async function saveContentAssets(
+  uid,
+  initiativeId,
+  draftContent = {},
+  mediaAssets = []
+) {
+  const ref = doc(db, "users", uid, "initiatives", initiativeId);
+  await setDoc(
+    ref,
+    { draftContent, mediaAssets, updatedAt: serverTimestamp() },
+    { merge: true }
+  );
+  return initiativeId;
+}
+
 export async function deleteInitiative(uid, initiativeId) {
   const ref = doc(db, "users", uid, "initiatives", initiativeId);
   await deleteDoc(ref);


### PR DESCRIPTION
## Summary
- add `saveContentAssets` utility to store generated drafts and media in an initiative
- persist generated content and media assets from `ContentAssetGenerator`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68994c55ede4832bb57ce52e71d7fd97