### PR TITLE
refactor: apply glass card and pill tracker

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -17,50 +17,58 @@
     opacity: 0.8;
   }
 
-.step-tracker {
-    position: relative;
-    margin: 20px 0;
-  }
-
-.steps {
-    display: grid;
-    gap: 12px;
-    justify-content: center;
-  }
-
-.step-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    cursor: pointer;
-    opacity: 0.5;
-    text-align: center;
-  }
-
-.step-item.active,
-.step-item.completed {
-    opacity: 1;
-  }
-
-.step-circle {
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    border: 2px solid #8C259E;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 4px;
+/* Reusable frosted glass card for each initiative step */
+.initiative-card {
     background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(25px);
+    -webkit-backdrop-filter: blur(25px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 1.5rem;
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+    padding: 20px;
+    margin: 20px auto;
+    color: #fff;
+    width: 100%;
+    max-width: 800px;
+    text-align: left;
   }
 
-.step-item.completed .step-circle {
-    background: #8C259E;
-    color: white;
+.step-tracker {
+    display: flex;
+    width: 100%;
+    max-width: 800px;
+    margin: 20px auto;
+    padding: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(25px);
+    -webkit-backdrop-filter: blur(25px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 9999px;
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+    overflow: hidden;
   }
 
-.step-label {
+.step-segment {
+    flex: 1;
+    padding: 8px 12px;
+    text-align: center;
+    cursor: pointer;
     font-size: 12px;
+    color: #fff;
+    transition: background 0.3s ease;
+  }
+
+.step-segment:not(:last-child) {
+    border-right: 1px solid rgba(255, 255, 255, 0.2);
+  }
+
+.step-segment.completed {
+    background: rgba(140, 37, 158, 0.5);
+  }
+
+.step-segment.active {
+    background: rgba(140, 37, 158, 0.8);
+    font-weight: 600;
   }
 
 .save-status {

--- a/src/components/HierarchicalOutlineGenerator.jsx
+++ b/src/components/HierarchicalOutlineGenerator.jsx
@@ -187,7 +187,7 @@ const HierarchicalOutlineGenerator = ({
   };
 
   return (
-    <div className="generator-result">
+    <div className="generator-result initiative-card">
       <h3>Hierarchical Course Outline</h3>
       {!courseOutline && (
         <button

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -1029,45 +1029,38 @@ const InitiativesNew = () => {
         Your AI Partner for End-to-End Course Creation
       </p>
       <div className="step-tracker">
-        <div
-          className="steps"
-          style={{ gridTemplateColumns: `repeat(${steps.length}, 1fr)` }}
-        >
-          {steps.map((label, idx) => (
-            <div
-              key={label}
-              className={`step-item ${
-                idx + 1 === step ? "active" : idx + 1 < step ? "completed" : ""
-              }`}
-              onClick={() => setStep(idx + 1)}
-            >
-              <div className="step-circle">
-                {idx + 1 < step ? "\u2713" : idx + 1}
-              </div>
-              <div className="step-label">{label}</div>
-            </div>
-          ))}
-        </div>
+        {steps.map((label, idx) => (
+          <div
+            key={label}
+            className={`step-segment ${
+              idx + 1 === step ? "active" : idx + 1 < step ? "completed" : ""
+            }`}
+            onClick={() => setStep(idx + 1)}
+          >
+            {label}
+          </div>
+        ))}
       </div>
       {saveStatus && <p className="save-status">{saveStatus}</p>}
 
       {step === 1 && (
-        <form onSubmit={handleSubmit} className="generator-form">
-          <h3>Project Intake</h3>
-          <p>Tell us about your project. The more detail, the better.</p>
-          <div className="intake-grid">
-            <div className="intake-left">
-              <label>
-                Project Name
-                <input
-                  type="text"
-                  value={projectName}
-                  placeholder="e.g., 'Q3 Sales Onboarding'"
-                  onChange={(e) => setProjectName(e.target.value)}
-                  className="generator-input"
-                />
-              </label>
-              <label>
+        <div className="initiative-card">
+          <form onSubmit={handleSubmit} className="generator-form">
+            <h3>Project Intake</h3>
+            <p>Tell us about your project. The more detail, the better.</p>
+            <div className="intake-grid">
+              <div className="intake-left">
+                <label>
+                  Project Name
+                  <input
+                    type="text"
+                    value={projectName}
+                    placeholder="e.g., 'Q3 Sales Onboarding'"
+                    onChange={(e) => setProjectName(e.target.value)}
+                    className="generator-input"
+                  />
+                </label>
+                <label>
                 What is the primary business goal?
                 <input
                   type="text"
@@ -1140,10 +1133,11 @@ const InitiativesNew = () => {
           </div>
           {error && <p className="generator-error">{error}</p>}
         </form>
+        </div>
       )}
 
       {step === 2 && (
-        <div className="generator-result">
+        <div className="generator-result initiative-card">
           <p>
             Answering the questions below is optional, but it will help ensure the brief is as good as possible.
           </p>
@@ -1187,7 +1181,7 @@ const InitiativesNew = () => {
       )}
 
       {step === 3 && (
-        <div className="generator-result" ref={projectBriefRef}>
+        <div className="generator-result initiative-card" ref={projectBriefRef}>
           <h3>Project Brief</h3>
           {isEditingBrief ? (
             <textarea
@@ -1256,7 +1250,7 @@ const InitiativesNew = () => {
       )}
 
       {step === 4 && (
-        <div className="generator-result">
+        <div className="generator-result initiative-card">
           <div>
             <h3>Learner Personas</h3>
             {personas.length === 0 ? (
@@ -1594,7 +1588,7 @@ const InitiativesNew = () => {
       )}
 
       {step === 5 && strategy && (
-        <div className="generator-result">
+        <div className="generator-result initiative-card">
           <h3>Select Learning Approach</h3>
           <select
             className="generator-input"

--- a/src/components/LearningObjectivesGenerator.jsx
+++ b/src/components/LearningObjectivesGenerator.jsx
@@ -237,7 +237,7 @@ const LearningObjectivesGenerator = ({
   };
 
   return (
-    <div className="generator-result learning-objectives">
+    <div className="generator-result learning-objectives initiative-card">
       <h3>Learning Objectives</h3>
       <div style={{ marginBottom: 10 }}>
         <label>


### PR DESCRIPTION
## Summary
- Wrap initiative steps in a reusable frosted glass card matching the Learning Design Document style
- Replace circular step tracker with a slimmer pill-style tracker that spans the card width
- Apply card styling to Learning Objectives and Outline generators for consistency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ceba31a94832b82e359a56e43cc65