### PR TITLE
Paginate clarifying questions in step two

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -102,6 +102,7 @@
     color: white;
     font-size: 16px;
     box-sizing: border-box;
+    text-align: left;
   }
 
   .learning-objectives {
@@ -225,6 +226,11 @@
     flex-wrap: wrap;
     justify-content: center;
     margin-top: 10px;
+  }
+
+  .page-indicator {
+    text-align: center;
+    margin: 10px 0;
   }
 
   .file-list {


### PR DESCRIPTION
## Summary
- Limit clarifying questions to nine items and track current question page
- Paginate step two questions three per page with page indicators and navigation
- Ensure question text areas are left-aligned and roomy for multi-sentence answers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf75e63b0832b9f4a04bc89d9190b