### PR TITLE
Improve persona generation diversity and objectives layout

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -42,6 +42,26 @@ const LAST_NAMES = [
   "Martinez", "Wilson",
 ];
 
+const AGE_RANGES = ["18-24", "25-34", "35-44", "45-54", "55+"];
+const EDUCATION_LEVELS = [
+  "No College",
+  "High school diploma",
+  "Associate degree",
+  "Bachelor's degree",
+  "Master's degree",
+  "Doctorate",
+];
+const TECH_LEVELS = ["Beginner", "Intermediate", "Advanced"];
+
+function getRandomItems(arr, count) {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = crypto.randomInt(0, i + 1);
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, count);
+}
+
 function generateUniqueName(existing = []) {
   const used = new Set(existing.map((n) => n.toLowerCase()));
   for (let i = 0; i < 100; i++) {
@@ -73,24 +93,40 @@ const transporter = nodemailer.createTransport({
 });
 
 function parseJsonFromText(text) {
-  const start = text.indexOf("{");
-  if (start === -1) throw new Error("No JSON object found in text");
+  const objStart = text.indexOf("{");
+  const arrStart = text.indexOf("[");
+  if (objStart === -1 && arrStart === -1) {
+    throw new Error("No JSON content found in text");
+  }
 
-  let depth = 0, inStr = false, esc = false;
+  const start =
+    arrStart !== -1 && (arrStart < objStart || objStart === -1)
+      ? arrStart
+      : objStart;
+  const open = text[start];
+  const close = open === "[" ? "]" : "}";
+
+  let depth = 0,
+    inStr = false,
+    esc = false;
 
   for (let i = start; i < text.length; i++) {
     const ch = text[i];
 
     if (inStr) {
-      if (esc) { esc = false; }
-      else if (ch === "\\") { esc = true; }
-      else if (ch === '"') { inStr = false; }
+      if (esc) {
+        esc = false;
+      } else if (ch === "\\") {
+        esc = true;
+      } else if (ch === '"') {
+        inStr = false;
+      }
       continue;
     }
 
     if (ch === '"') inStr = true;
-    else if (ch === "{") depth++;
-    else if (ch === "}") {
+    else if (ch === open) depth++;
+    else if (ch === close) {
       depth--;
       if (depth === 0) {
         const candidate = text.slice(start, i + 1);
@@ -99,7 +135,7 @@ function parseJsonFromText(text) {
     }
   }
 
-  throw new Error("No complete JSON object found");
+  throw new Error("No complete JSON content found");
 }
 
 export const setCustomClaims = onRequest(async (req, res) => {
@@ -635,6 +671,7 @@ export const generateLearnerPersona = onCall(
       refreshField,
       personaName,
       existingNames = [],
+      existingLearningPreferences = [],
     } = req.data || {};
 
     if (!projectBrief) {
@@ -651,12 +688,16 @@ export const generateLearnerPersona = onCall(
 
     const randomSeed = Math.random().toString(36).substring(2, 8);
     const finalName = personaName || generateUniqueName(existingNames);
+    const ageRange = AGE_RANGES[crypto.randomInt(0, AGE_RANGES.length)];
+    const ageRangeOptions = getRandomItems(
+      AGE_RANGES.filter((a) => a !== ageRange),
+      2
+    );
 
     // Refresh field options only
     const refreshableFields = [
       "motivation",
       "challenges",
-      "ageRange",
       "educationLevel",
       "techProficiency",
       "learningPreferences",
@@ -683,14 +724,19 @@ Audience Profile: ${audienceProfile}
 Project Constraints: ${projectConstraints}\nSource Material: ${sourceMaterial}`;
       } else {
         const fieldDescriptions = {
-          ageRange: "age range (e.g., '25-34')",
-          educationLevel: "education level (e.g., 'Bachelor's degree')",
-          techProficiency: "tech proficiency level (e.g., 'Intermediate')",
+          educationLevel: "education level",
+          techProficiency: "tech proficiency level",
           learningPreferences: "learning preference in a short phrase",
         };
+        const optionLists = {
+          educationLevel: EDUCATION_LEVELS,
+          techProficiency: TECH_LEVELS,
+        };
+        const list = optionLists[refreshField] || [];
+        const listText = list.join(", ");
         listPrompt = `You are a Senior Instructional Designer. Based on the project information below, list three fresh learner ${
           fieldDescriptions[refreshField]
-        } options in JSON with an array called "options". Each option must be a concise phrase.
+        } options in JSON with an array called "options". Each option must be a concise phrase selected from [${listText}].
 
 Project Brief: ${projectBrief}
 Business Goal: ${businessGoal}
@@ -718,40 +764,45 @@ Project Constraints: ${projectConstraints}\nSource Material: ${sourceMaterial}`;
       return { [key]: data.options || [] };
     }
 
-    const textPrompt = `You are a Senior Instructional Designer. Using the provided information, create one learner persona named ${finalName}. Provide:
-- "ageRange": the typical age range as a string (e.g., "25-34") and "ageRangeOptions" with exactly two alternatives.
-- "educationLevel": a concise education description and "educationLevelOptions" with two alternatives.
-- "techProficiency": the learner's technology skill level and "techProficiencyOptions" with two alternatives.
-- "learningPreferences": one full-sentence about ${finalName}'s preferred learning style and "learningPreferencesOptions" with two alternative full-sentence options about ${finalName}.
-- For both the primary motivation and the primary challenge:
-  - Provide a short, specific keyword (1-3 words) that summarizes the item. Avoid generic labels such as "general" or "other".
-  - Provide a full-sentence description in a "text" field written about ${finalName} in third person using their name.
-  - Also supply exactly two alternative options for motivations and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" is also a full-sentence description about ${finalName}.
-Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
+      const nameInstruction = personaName
+        ? `The persona's name is ${personaName}.`
+        : `Create a unique first and last name for the learner persona that is not in this list: ${
+            existingNames.join(", ") || "none"
+          }.`;
+      const educationList = EDUCATION_LEVELS.join(", ");
+      const techList = TECH_LEVELS.join(", ");
+      const textPrompt = `You are a Senior Instructional Designer. ${nameInstruction} The persona is in the ${ageRange} age group. Using the provided information, create one learner persona. Provide:
+  - "educationLevel": select one option from [${educationList}] and "educationLevelOptions" with two other distinct options from this list.
+  - "techProficiency": select one option from [${techList}] and "techProficiencyOptions" with two other distinct options from this list.
+   - "learningPreferences": one full-sentence about the learner's preferred learning style and "learningPreferencesOptions" with two alternative full-sentence options about the learner.
+  - For both the primary motivation and the primary challenge:
+    - Provide a short, specific keyword (1-3 words) that summarizes the item. Avoid generic labels such as "general" or "other".
+    - Provide a full-sentence description in a "text" field written about the learner in third person using their name.
+    - Also supply exactly two alternative options for motivations and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" is also a full-sentence description about the learner.
+  Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
 
-{
-  "name": "Name",
-  "ageRange": "25-34",
-  "ageRangeOptions": ["18-24", "35-44"],
-  "educationLevel": "Bachelor's degree",
-  "educationLevelOptions": ["High school diploma", "Master's degree"],
-  "techProficiency": "Intermediate",
-  "techProficiencyOptions": ["Beginner", "Advanced"],
-  "learningPreferences": "Full sentence about Name",
-  "learningPreferencesOptions": ["Full sentence about Name", "Full sentence about Name"],
-  "motivation": {"keyword": "short", "text": "full"},
-  "motivationOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}],
-  "challenges": {"keyword": "short", "text": "full"},
-  "challengeOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}]
-}
+  {
+    "name": "Name",
+    "educationLevel": "High school diploma",
+    "educationLevelOptions": ["No College", "Bachelor's degree"],
+    "techProficiency": "Intermediate",
+    "techProficiencyOptions": ["Beginner", "Advanced"],
+    "learningPreferences": "Full sentence about Name",
+    "learningPreferencesOptions": ["Full sentence about Name", "Full sentence about Name"],
+    "motivation": {"keyword": "short", "text": "full"},
+    "motivationOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}],
+    "challenges": {"keyword": "short", "text": "full"},
+    "challengeOptions": [{"keyword": "short", "text": "full"}, {"keyword": "short", "text": "full"}]
+  }
 
-Avoid motivation keywords: ${existingMotivationKeywords.join(", ") || "none"}.
-Avoid challenge keywords: ${existingChallengeKeywords.join(", ") || "none"}.
+  Avoid motivation keywords: ${existingMotivationKeywords.join(", ") || "none"}.
+  Avoid challenge keywords: ${existingChallengeKeywords.join(", ") || "none"}.
+  Avoid learning preferences: ${existingLearningPreferences.join(" | ") || "none"}.
 
-  Project Brief: ${projectBrief}
-  Business Goal: ${businessGoal}
-  Audience Profile: ${audienceProfile}
-  Project Constraints: ${projectConstraints}\nSource Material: ${sourceMaterial}`;
+    Project Brief: ${projectBrief}
+    Business Goal: ${businessGoal}
+    Audience Profile: ${audienceProfile}
+    Project Constraints: ${projectConstraints}\nSource Material: ${sourceMaterial}`;
 
     const { text } = await ai.generate(textPrompt);
 
@@ -762,11 +813,35 @@ Avoid challenge keywords: ${existingChallengeKeywords.join(", ") || "none"}.
       console.error("Failed to parse AI response:", err, text);
       throw new HttpsError("internal", "Invalid AI response format.");
     }
-
-    persona.name = finalName;
-return persona;
-  }
-);
+      if (personaName) {
+        persona.name = personaName;
+      } else if (
+        !persona.name ||
+        existingNames
+          .map((n) => n.toLowerCase())
+          .includes(persona.name.toLowerCase())
+      ) {
+        persona.name = generateUniqueName(existingNames);
+      }
+      persona.ageRange = ageRange;
+      persona.ageRangeOptions = ageRangeOptions;
+      if (!EDUCATION_LEVELS.includes(persona.educationLevel)) {
+        persona.educationLevel = getRandomItems(EDUCATION_LEVELS, 1)[0];
+      }
+      persona.educationLevelOptions = getRandomItems(
+        EDUCATION_LEVELS.filter((e) => e !== persona.educationLevel),
+        2
+      );
+      if (!TECH_LEVELS.includes(persona.techProficiency)) {
+        persona.techProficiency = getRandomItems(TECH_LEVELS, 1)[0];
+      }
+      persona.techProficiencyOptions = getRandomItems(
+        TECH_LEVELS.filter((t) => t !== persona.techProficiency),
+        2
+      );
+      return persona;
+    }
+  );
 
 
 // Renamed internal constant to avoid any accidental duplicate declarations
@@ -924,15 +999,16 @@ export const generateHierarchicalOutline = onCall(
 
       const baseInfo = `Project Brief: ${projectBrief}\nBusiness Goal: ${businessGoal}\nAudience Profile: ${audienceProfile}\nProject Constraints: ${projectConstraints}\nSelected Learning Approach: ${selectedModality}\nSource Material: ${sourceMaterial}\nLearning Objectives:\n${lines.join("\n")}`;
 
-      const prompt = `You are a Senior Instructional Designer. Using the information below, create a detailed, hierarchical course outline that ensures all learning objectives are fully covered. Return the outline as plain text with modules and subtopics.\n\n${baseInfo}`;
+      const prompt = `You are a Senior Instructional Designer. Using the information below, create a detailed, hierarchical course outline that ensures all learning objectives are fully covered. Each top-level section must include at least one sub-topic (e.g., 1.1) so that every heading has children. Return the outline as JSON where each entry is an object with "number" and "text" fields (e.g., [{"number":"1","text":"Intro"},{"number":"1.1","text":"Topic"}]).\n\n${baseInfo}`;
 
       const flow = ai.defineFlow("hierarchicalOutlineFlow", async () => {
         const { text } = await ai.generate(prompt);
         return text;
       });
 
-      const outline = await flow();
-      return { outline };
+      const raw = await flow();
+      const parsed = parseJsonFromText(raw);
+      return { outline: Array.isArray(parsed) ? parsed : parsed?.outline || [] };
     } catch (error) {
       console.error("Error generating hierarchical outline:", error);
       throw new HttpsError(

--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -84,6 +84,25 @@
     background: rgba(255, 255, 255, 0.1);
     color: white;
     font-size: 16px;
+    box-sizing: border-box;
+  }
+
+  .learning-objectives {
+    padding-left: 30px;
+  }
+
+  .learning-objectives .generator-input {
+    width: 85%;
+    max-width: none;
+    margin: 10px 0;
+  }
+
+  .learning-objectives h3 {
+    text-align: left;
+  }
+
+  .learning-objectives label {
+    display: block;
   }
 
   .intake-grid {
@@ -247,6 +266,69 @@
     margin: 0;
 }
 
+.outline-display {
+    background: rgba(255, 255, 255, 0.05);
+    padding: 15px;
+    border-radius: 8px;
+    margin-bottom: 10px;
+}
+
+.outline-section {
+    margin-bottom: 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.outline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 8px;
+    border-radius: 4px;
+    font-size: 1.05em;
+}
+
+.outline-arrow {
+    margin-left: 8px;
+}
+
+.outline-subitems {
+    padding-left: 20px;
+    margin-top: 4px;
+}
+
+.outline-subline {
+    padding: 4px 0;
+    font-size: 0.95em;
+}
+
+.outline-edit-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.outline-edit-row input {
+    flex: 1;
+    padding: 6px 8px;
+    border-radius: 4px;
+    border: 1px solid #8C259E;
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+}
+
+.outline-number {
+    font-weight: 600;
+    min-width: 40px;
+}
+
+.outline-delete {
+    border-image: linear-gradient(45deg, #B22222, #FF4500) 1;
+}
+
 /* Spinner styling */
 .spinner {
   display: inline-block;
@@ -392,6 +474,51 @@
   text-align: center;
 }
 
+/* Ensure inputs don't overflow their grid item */
+.persona-edit-grid .grid-item .generator-input {
+  max-width: 100%;
+  margin: 10px 0;
+}
+
+/* Taller cards on the top row */
+.persona-edit-grid .grid-item.top-row {
+  min-height: 260px;
+}
+
+/* Field groups for labeled selects */
+.persona-edit-grid .grid-item .field-group {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.persona-edit-grid .grid-item .field-group label {
+  margin-bottom: 4px;
+}
+
+/* Bottom row adjustments */
+.persona-edit-grid .grid-item.bottom-row {
+  gap: 4px;
+}
+
+.persona-edit-grid .grid-item.bottom-row h5 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.persona-edit-grid .grid-item.bottom-row .pill-row {
+  margin: 0 0 16px;
+}
+
+.persona-edit-grid .grid-item.bottom-row .pill-row .pill {
+  flex: 1 1 calc(50% - 8px);
+}
+
+.persona-edit-grid + .button-row {
+  margin-top: 25px;
+}
+
 @media (max-width: 600px) {
   .persona-edit-grid .grid-item {
     flex-basis: 100%;
@@ -404,6 +531,7 @@
   flex-wrap: wrap;
   gap: 8px;
   margin: 10px 0;
+  justify-content: center;
 }
 
 .pill {

--- a/src/components/HierarchicalOutlineGenerator.jsx
+++ b/src/components/HierarchicalOutlineGenerator.jsx
@@ -21,10 +21,70 @@ const HierarchicalOutlineGenerator = ({
   const { courseOutline, setCourseOutline } = useProject();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [lines, setLines] = useState([]);
+  const [expandedSections, setExpandedSections] = useState({});
   const functions = getFunctions(app, "us-central1");
   const callGenerate = httpsCallable(functions, "generateHierarchicalOutline");
   const [searchParams] = useSearchParams();
   const initiativeId = searchParams.get("initiativeId") || "default";
+
+  const parseOutline = (outline = "") =>
+    outline
+      .split(/\r?\n/)
+      .filter((l) => l.trim())
+      .map((line) => {
+        const match = line.match(/^(\d+(?:\.\d+)*)\s+(.*)$/);
+        if (match) {
+          return {
+            level: match[1].split(".").length,
+            text: match[2].trim(),
+          };
+        }
+        return { level: 1, text: line.trim() };
+      });
+
+  const renumber = (items = []) => {
+    const counters = [];
+    return items.map((item) => {
+      const lvl = item.level || 1;
+      counters[lvl - 1] = (counters[lvl - 1] || 0) + 1;
+      counters.length = lvl;
+      return {
+        ...item,
+        number: counters.slice(0, lvl).join("."),
+      };
+    });
+  };
+
+  const ensureSubtopics = (items = []) => {
+    const result = [];
+    items.forEach((item, idx) => {
+      result.push(item);
+      if (item.level === 1) {
+        const next = items[idx + 1];
+        if (!next || next.level === 1) {
+          result.push({ level: 2, text: "Overview" });
+        }
+      }
+    });
+    return result;
+  };
+
+  const groupLines = (items = []) => {
+    const sections = [];
+    items.forEach((line) => {
+      if (line.level === 1) {
+        sections.push({ header: line, children: [] });
+      } else if (sections.length) {
+        sections[sections.length - 1].children.push(line);
+      }
+    });
+    return sections;
+  };
+
+  const formatOutline = (items = []) =>
+    items.map((l) => `${l.number} ${l.text}`).join("\n");
 
   const handleGenerate = async () => {
     setLoading(true);
@@ -40,7 +100,17 @@ const HierarchicalOutlineGenerator = ({
         learningObjectives,
         sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
       });
-      setCourseOutline(data.outline);
+      const outlineItems = Array.isArray(data.outline) ? data.outline : [];
+      if (!outlineItems.length) {
+        throw new Error("No outline returned");
+      }
+      const mapped = outlineItems.map((l) => ({
+        level: (l.number || "").split(".").length,
+        text: l.text || "",
+      }));
+      const initialLines = renumber(ensureSubtopics(mapped));
+      setLines(initialLines);
+      setCourseOutline(formatOutline(initialLines));
     } catch (err) {
       console.error("Error generating hierarchical outline:", err);
       setError(err?.message || "Error generating hierarchical outline.");
@@ -52,9 +122,15 @@ const HierarchicalOutlineGenerator = ({
   useEffect(() => {
     if (!courseOutline) {
       handleGenerate();
+    } else {
+      setLines(renumber(ensureSubtopics(parseOutline(courseOutline))));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courseOutline]);
+
+  useEffect(() => {
+    setExpandedSections({});
+  }, [lines]);
 
   useEffect(() => {
     const uid = auth.currentUser?.uid;
@@ -70,17 +146,41 @@ const HierarchicalOutlineGenerator = ({
     }
   };
 
+  const handleLineChange = (idx, value) => {
+    setLines((prev) => {
+      const updated = [...prev];
+      updated[idx] = { ...updated[idx], text: value };
+      return updated;
+    });
+  };
+
+  const handleDeleteLine = (idx) => {
+    setLines((prev) => {
+      const filtered = prev.filter((_, i) => i !== idx);
+      return renumber(ensureSubtopics(filtered));
+    });
+  };
+
+  const toggleSection = (idx) => {
+    setExpandedSections((prev) => ({ ...prev, [idx]: !prev[idx] }));
+  };
+
+  const handleToggleEdit = async () => {
+    if (isEditing) {
+      const updated = formatOutline(renumber(lines));
+      setCourseOutline(updated);
+      await handleManualSave();
+    }
+    setIsEditing((prev) => !prev);
+  };
+
+  const handleNext = async () => {
+    await handleManualSave();
+    if (onNext) onNext();
+  };
+
   return (
     <div className="generator-result">
-      <div className="button-row">
-        <button
-          type="button"
-          onClick={onBack}
-          className="generator-button back-button"
-        >
-          Back
-        </button>
-      </div>
       <h3>Hierarchical Course Outline</h3>
       {!courseOutline && (
         <button
@@ -95,28 +195,85 @@ const HierarchicalOutlineGenerator = ({
       {error && <p className="generator-error">{error}</p>}
       {courseOutline && (
         <>
-          <div className="generator-result" style={{ textAlign: "left" }}>
-            <textarea
-              value={courseOutline}
-              onChange={(e) => setCourseOutline(e.target.value)}
-              style={{ width: "100%", minHeight: "300px" }}
-            />
-          </div>
+          {!isEditing ? (
+            <div className="outline-display">
+              {groupLines(lines).map((section, idx) => (
+                <div key={idx} className="outline-section">
+                  <div
+                    className="outline-header"
+                    onClick={() => toggleSection(idx)}
+                  >
+                    <div>
+                      <span className="outline-number">{section.header.number}</span>{" "}
+                      {section.header.text}
+                    </div>
+                    <span className="outline-arrow">
+                      {expandedSections[idx] ? "▼" : "▶"}
+                    </span>
+                  </div>
+                  {expandedSections[idx] && (
+                    <div className="outline-subitems">
+                      {section.children.map((child, cidx) => (
+                        <div
+                          key={cidx}
+                          className="outline-subline"
+                          style={{ paddingLeft: (child.level - 2) * 20 }}
+                        >
+                          <span className="outline-number">{child.number}</span>{" "}
+                          {child.text}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="outline-edit">
+              {lines.map((line, idx) => (
+                <div
+                  key={idx}
+                  className="outline-edit-row"
+                  style={{ paddingLeft: (line.level - 1) * 20 }}
+                >
+                  <span className="outline-number">{line.number}</span>
+                  <input
+                    value={line.text}
+                    onChange={(e) => handleLineChange(idx, e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteLine(idx)}
+                    className="generator-button outline-delete"
+                  >
+                    Delete
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="button-row">
             <button
               type="button"
-              onClick={handleManualSave}
-              className="generator-button save-button"
+              onClick={onBack}
+              className="generator-button back-button"
             >
-              Save
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={handleToggleEdit}
+              className={`generator-button ${isEditing ? "save-button" : "edit-button"}`}
+            >
+              {isEditing ? "Save" : "Edit"}
             </button>
             {onNext && (
               <button
                 type="button"
-                onClick={onNext}
+                onClick={handleNext}
                 className="generator-button next-button"
               >
-                Generate Learning Design Document
+                Next
               </button>
             )}
           </div>

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -127,6 +127,8 @@ const InitiativesNew = () => {
   const [personaCount, setPersonaCount] = useState(0);
   const [usedMotivationKeywords, setUsedMotivationKeywords] = useState([]);
   const [usedChallengeKeywords, setUsedChallengeKeywords] = useState([]);
+  const [usedNames, setUsedNames] = useState([]);
+  const [usedLearningPrefs, setUsedLearningPrefs] = useState([]);
 
   const {
     learningObjectives,
@@ -148,6 +150,16 @@ const InitiativesNew = () => {
   const addUsedChallenge = (keywords = []) => {
     setUsedChallengeKeywords((prev) =>
       Array.from(new Set([...prev, ...keywords.filter(Boolean)]))
+    );
+  };
+  const addUsedName = (names = []) => {
+    setUsedNames((prev) =>
+      Array.from(new Set([...prev, ...names.filter(Boolean)]))
+    );
+  };
+  const addUsedLearningPref = (prefs = []) => {
+    setUsedLearningPrefs((prev) =>
+      Array.from(new Set([...prev, ...prefs.filter(Boolean)]))
     );
   };
 
@@ -224,6 +236,11 @@ const InitiativesNew = () => {
           ].filter(Boolean);
           addUsedMotivation(mKeys);
           addUsedChallenge(cKeys);
+          addUsedName([p.name]);
+          addUsedLearningPref([
+            p.learningPreferences,
+            ...(p.learningPreferencesOptions || []),
+          ]);
         });
       })
       .catch((err) => console.error("Error loading personas:", err));
@@ -540,7 +557,7 @@ const InitiativesNew = () => {
     try {
       const startIndex = personas.length;
       const newPersonas = [];
-      let existingNames = personas.map((p) => p.name);
+      let existingNames = [...usedNames, ...personas.map((p) => p.name)];
       for (let i = 0; i < toGenerate; i++) {
         const personaRes = await generateLearnerPersona({
           projectBrief,
@@ -551,6 +568,7 @@ const InitiativesNew = () => {
           existingMotivationKeywords: usedMotivationKeywords,
           existingChallengeKeywords: usedChallengeKeywords,
           existingNames,
+          existingLearningPreferences: usedLearningPrefs,
         });
         const personaData = normalizePersona(personaRes.data);
         if (!personaData?.name) {
@@ -609,6 +627,11 @@ const InitiativesNew = () => {
           ...challengesList.map((o) => o.keyword),
           ...challengeOptions.map((o) => o.keyword),
         ]);
+        addUsedName([personaData.name]);
+        addUsedLearningPref([
+          rest.learningPreferences,
+          ...(rest.learningPreferencesOptions || []),
+        ]);
         existingNames.push(personaData.name);
         const uid = auth.currentUser?.uid;
         let savedPersona = personaToSave;
@@ -638,9 +661,13 @@ const InitiativesNew = () => {
     setPersonaLoading(true);
     setPersonaError("");
     try {
-      const existingNames = personas
+      const existingNamesCurrent = personas
         .filter((_, i) => !(action === "replace" && i === activePersonaIndex))
         .map((p) => p.name);
+      const existingNames = [
+        ...usedNames,
+        ...existingNamesCurrent,
+      ];
       const personaRes = await generateLearnerPersona({
         projectBrief,
         businessGoal,
@@ -650,6 +677,7 @@ const InitiativesNew = () => {
         existingMotivationKeywords: usedMotivationKeywords,
         existingChallengeKeywords: usedChallengeKeywords,
         existingNames,
+        existingLearningPreferences: usedLearningPrefs,
       });
       const personaData = normalizePersona(personaRes.data);
       if (!personaData?.name) {
@@ -710,6 +738,11 @@ const InitiativesNew = () => {
       addUsedChallenge([
         ...challengesList.map((o) => o.keyword),
         ...challengeOptions.map((o) => o.keyword),
+      ]);
+      addUsedName([personaData.name]);
+      addUsedLearningPref([
+        rest.learningPreferences,
+        ...(rest.learningPreferencesOptions || []),
       ]);
       const uid = auth.currentUser?.uid;
       if (uid) {
@@ -1223,7 +1256,7 @@ const InitiativesNew = () => {
                 {editingPersona ? (
                   <>
                     <div className="persona-edit-grid">
-                      <div className="grid-item glass-card">
+                      <div className="grid-item glass-card top-row">
                         {editingPersona.avatar && (
                           <img
                             src={editingPersona.avatar}
@@ -1248,64 +1281,73 @@ const InitiativesNew = () => {
                               e.target.value
                             )
                           }
-                          rows={2}
+                          rows={3}
                         />
                       </div>
-                      <div className="grid-item glass-card">
-                        <select
-                          className="generator-input"
-                          value={editingPersona.ageRange}
-                          onChange={(e) =>
-                            handlePersonaFieldChange("ageRange", e.target.value)
-                          }
-                        >
-                          {[editingPersona.ageRange,
-                            ...editingPersona.ageRangeOptions].map((opt) => (
-                            <option key={opt} value={opt}>
-                              {opt}
-                            </option>
-                          ))}
-                        </select>
-                        <select
-                          className="generator-input"
-                          value={editingPersona.educationLevel}
-                          onChange={(e) =>
-                            handlePersonaFieldChange(
-                              "educationLevel",
-                              e.target.value
-                            )
-                          }
-                        >
-                          {[editingPersona.educationLevel,
-                            ...editingPersona.educationLevelOptions].map(
-                            (opt) => (
+                      <div className="grid-item glass-card top-row">
+                        <div className="field-group">
+                          <label>Age Group</label>
+                          <select
+                            className="generator-input"
+                            value={editingPersona.ageRange}
+                            onChange={(e) =>
+                              handlePersonaFieldChange("ageRange", e.target.value)
+                            }
+                          >
+                            {[editingPersona.ageRange,
+                              ...editingPersona.ageRangeOptions].map((opt) => (
                               <option key={opt} value={opt}>
                                 {opt}
                               </option>
-                            )
-                          )}
-                        </select>
-                        <select
-                          className="generator-input"
-                          value={editingPersona.techProficiency}
-                          onChange={(e) =>
-                            handlePersonaFieldChange(
-                              "techProficiency",
-                              e.target.value
-                            )
-                          }
-                        >
-                          {[editingPersona.techProficiency,
-                            ...editingPersona.techProficiencyOptions].map(
-                            (opt) => (
-                              <option key={opt} value={opt}>
-                                {opt}
-                              </option>
-                            )
-                          )}
-                        </select>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="field-group">
+                          <label>Education Level</label>
+                          <select
+                            className="generator-input"
+                            value={editingPersona.educationLevel}
+                            onChange={(e) =>
+                              handlePersonaFieldChange(
+                                "educationLevel",
+                                e.target.value
+                              )
+                            }
+                          >
+                            {[editingPersona.educationLevel,
+                              ...editingPersona.educationLevelOptions].map(
+                              (opt) => (
+                                <option key={opt} value={opt}>
+                                  {opt}
+                                </option>
+                              )
+                            )}
+                          </select>
+                        </div>
+                        <div className="field-group">
+                          <label>Tech Proficiency</label>
+                          <select
+                            className="generator-input"
+                            value={editingPersona.techProficiency}
+                            onChange={(e) =>
+                              handlePersonaFieldChange(
+                                "techProficiency",
+                                e.target.value
+                              )
+                            }
+                          >
+                            {[editingPersona.techProficiency,
+                              ...editingPersona.techProficiencyOptions].map(
+                              (opt) => (
+                                <option key={opt} value={opt}>
+                                  {opt}
+                                </option>
+                              )
+                            )}
+                          </select>
+                        </div>
                       </div>
-                      <div className="grid-item glass-card">
+                      <div className="grid-item glass-card bottom-row">
                         <h5>Motivation</h5>
                         <div className="pill-row">
                           {editingPersona.motivationChoices?.map((m, i) => (
@@ -1329,7 +1371,7 @@ const InitiativesNew = () => {
                           </button>
                         )}
                       </div>
-                      <div className="grid-item glass-card">
+                      <div className="grid-item glass-card bottom-row">
                         <h5>Challenges</h5>
                         <div className="pill-row">
                           {editingPersona.challengeChoices?.map((c, i) => (

--- a/src/components/LearningDesignDocument.jsx
+++ b/src/components/LearningDesignDocument.jsx
@@ -57,7 +57,7 @@ const LearningDesignDocument = ({
       handleGenerate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [learningDesignDocument]);
+  }, []);
 
   useEffect(() => {
     const uid = auth.currentUser?.uid;
@@ -71,6 +71,11 @@ const LearningDesignDocument = ({
     if (uid) {
       await saveInitiative(uid, initiativeId, { learningDesignDocument });
     }
+  };
+
+  const handleNext = async () => {
+    await handleManualSave();
+    navigate(`/ai-tools/content-assets?initiativeId=${initiativeId}`);
   };
 
   return (
@@ -102,34 +107,42 @@ const LearningDesignDocument = ({
         </div>
       )}
       {learningDesignDocument && (
-        <div className="generator-result" style={{ textAlign: "left" }}>
-          <textarea
-            value={learningDesignDocument}
-            onChange={(e) => setLearningDesignDocument(e.target.value)}
-            style={{ width: "100%", minHeight: "300px" }}
-          />
-        </div>
-      )}
-      <div className="button-row">
-        <button
-          type="button"
-          onClick={handleManualSave}
-          className="generator-button save-button"
-        >
-          Save
-        </button>
-        <button
-          type="button"
-          onClick={() =>
-            navigate(`/ai-tools/content-assets?initiativeId=${initiativeId}`)
-          }
-          className="generator-button next-button"
-        >
-          Next: Content & Assets
-        </button>
+      <div className="generator-result" style={{ textAlign: "left" }}>
+        <textarea
+          value={learningDesignDocument}
+          onChange={(e) => setLearningDesignDocument(e.target.value)}
+          style={{ width: "100%", minHeight: "300px" }}
+        />
       </div>
+    )}
+    <div className="button-row">
+      <button
+        type="button"
+        onClick={handleManualSave}
+        className="generator-button save-button"
+      >
+        Save
+      </button>
+      {learningDesignDocument && (
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={loading}
+          className="generator-button"
+        >
+          {loading ? "Generating..." : "Regenerate Document"}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={handleNext}
+        className="generator-button next-button"
+      >
+        Next: Content & Assets
+      </button>
     </div>
-  );
+  </div>
+);
 };
 
 export default LearningDesignDocument;

--- a/src/components/LearningObjectivesGenerator.jsx
+++ b/src/components/LearningObjectivesGenerator.jsx
@@ -186,6 +186,11 @@ const LearningObjectivesGenerator = ({
     }
   };
 
+  const handleNext = async () => {
+    await handleSave();
+    if (onNext) onNext();
+  };
+
   const renderObjective = (obj, type, index) => {
     if (!obj) return null;
     const isEditing = editing && editing.type === type && editing.index === index;
@@ -234,16 +239,7 @@ const LearningObjectivesGenerator = ({
   };
 
   return (
-    <div className="generator-result">
-      <div className="button-row">
-        <button
-          type="button"
-          onClick={onBack}
-          className="generator-button back-button"
-        >
-          Back
-        </button>
-      </div>
+    <div className="generator-result learning-objectives">
       <h3>Learning Objectives</h3>
       <div style={{ marginBottom: 10 }}>
         <label>
@@ -302,27 +298,36 @@ const LearningObjectivesGenerator = ({
           {(learningObjectives.enablingObjectives || []).map((obj, idx) =>
             renderObjective(obj, "enabling", idx)
           )}
-          <div className="button-row">
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={saving}
-              className="generator-button save-button"
-            >
-              {saving ? "Saving..." : "Save Objectives"}
-            </button>
-            {onNext && (
-              <button
-                type="button"
-                onClick={onNext}
-                className="generator-button next-button"
-              >
-                Next
-              </button>
-            )}
-          </div>
         </div>
       )}
+      <div className="button-row">
+        <button
+          type="button"
+          onClick={onBack}
+          className="generator-button back-button"
+        >
+          Back
+        </button>
+        {learningObjectives && (
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="generator-button save-button"
+          >
+            {saving ? "Saving..." : "Save Objectives"}
+          </button>
+        )}
+        {learningObjectives && onNext && (
+          <button
+            type="button"
+            onClick={handleNext}
+            className="generator-button next-button"
+          >
+            Next
+          </button>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Save learning objectives to the project when advancing and allow manual updates
- Ensure the course outline persists before leaving the outline step
- Add a regenerate button for the learning design document and save it before continuing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7634d3ac832b9ba371b218b2f331