### PR TITLE
feat: improve project brief readability

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -388,7 +388,7 @@ export const generateProjectBrief = onCall(
       model: gemini("gemini-1.5-pro"),
     });
 
-    const promptTemplate = `You are an expert Performance Consultant and Business Analyst. Using the information provided, create a project brief and list any questions that require clarification before moving forward.
+    const promptTemplate = `You are an expert Performance Consultant and Business Analyst. Using the information provided, create a project brief written in a clear, narrative style like a blog post, using distinct paragraphs for readability. Also list any questions that require clarification before moving forward.
 Return a valid JSON object with the structure:{
   "projectBrief": "text of the brief",
   "clarifyingQuestions": ["question1", "question2"]

--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -163,7 +163,24 @@
   }
 
   .save-button {
-    border-image: linear-gradient(45deg, #00BFFF, #00FFEA) 1;
+    border-image: linear-gradient(45deg, #006400, #00FF00) 1;
+  }
+
+  .edit-button {
+    border-image: linear-gradient(45deg, #1E90FF, #00BFFF) 1;
+  }
+
+  .project-brief-display {
+    max-width: 80%;
+    margin: 0 auto;
+    text-align: left;
+    line-height: 1.6;
+    white-space: pre-wrap;
+  }
+
+  .project-brief-textarea {
+    width: 80%;
+    max-width: 80%;
   }
 
   .button-row {

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -938,13 +938,22 @@ const InitiativesNew = () => {
       {step === 3 && (
         <div className="generator-result" ref={projectBriefRef}>
           <h3>Project Brief</h3>
-          <textarea
-            className="generator-input"
-            value={projectBrief}
-            onChange={(e) => setProjectBrief(e.target.value)}
-            readOnly={!isEditingBrief}
-            rows={10}
-          />
+          {isEditingBrief ? (
+            <textarea
+              className="generator-input project-brief-textarea"
+              value={projectBrief}
+              onChange={(e) => setProjectBrief(e.target.value)}
+              rows={10}
+            />
+          ) : (
+            <div className="project-brief-display">
+              {projectBrief
+                .split("\n")
+                .map((para, idx) => (
+                  <p key={idx}>{para}</p>
+                ))}
+            </div>
+          )}
           <div className="button-row">
             <button
               type="button"
@@ -953,28 +962,26 @@ const InitiativesNew = () => {
             >
               Back
             </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              className="generator-button save-button"
-            >
-              Save
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (isEditingBrief) {
-                  const uid = auth.currentUser?.uid;
-                  if (uid) {
-                    saveInitiative(uid, initiativeId, { projectBrief });
-                  }
-                }
-                setIsEditingBrief((prev) => !prev);
-              }}
-              className="generator-button"
-            >
-              {isEditingBrief ? "Save Brief" : "Edit Brief"}
-            </button>
+            {isEditingBrief ? (
+              <button
+                type="button"
+                onClick={async () => {
+                  await handleSave();
+                  setIsEditingBrief(false);
+                }}
+                className="generator-button save-button"
+              >
+                Save
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsEditingBrief(true)}
+                className="generator-button edit-button"
+              >
+                Edit
+              </button>
+            )}
             <button
               type="button"
               onClick={handleDownload}


### PR DESCRIPTION
## Summary
- Show project brief in a blog-style read-only view by default and enable an expanded textarea when editing
- Add distinct gradients for save (green) and edit (blue) buttons with supporting CSS
- Tweak project brief generation prompt for narrative paragraphs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4d4d45c8832b91870dcf2d9a21fc