### PR TITLE
feat: improve project brief readability and personas step

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -388,7 +388,7 @@ export const generateProjectBrief = onCall(
       model: gemini("gemini-1.5-pro"),
     });
 
-    const promptTemplate = `You are an expert Performance Consultant and Business Analyst. Using the information provided, create a project brief and list any questions that require clarification before moving forward.
+    const promptTemplate = `You are an expert Performance Consultant and Business Analyst. Using the information provided, create a project brief written in a clear, narrative style like a blog post, using distinct paragraphs for readability. Also list any questions that require clarification before moving forward.
 Return a valid JSON object with the structure:{
   "projectBrief": "text of the brief",
   "clarifyingQuestions": ["question1", "question2"]

--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -163,7 +163,24 @@
   }
 
   .save-button {
-    border-image: linear-gradient(45deg, #00BFFF, #00FFEA) 1;
+    border-image: linear-gradient(45deg, #006400, #00FF00) 1;
+  }
+
+  .edit-button {
+    border-image: linear-gradient(45deg, #1E90FF, #00BFFF) 1;
+  }
+
+  .project-brief-display {
+    max-width: 80%;
+    margin: 0 auto;
+    text-align: left;
+    line-height: 1.6;
+    white-space: pre-wrap;
+  }
+
+  .project-brief-textarea {
+    width: 80%;
+    max-width: 80%;
   }
 
   .button-row {
@@ -342,5 +359,47 @@
   height: 20px;
   border-width: 3px;
   margin: 0;
+}
+
+.persona-edit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+
+@media (max-width: 600px) {
+  .persona-edit-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.persona-edit-grid .grid-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px 0;
+}
+
+.pill {
+  padding: 6px 12px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 2px solid transparent;
+  cursor: pointer;
+}
+
+.pill.selected {
+  border-image: linear-gradient(45deg, #8C259E, #D071F9) 1;
+}
+
+.cancel-button {
+  border-image: linear-gradient(45deg, #B22222, #FF4500) 1;
 }
 


### PR DESCRIPTION
## Summary
- Show project brief in a blog-style read-only view by default and enable an expanded textarea when editing
- Add distinct gradients for save (green) and edit (blue) buttons with supporting CSS
- Tweak project brief generation prompt for narrative paragraphs
- Redesign learner personas step with a two-by-two edit grid, dropdown demographics, and pill selectors for motivations and challenges
- Move personas navigation buttons to a bottom Back/Save/Next row and add regenerate/cancel/save controls in edit mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4d4d45c8832b91870dcf2d9a21fc