### PR TITLE
Improve objectives persistence and design doc layout

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -273,6 +273,14 @@
     margin-bottom: 10px;
 }
 
+.objectives-display {
+    background: rgba(255, 255, 255, 0.05);
+    padding: 15px;
+    border-radius: 8px;
+    margin-bottom: 10px;
+    text-align: left;
+}
+
 .outline-section {
     margin-bottom: 8px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -596,8 +604,7 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 1.5rem;
   box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
-  width: 100%;
-  max-width: 1100px;
+  width: 75%;
   height: 95vh;
   display: flex;
   flex-direction: column;
@@ -616,6 +623,9 @@
   font-size: 1.5rem;
   font-weight: 700;
   margin: 0;
+}
+.design-doc-title {
+  text-align: left;
 }
 
 .design-doc-title p {
@@ -678,6 +688,7 @@
   flex: 1;
   padding: 32px;
   overflow-y: auto;
+  text-align: left;
 }
 
 .design-doc-content h2 {
@@ -746,5 +757,9 @@
 .design-doc-placeholder {
   padding: 32px;
   text-align: center;
+}
+
+.design-doc-panel .button-row {
+  margin-top: 20px;
 }
 

--- a/src/components/HierarchicalOutlineGenerator.jsx
+++ b/src/components/HierarchicalOutlineGenerator.jsx
@@ -139,10 +139,10 @@ const HierarchicalOutlineGenerator = ({
     }
   }, [courseOutline, initiativeId]);
 
-  const handleManualSave = async () => {
+  const handleManualSave = async (outline = courseOutline) => {
     const uid = auth.currentUser?.uid;
     if (uid) {
-      await saveInitiative(uid, initiativeId, { courseOutline });
+      await saveInitiative(uid, initiativeId, { courseOutline: outline });
     }
   };
 
@@ -169,13 +169,18 @@ const HierarchicalOutlineGenerator = ({
     if (isEditing) {
       const updated = formatOutline(renumber(lines));
       setCourseOutline(updated);
-      await handleManualSave();
+      await handleManualSave(updated);
     }
     setIsEditing((prev) => !prev);
   };
 
   const handleNext = async () => {
-    await handleManualSave();
+    let outlineToSave = courseOutline;
+    if (isEditing) {
+      outlineToSave = formatOutline(renumber(lines));
+      setCourseOutline(outlineToSave);
+    }
+    await handleManualSave(outlineToSave);
     if (onNext) onNext();
   };
 

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -132,9 +132,12 @@ const InitiativesNew = () => {
 
   const {
     learningObjectives,
+    setLearningObjectives,
     courseOutline,
+    setCourseOutline,
     learningDesignDocument,
     setLearningDesignDocument,
+    resetProject,
   } = useProject();
 
   const projectBriefRef = useRef(null);
@@ -181,6 +184,8 @@ const InitiativesNew = () => {
         clarifyingAnswers,
         strategy,
         selectedModality,
+        learningObjectives,
+        courseOutline,
         learningDesignDocument,
       });
       setSaveStatus("Saved");
@@ -194,6 +199,26 @@ const InitiativesNew = () => {
   useEffect(() => {
     const uid = auth.currentUser?.uid;
     if (!uid) return;
+
+    // Reset all local and project state when switching initiatives
+    resetProject();
+    setProjectName("");
+    setBusinessGoal("");
+    setAudienceProfile("");
+    setSourceMaterials([]);
+    setProjectConstraints("");
+    setProjectBrief("");
+    setClarifyingQuestions([]);
+    setClarifyingAnswers([]);
+    setStrategy(null);
+    setSelectedModality("");
+    setPersonas([]);
+    setActivePersonaIndex(0);
+    setPersonaCount(0);
+    setUsedMotivationKeywords([]);
+    setUsedChallengeKeywords([]);
+    setUsedNames([]);
+    setUsedLearningPrefs([]);
 
     loadInitiative(uid, initiativeId)
       .then((data) => {
@@ -214,6 +239,8 @@ const InitiativesNew = () => {
           setClarifyingAnswers(data.clarifyingAnswers || []);
           setStrategy(data.strategy || null);
           setSelectedModality(data.selectedModality || "");
+          setLearningObjectives(data.learningObjectives || null);
+          setCourseOutline(data.courseOutline || "");
           setLearningDesignDocument(data.learningDesignDocument || "");
         }
       })
@@ -244,7 +271,13 @@ const InitiativesNew = () => {
         });
       })
       .catch((err) => console.error("Error loading personas:", err));
-  }, [initiativeId, setLearningDesignDocument]);
+  }, [
+    initiativeId,
+    resetProject,
+    setLearningDesignDocument,
+    setLearningObjectives,
+    setCourseOutline,
+  ]);
 
   useEffect(() => {
     if (!projectBriefRef.current || !nextButtonRef.current) return;
@@ -503,7 +536,7 @@ const InitiativesNew = () => {
         projectConstraints,
         clarifyingQuestions,
         clarifyingAnswers,
-        personaCount: 0,
+        personaCount: personas.length,
         sourceMaterial: getCombinedSource(),
       });
 

--- a/src/context/ProjectContext.jsx
+++ b/src/context/ProjectContext.jsx
@@ -1,19 +1,53 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useCallback } from "react";
 import PropTypes from "prop-types";
 
 const ProjectContext = createContext();
 
