### PR TITLE
Split LDD asset generation into sequential chunks with progress UI

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -161,3 +161,37 @@
   text-align: center;
 }
 
+/* Generation progress list */
+.generation-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 20px;
+  text-align: left;
+}
+
+.generation-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  margin-bottom: 8px;
+}
+
+.generation-item.done {
+  cursor: pointer;
+}
+
+.checkmark {
+  color: #4CAF50;
+  font-size: 20px;
+}
+
+.spinner.small {
+  width: 20px;
+  height: 20px;
+  border-width: 3px;
+  margin: 0;
+}
+


### PR DESCRIPTION
## Summary
- process Learning Design Document components individually to prevent timeouts and track job progress
- add client UI that displays per-component generation status with spinner and checkmarks
- style progress list and expose completed drafts with back navigation

## Testing
- `npm run lint`
- `npm --prefix functions test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899f7d26cec832bb3b3a8b0874f44a0