### PR TITLE
feat: export generated content assets

### DIFF
--- a/src/components/ContentAssetGenerator.jsx
+++ b/src/components/ContentAssetGenerator.jsx
@@ -24,31 +24,101 @@ const ContentAssetGenerator = () => {
   const functions = getFunctions(app, "us-central1");
   const callGenerate = httpsCallable(functions, "generateContentAssets");
 
+  const MAX_RETRIES = 1;
+
+  const isTimeoutError = (err) => {
+    const message = err?.message || "";
+    return err?.code === "deadline-exceeded" || /504|timeout/i.test(message);
+  };
+
   const handleGenerate = async () => {
     if (!learningDesignDocument) return;
     setLoading(true);
     setError("");
     setDraftContent({});
     setMediaAssets([]);
-    try {
-      const { data } = await callGenerate(learningDesignDocument);
-      setDraftContent(data.drafts || {});
-      setMediaAssets(data.mediaAssets || []);
-      const uid = auth.currentUser?.uid;
-      if (uid) {
-        await saveContentAssets(
-          uid,
-          initiativeId,
-          data.drafts || {},
-          data.mediaAssets || []
+
+    let attempt = 0;
+    while (attempt <= MAX_RETRIES) {
+      try {
+        const { data } = await callGenerate(learningDesignDocument);
+        setDraftContent(data.drafts || {});
+        setMediaAssets(data.mediaAssets || []);
+        const uid = auth.currentUser?.uid;
+        if (uid) {
+          await saveContentAssets(
+            uid,
+            initiativeId,
+            data.drafts || {},
+            data.mediaAssets || []
+          );
+        }
+        break;
+      } catch (err) {
+        console.error("Error generating content assets:", err);
+        if (isTimeoutError(err) && attempt < MAX_RETRIES) {
+          attempt += 1;
+          continue;
+        }
+        setError(
+          isTimeoutError(err)
+            ? "The generation request timed out. Please try again."
+            : err?.message || "Error generating content assets."
         );
+        break;
       }
-    } catch (err) {
-      console.error("Error generating content assets:", err);
-      setError(err?.message || "Error generating content assets.");
-    } finally {
-      setLoading(false);
     }
+
+    setLoading(false);
+  };
+
+  const handleExport = (format = "json") => {
+    const data = {
+      ...draftContent,
+      mediaAssets: mediaAssets || [],
+    };
+
+    let content = "";
+    let type = "application/json";
+    let extension = "json";
+
+    if (format === "md") {
+      const mdLines = ["# Draft Content"];
+      Object.entries(draftContent || {}).forEach(([key, items]) => {
+        mdLines.push(`\n## ${formatType(key)}`);
+        (items || []).forEach((item) => {
+          if (typeof item === "string") {
+            mdLines.push(`- ${item}`);
+          } else {
+            mdLines.push("- ```json\n" + JSON.stringify(item, null, 2) + "\n```");
+          }
+        });
+      });
+
+      mdLines.push("\n# Media Assets");
+      (mediaAssets || []).forEach((asset) => {
+        const usage = asset.usageNotes || asset.usage || "";
+        mdLines.push(
+          `- **${asset.type || ""}**: ${asset.description || ""} ${usage}`.trim(),
+        );
+      });
+
+      content = mdLines.join("\n");
+      type = "text/markdown";
+      extension = "md";
+    } else {
+      content = JSON.stringify(data, null, 2);
+    }
+
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `content-assets.${extension}`;
+    document.body.appendChild(a);
+    a.click();
+    URL.revokeObjectURL(url);
+    a.remove();
   };
 
   const draftTypes = Object.keys(draftContent || {});
@@ -83,6 +153,24 @@ const ContentAssetGenerator = () => {
       </button>
       {error && <p className="generator-error">{error}</p>}
       {loading && <div className="spinner"></div>}
+
+      {(draftTypes.length > 0 || mediaAssets.length > 0) && (
+        <div style={{ marginTop: "10px" }}>
+          <button
+            onClick={() => handleExport("json")}
+            className="generator-button"
+            style={{ marginRight: "10px" }}
+          >
+            Export JSON
+          </button>
+          <button
+            onClick={() => handleExport("md")}
+            className="generator-button"
+          >
+            Export Markdown
+          </button>
+        </div>
+      )}
 
       {draftTypes.length > 0 && (
         <div className="generator-result">


### PR DESCRIPTION
## Summary
- add client-side export for generated drafts and media assets
- allow download as JSON or Markdown for offline review and re-import
- retry content generation once and surface a friendly timeout message when API responds slowly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68994dd3a8a0832b8b41902bbabbfb45