### PR TITLE
Fix persona edit layout overflow and alignment

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -392,6 +392,12 @@
   text-align: center;
 }
 
+/* Ensure inputs don't overflow their grid item */
+.persona-edit-grid .grid-item .generator-input {
+  max-width: 100%;
+  margin: 10px 0;
+}
+
 @media (max-width: 600px) {
   .persona-edit-grid .grid-item {
     flex-basis: 100%;
@@ -404,6 +410,7 @@
   flex-wrap: wrap;
   gap: 8px;
   margin: 10px 0;
+  justify-content: center;
 }
 
 .pill {


### PR DESCRIPTION
## Summary
- Prevent persona name and bio fields from overflowing their containers
- Center motivation and challenge option pills in persona editor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7634d3ac832b9ba371b218b2f331