### PR TITLE
Paginate clarifying questions in step two

### DIFF
--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -102,6 +102,13 @@
     color: white;
     font-size: 16px;
     box-sizing: border-box;
+    text-align: left;
+  }
+
+  .clarify-textarea {
+    width: calc(100% - 20px);
+    max-width: none;
+    margin: 0 10px 10px;
   }
 
   .learning-objectives {
@@ -225,6 +232,11 @@
     flex-wrap: wrap;
     justify-content: center;
     margin-top: 10px;
+  }
+
+  .page-indicator {
+    text-align: center;
+    margin: 10px 0;
   }
 
   .file-list {


### PR DESCRIPTION
## Summary
- Add optionality note and wider, shorter inputs for clarifying questions
- Move question pagination to bottom navigation with auto-saving
- Return to final questions page when leaving the project brief

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf75e63b0832b9f4a04bc89d9190b