### PR TITLE
Improve persona generation diversity

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -84,6 +84,7 @@
     background: rgba(255, 255, 255, 0.1);
     color: white;
     font-size: 16px;
+    box-sizing: border-box;
   }
 
   .intake-grid {
@@ -392,6 +393,43 @@
   text-align: center;
 }
 
+/* Ensure inputs don't overflow their grid item */
+.persona-edit-grid .grid-item .generator-input {
+  max-width: 100%;
+  margin: 10px 0;
+}
+
+/* Taller cards on the top row */
+.persona-edit-grid .grid-item.top-row {
+  min-height: 260px;
+}
+
+/* Field groups for labeled selects */
+.persona-edit-grid .grid-item .field-group {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.persona-edit-grid .grid-item .field-group label {
+  margin-bottom: 4px;
+}
+
+/* Bottom row adjustments */
+.persona-edit-grid .grid-item.bottom-row {
+  gap: 4px;
+}
+
+.persona-edit-grid .grid-item.bottom-row h5 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.persona-edit-grid .grid-item.bottom-row .pill-row {
+  margin: 0 0 16px;
+}
+
 @media (max-width: 600px) {
   .persona-edit-grid .grid-item {
     flex-basis: 100%;
@@ -404,6 +442,7 @@
   flex-wrap: wrap;
   gap: 8px;
   margin: 10px 0;
+  justify-content: center;
 }
 
 .pill {

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -127,6 +127,8 @@ const InitiativesNew = () => {
   const [personaCount, setPersonaCount] = useState(0);
   const [usedMotivationKeywords, setUsedMotivationKeywords] = useState([]);
   const [usedChallengeKeywords, setUsedChallengeKeywords] = useState([]);
+  const [usedNames, setUsedNames] = useState([]);
+  const [usedLearningPrefs, setUsedLearningPrefs] = useState([]);
 
   const {
     learningObjectives,
@@ -148,6 +150,16 @@ const InitiativesNew = () => {
   const addUsedChallenge = (keywords = []) => {
     setUsedChallengeKeywords((prev) =>
       Array.from(new Set([...prev, ...keywords.filter(Boolean)]))
+    );
+  };
+  const addUsedName = (names = []) => {
+    setUsedNames((prev) =>
+      Array.from(new Set([...prev, ...names.filter(Boolean)]))
+    );
+  };
+  const addUsedLearningPref = (prefs = []) => {
+    setUsedLearningPrefs((prev) =>
+      Array.from(new Set([...prev, ...prefs.filter(Boolean)]))
     );
   };
 
@@ -224,6 +236,11 @@ const InitiativesNew = () => {
           ].filter(Boolean);
           addUsedMotivation(mKeys);
           addUsedChallenge(cKeys);
+          addUsedName([p.name]);
+          addUsedLearningPref([
+            p.learningPreferences,
+            ...(p.learningPreferencesOptions || []),
+          ]);
         });
       })
       .catch((err) => console.error("Error loading personas:", err));
@@ -540,7 +557,7 @@ const InitiativesNew = () => {
     try {
       const startIndex = personas.length;
       const newPersonas = [];
-      let existingNames = personas.map((p) => p.name);
+      let existingNames = [...usedNames, ...personas.map((p) => p.name)];
       for (let i = 0; i < toGenerate; i++) {
         const personaRes = await generateLearnerPersona({
           projectBrief,
@@ -551,6 +568,7 @@ const InitiativesNew = () => {
           existingMotivationKeywords: usedMotivationKeywords,
           existingChallengeKeywords: usedChallengeKeywords,
           existingNames,
+          existingLearningPreferences: usedLearningPrefs,
         });
         const personaData = normalizePersona(personaRes.data);
         if (!personaData?.name) {
@@ -609,6 +627,11 @@ const InitiativesNew = () => {
           ...challengesList.map((o) => o.keyword),
           ...challengeOptions.map((o) => o.keyword),
         ]);
+        addUsedName([personaData.name]);
+        addUsedLearningPref([
+          rest.learningPreferences,
+          ...(rest.learningPreferencesOptions || []),
+        ]);
         existingNames.push(personaData.name);
         const uid = auth.currentUser?.uid;
         let savedPersona = personaToSave;
@@ -638,9 +661,13 @@ const InitiativesNew = () => {
     setPersonaLoading(true);
     setPersonaError("");
     try {
-      const existingNames = personas
+      const existingNamesCurrent = personas
         .filter((_, i) => !(action === "replace" && i === activePersonaIndex))
         .map((p) => p.name);
+      const existingNames = [
+        ...usedNames,
+        ...existingNamesCurrent,
+      ];
       const personaRes = await generateLearnerPersona({
         projectBrief,
         businessGoal,
@@ -650,6 +677,7 @@ const InitiativesNew = () => {
         existingMotivationKeywords: usedMotivationKeywords,
         existingChallengeKeywords: usedChallengeKeywords,
         existingNames,
+        existingLearningPreferences: usedLearningPrefs,
       });
       const personaData = normalizePersona(personaRes.data);
       if (!personaData?.name) {
@@ -710,6 +738,11 @@ const InitiativesNew = () => {
       addUsedChallenge([
         ...challengesList.map((o) => o.keyword),
         ...challengeOptions.map((o) => o.keyword),
+      ]);
+      addUsedName([personaData.name]);
+      addUsedLearningPref([
+        rest.learningPreferences,
+        ...(rest.learningPreferencesOptions || []),
       ]);
       const uid = auth.currentUser?.uid;
       if (uid) {
@@ -1223,7 +1256,7 @@ const InitiativesNew = () => {
                 {editingPersona ? (
                   <>
                     <div className="persona-edit-grid">
-                      <div className="grid-item glass-card">
+                      <div className="grid-item glass-card top-row">
                         {editingPersona.avatar && (
                           <img
                             src={editingPersona.avatar}
@@ -1248,64 +1281,73 @@ const InitiativesNew = () => {
                               e.target.value
                             )
                           }
-                          rows={2}
+                          rows={3}
                         />
                       </div>
-                      <div className="grid-item glass-card">
-                        <select
-                          className="generator-input"
-                          value={editingPersona.ageRange}
-                          onChange={(e) =>
-                            handlePersonaFieldChange("ageRange", e.target.value)
-                          }
-                        >
-                          {[editingPersona.ageRange,
-                            ...editingPersona.ageRangeOptions].map((opt) => (
-                            <option key={opt} value={opt}>
-                              {opt}
-                            </option>
-                          ))}
-                        </select>
-                        <select
-                          className="generator-input"
-                          value={editingPersona.educationLevel}
-                          onChange={(e) =>
-                            handlePersonaFieldChange(
-                              "educationLevel",
-                              e.target.value
-                            )
-                          }
-                        >
-                          {[editingPersona.educationLevel,
-                            ...editingPersona.educationLevelOptions].map(
-                            (opt) => (
+                      <div className="grid-item glass-card top-row">
+                        <div className="field-group">
+                          <label>Age Group</label>
+                          <select
+                            className="generator-input"
+                            value={editingPersona.ageRange}
+                            onChange={(e) =>
+                              handlePersonaFieldChange("ageRange", e.target.value)
+                            }
+                          >
+                            {[editingPersona.ageRange,
+                              ...editingPersona.ageRangeOptions].map((opt) => (
                               <option key={opt} value={opt}>
                                 {opt}
                               </option>
-                            )
-                          )}
-                        </select>
-                        <select
-                          className="generator-input"
-                          value={editingPersona.techProficiency}
-                          onChange={(e) =>
-                            handlePersonaFieldChange(
-                              "techProficiency",
-                              e.target.value
-                            )
-                          }
-                        >
-                          {[editingPersona.techProficiency,
-                            ...editingPersona.techProficiencyOptions].map(
-                            (opt) => (
-                              <option key={opt} value={opt}>
-                                {opt}
-                              </option>
-                            )
-                          )}
-                        </select>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="field-group">
+                          <label>Education Level</label>
+                          <select
+                            className="generator-input"
+                            value={editingPersona.educationLevel}
+                            onChange={(e) =>
+                              handlePersonaFieldChange(
+                                "educationLevel",
+                                e.target.value
+                              )
+                            }
+                          >
+                            {[editingPersona.educationLevel,
+                              ...editingPersona.educationLevelOptions].map(
+                              (opt) => (
+                                <option key={opt} value={opt}>
+                                  {opt}
+                                </option>
+                              )
+                            )}
+                          </select>
+                        </div>
+                        <div className="field-group">
+                          <label>Tech Proficiency</label>
+                          <select
+                            className="generator-input"
+                            value={editingPersona.techProficiency}
+                            onChange={(e) =>
+                              handlePersonaFieldChange(
+                                "techProficiency",
+                                e.target.value
+                              )
+                            }
+                          >
+                            {[editingPersona.techProficiency,
+                              ...editingPersona.techProficiencyOptions].map(
+                              (opt) => (
+                                <option key={opt} value={opt}>
+                                  {opt}
+                                </option>
+                              )
+                            )}
+                          </select>
+                        </div>
                       </div>
-                      <div className="grid-item glass-card">
+                      <div className="grid-item glass-card bottom-row">
                         <h5>Motivation</h5>
                         <div className="pill-row">
                           {editingPersona.motivationChoices?.map((m, i) => (
@@ -1329,7 +1371,7 @@ const InitiativesNew = () => {
                           </button>
                         )}
                       </div>
-                      <div className="grid-item glass-card">
+                      <div className="grid-item glass-card bottom-row">
                         <h5>Challenges</h5>
                         <div className="pill-row">
                           {editingPersona.challengeChoices?.map((c, i) => (


### PR DESCRIPTION
## Summary
- Track previously used persona names and bios to avoid repetition when generating or regenerating personas
- Instruct AI to create unique names and learning preferences and skip items already shown
- Fallback to a locally generated name if the AI returns a duplicate or blank name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7634d3ac832b9ba371b218b2f331