+const defaultState = {
+  courseOutline: "",
+  modules: [],
+  selectedModule: "",
+  lessonContent: "",
+  storyboard: "",
+  assessment: "",
+  learningObjectives: null,
+  learningDesignDocument: "",
+  draftContent: {},
+  mediaAssets: [],
+};
+
 export const ProjectProvider = ({ children }) => {
-  const [courseOutline, setCourseOutline] = useState("");
-  const [modules, setModules] = useState([]);
-  const [selectedModule, setSelectedModule] = useState("");
-  const [lessonContent, setLessonContent] = useState("");
-  const [storyboard, setStoryboard] = useState("");
-  const [assessment, setAssessment] = useState("");
-  const [learningObjectives, setLearningObjectives] = useState(null);
-  const [learningDesignDocument, setLearningDesignDocument] = useState("");
-  const [draftContent, setDraftContent] = useState({});
-  const [mediaAssets, setMediaAssets] = useState([]);
+  const [courseOutline, setCourseOutline] = useState(defaultState.courseOutline);
+  const [modules, setModules] = useState(defaultState.modules);
+  const [selectedModule, setSelectedModule] = useState(
+    defaultState.selectedModule
+  );
+  const [lessonContent, setLessonContent] = useState(
+    defaultState.lessonContent
+  );
+  const [storyboard, setStoryboard] = useState(defaultState.storyboard);
+  const [assessment, setAssessment] = useState(defaultState.assessment);
+  const [learningObjectives, setLearningObjectives] = useState(
+    defaultState.learningObjectives
+  );
+  const [learningDesignDocument, setLearningDesignDocument] = useState(
+    defaultState.learningDesignDocument
+  );
+  const [draftContent, setDraftContent] = useState(defaultState.draftContent);
+  const [mediaAssets, setMediaAssets] = useState(defaultState.mediaAssets);
+
+  const resetProject = useCallback(() => {
+    setCourseOutline(defaultState.courseOutline);
+    setModules(defaultState.modules);
+    setSelectedModule(defaultState.selectedModule);
+    setLessonContent(defaultState.lessonContent);
+    setStoryboard(defaultState.storyboard);
+    setAssessment(defaultState.assessment);
+    setLearningObjectives(defaultState.learningObjectives);
+    setLearningDesignDocument(defaultState.learningDesignDocument);
+    setDraftContent(defaultState.draftContent);
+    setMediaAssets(defaultState.mediaAssets);
+  }, []);
 
   const value = {
     courseOutline,
@@ -36,6 +70,7 @@ export const ProjectProvider = ({ children }) => {
     setDraftContent,
     mediaAssets,
     setMediaAssets,
+    resetProject,
   };
 
   return (


### PR DESCRIPTION
## Summary
- Show learning objectives in read-only view with edit/save toggle and persist on next
- Load and save objectives and outline data across sessions
- Refine design doc styling and spacing with wider panel and left-aligned text
- Reset project state when switching initiatives to avoid cross-project leakage
- Stabilize project reset with memoized helper and send actual persona count when generating strategy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b7e7dd6d4832baf6794be5fd2961e