### PR TITLE
Align initiative cards with tracker style and revive pulsing background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,6 +19,7 @@ body {
   flex-direction: column;
   align-items: center;
   position: relative;
+  z-index: 0;
 }
 
 #root {
@@ -46,28 +47,28 @@ body::before {
     radial-gradient(circle at 70% 30%, #667eea, transparent 60%),
     radial-gradient(circle at 30% 70%, #8b5cf6, transparent 60%);
   filter: blur(120px);
-  opacity: 0.6;
+  opacity: 0.7;
   pointer-events: none;
   z-index: -1;
   transform: scale(1) translate(0, 0);
 }
 
 body.pulsing::before {
-  animation: pulseGradient 5s ease-in-out infinite;
+  animation: pulseGradient 4s ease-in-out infinite;
 }
 
 @keyframes pulseGradient {
   0% {
     transform: scale(1) translate(0, 0);
-    opacity: 0.55;
+    opacity: 0.5;
   }
   50% {
-    transform: scale(1.8) translate(25%, -25%);
-    opacity: 0.9;
+    transform: scale(2.4) translate(40%, -40%);
+    opacity: 1;
   }
   100% {
     transform: scale(1) translate(0, 0);
-    opacity: 0.55;
+    opacity: 0.5;
   }
 }
 

--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -17,11 +17,11 @@
     opacity: 0.8;
   }
 
-/* Reusable initiative card with gradient background and pulsing overlay */
+/* Reusable initiative card with frosted glass styling */
 .initiative-card {
-    background: rgba(255, 255, 255, 0.15);
-    backdrop-filter: blur(30px);
-    -webkit-backdrop-filter: blur(30px);
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(25px);
+    -webkit-backdrop-filter: blur(25px);
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 1.5rem;
     box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
@@ -270,7 +270,6 @@
   
   /* Result container styling */
   .generator-result {
-    background: transparent;
     padding: 20px;
     border-radius: 12px;
     margin-top: 20px;


### PR DESCRIPTION
## Summary
- Match initiative-card frosted glass styling to step tracker for consistent color and opacity
- Restore and amplify background pulsing during AI operations via z-index fix and stronger animation
- Ensure generator results don't override initiative card background, keeping the #ffffff1a frosted glass across steps

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d3037496c832bb7ed7e67f68c055e