### PR TITLE
Refine personas persistence and add training plan step

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -764,7 +764,7 @@ export const generateLearnerPersona = onCall(
       if (refreshField === "motivation" || refreshField === "challenges") {
         listPrompt = `You are a Senior Instructional Designer. Based on the project information below, list three fresh learner ${
           refreshField
-        } options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) that captures the theme — do not use generic terms like "general" or "other" — and a "text" field written in full sentences describing the learner without using their name. Avoid the following ${
+        } options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) that captures the theme — do not use generic terms like "general" or "other" — and a "text" field written as a full sentence about the learner without using their name or pronouns. Vary the sentence openings and do not begin with "The learner." Avoid the following ${
           refreshField
         } keywords: ${
           refreshField === "motivation"
@@ -778,7 +778,7 @@ Audience Profile: ${audienceProfile}
 Project Constraints: ${projectConstraints}\nSource Material: ${sourceMaterial}`;
       } else if (refreshField === "learningPreferences") {
         const personaInstruction = "";
-        listPrompt = `You are a Senior Instructional Designer.${personaInstruction} Based on the project information below, list three fresh learner learning preference options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) describing a distinct modality or strategy and a "text" field that is a full-sentence about the learner. Avoid the following learning preference keywords: ${existingLearningPreferenceKeywords.join(", ") || "none"}.
+        listPrompt = `You are a Senior Instructional Designer.${personaInstruction} Based on the project information below, list three fresh learner learning preference options in JSON with an array called "options". Each option must have a short, specific "keyword" (1-3 words) describing a distinct modality or strategy and a "text" field that is a full sentence about the learner without using their name or pronouns. Vary the sentence openings and do not begin with "The learner." Avoid the following learning preference keywords: ${existingLearningPreferenceKeywords.join(", ") || "none"}.
 
 Project Brief: ${projectBrief}
 Business Goal: ${businessGoal}
@@ -831,11 +831,11 @@ Project Constraints: ${projectConstraints}\nSource Material: ${sourceMaterial}`;
       const textPrompt = `You are a Senior Instructional Designer. ${nameInstruction} The persona is in the ${ageRange} age group. Using the provided information, create one learner persona. Provide:
   - "educationLevel": select one option from [${educationList}] and "educationLevelOptions" with two other distinct options from this list.
   - "techProficiency": select one option from [${techList}] and "techProficiencyOptions" with two other distinct options from this list.
-   - "learningPreferences": {"keyword": "short concept", "text": "full-sentence about the learner"} describing the learner's preferred learning style and "learningPreferencesOptions" with two alternative objects following the same keyword/text structure. Each keyword must capture a distinct modality or strategy (e.g., "hands-on practice", "visual storytelling").
+   - "learningPreferences": {"keyword": "short concept", "text": "full sentence about the learner without using their name or pronouns"} describing the learner's preferred learning style and "learningPreferencesOptions" with two alternative objects following the same keyword/text structure. Each keyword must capture a distinct modality or strategy (e.g., "hands-on practice", "visual storytelling"). Vary sentence openings and do not begin with "The learner." 
   - For both the primary motivation and the primary challenge:
     - Provide a short, specific keyword (1-3 words) that summarizes the item. Avoid generic labels such as "general" or "other".
-    - Provide a full-sentence description in a "text" field about the learner in third person without using their name.
-    - Also supply exactly two alternative options for motivations and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" is also a full-sentence description about the learner without using their name.
+    - Provide a full-sentence description in a "text" field about the learner without using their name or pronouns. Vary the sentence openings and do not begin with "The learner." 
+    - Also supply exactly two alternative options for motivation and two for challenges, each following the same keyword/text structure with unique keywords. Ensure each option's "text" also avoids pronouns and does not begin with "The learner." 
   Return a JSON object exactly like this, no code fences, and vary the persona each time using this seed: ${randomSeed}
 
   {
@@ -1161,10 +1161,11 @@ export const generateLearningDesignDocument = onCall(
       blendModalities = [],
       learningObjectives,
       courseOutline,
+      trainingPlan,
       sourceMaterial = "",
     } = req.data || {};
 
-    if (!projectBrief || !learningObjectives || !courseOutline) {
+    if (!projectBrief) {
       throw new HttpsError(
         "invalid-argument",
         "Required information is missing."
@@ -1196,7 +1197,12 @@ export const generateLearningDesignDocument = onCall(
         Array.isArray(blendModalities) && blendModalities.length
           ? `\nBlended Modalities: ${blendModalities.join(", ")}`
           : "";
-      const baseInfo = `Project Brief: ${projectBrief}\nBusiness Goal: ${businessGoal}\nAudience Profile: ${audienceProfile}\nProject Constraints: ${projectConstraints}\nSelected Learning Approach: ${selectedModality}${blendedInfo}\nSource Material: ${sourceMaterial}\nCourse Outline:\n${courseOutline}\nLearning Objectives:\n${lines.join("\n")}`;
+      const outlineInfo = courseOutline ? `\nCourse Outline:\n${courseOutline}` : "";
+      const objectivesInfo = lines.length
+        ? `\nLearning Objectives:\n${lines.join("\n")}`
+        : "";
+      const planInfo = trainingPlan ? `\nTraining Plan:\n${trainingPlan}` : "";
+      const baseInfo = `Project Brief: ${projectBrief}\nBusiness Goal: ${businessGoal}\nAudience Profile: ${audienceProfile}\nProject Constraints: ${projectConstraints}\nSelected Learning Approach: ${selectedModality}${blendedInfo}\nSource Material: ${sourceMaterial}${planInfo}${outlineInfo}${objectivesInfo}`;
 
       const prompt = `You are a Senior Instructional Designer. Using the information below, create a comprehensive Learning Design Document that serves as the single source of truth for the project. Include the following sections: 1. Front Matter & Executive Summary (Project Title, Project Overview, Key Stakeholders) 2. Audience Analysis (Learner Demographics, Prior Knowledge & Skills, Learner Motivation, Technical Environment, Learner Personas) 3. Business Goals & Learning Objectives (Business Goal, Terminal Learning Objective, Enabling Learning Objectives) 4. Instructional Strategy (Delivery Modality, Instructional Approach, Tone & Style, Interaction Strategy) 5. Curriculum Blueprint (Hierarchical Outline, Objective Mapping, Content Summary, Estimated Seat Time) 6. Assessment & Evaluation Strategy (Formative Assessment, Summative Assessment, Evaluation Plan for Kirkpatrick Levels 1-4, xAPI Strategy if applicable). Present the document in clear markdown with headings and subheadings.\n\n${baseInfo}`;
 

--- a/src/components/AIToolsGenerators.css
+++ b/src/components/AIToolsGenerators.css
@@ -419,6 +419,10 @@
   border: 4px solid purple;
 }
 
+.learning-personas-title {
+  color: purple;
+}
+
 /* New persona layout */
 .persona-top {
   display: flex;
@@ -532,8 +536,12 @@
 
 .persona-role {
   font-size: 1.25rem;
-  font-weight: 700;
-  color: #8b5cf6;
+  font-weight: 800;
+  color: #fff;
+  background-color: purple;
+  padding: 2px 6px;
+  border-radius: 4px;
+  display: inline-block;
 }
 
 .persona-department {

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -14,6 +14,7 @@ import { useSearchParams } from "react-router-dom";
 import LearningObjectivesGenerator from "./LearningObjectivesGenerator.jsx";
 import HierarchicalOutlineGenerator from "./HierarchicalOutlineGenerator.jsx";
 import LearningDesignDocument from "./LearningDesignDocument.jsx";
+import TrainingPlanGenerator from "./TrainingPlanGenerator.jsx";
 import { useProject } from "../context/ProjectContext.jsx";
 import "./AIToolsGenerators.css";
 import PersonaDisplay from "./PersonaDisplay.jsx";
@@ -284,9 +285,10 @@ const InitiativesNew = () => {
     "Brief",
     "Personas",
     "Approach",
+    "Plan",
+    "Design",
     "Objectives",
     "Outline",
-    "Design",
   ];
   const [step, setStep] = useState(1);
   const [projectName, setProjectName] = useState("");
@@ -312,6 +314,7 @@ const InitiativesNew = () => {
   const [strategy, setStrategy] = useState(null);
   const [selectedModality, setSelectedModality] = useState("");
   const [blendModalities, setBlendModalities] = useState([]);
+  const [trainingPlan, setTrainingPlan] = useState("");
 
   const [isEditingBrief, setIsEditingBrief] = useState(false);
 
@@ -551,6 +554,7 @@ const InitiativesNew = () => {
         strategy,
         selectedModality,
         blendModalities,
+        trainingPlan,
         learningObjectives,
         courseOutline,
         learningDesignDocument,
@@ -588,6 +592,7 @@ const InitiativesNew = () => {
     setUsedTypes([]);
     setUsedLearningPrefKeywords([]);
     setBlendModalities([]);
+    setTrainingPlan("");
 
     loadInitiative(uid, initiativeId)
       .then((data) => {
@@ -612,6 +617,7 @@ const InitiativesNew = () => {
           setStrategy(data.strategy || null);
           setSelectedModality(data.selectedModality || "");
           setBlendModalities(data.blendModalities || []);
+          setTrainingPlan(data.trainingPlan || "");
           setLearningObjectives(data.learningObjectives || null);
           setCourseOutline(data.courseOutline || "");
           setLearningDesignDocument(data.learningDesignDocument || "");
@@ -1545,15 +1551,15 @@ const InitiativesNew = () => {
         <div className="initiative-card generator-result"
         >
           <div>
-            <h3 className="text-white">Learner Personas</h3>
+            <h3 className="learning-personas-title">Learning Personas</h3>
             {personas.length === 0 ? (
               <>
                 <p>
-                  Learner personas help tailor the training to different
-                  audience segments by highlighting motivations, challenges,
-                  and preferences. They can influence project decisions and
-                  outcomes. You may generate up to three personas, but none are
-                  required.
+                  Learning personas help tailor the training to different
+                  audience segments by highlighting motivation, challenges,
+                  and preferences. These insights can influence project
+                  decisions and outcomes. You may generate up to three personas,
+                  but none are required.
                 </p>
                 <label>
                   How many personas would you like to generate? (0-3)
@@ -1796,7 +1802,7 @@ const InitiativesNew = () => {
       )}
 
       {step === 6 && (
-        <LearningObjectivesGenerator
+        <TrainingPlanGenerator
           projectBrief={projectBrief}
           businessGoal={businessGoal}
           audienceProfile={audienceProfile}
@@ -1804,27 +1810,14 @@ const InitiativesNew = () => {
           selectedModality={selectedModality}
           blendModalities={blendModalities}
           sourceMaterials={sourceMaterials}
+          trainingPlan={trainingPlan}
+          setTrainingPlan={setTrainingPlan}
           onBack={() => setStep(5)}
           onNext={() => setStep(7)}
         />
       )}
 
       {step === 7 && (
-        <HierarchicalOutlineGenerator
-          projectBrief={projectBrief}
-          businessGoal={businessGoal}
-          audienceProfile={audienceProfile}
-          projectConstraints={projectConstraints}
-          selectedModality={selectedModality}
-          blendModalities={blendModalities}
-          learningObjectives={learningObjectives}
-          sourceMaterials={sourceMaterials}
-          onBack={() => setStep(6)}
-          onNext={() => setStep(8)}
-        />
-      )}
-
-      {step === 8 && (
         <LearningDesignDocument
           projectName={projectName}
           projectBrief={projectBrief}
@@ -1835,8 +1828,37 @@ const InitiativesNew = () => {
           blendModalities={blendModalities}
           learningObjectives={learningObjectives}
           courseOutline={courseOutline}
+          trainingPlan={trainingPlan}
+          sourceMaterials={sourceMaterials}
+          onBack={() => setStep(6)}
+        />
+      )}
+
+      {step === 8 && (
+        <LearningObjectivesGenerator
+          projectBrief={projectBrief}
+          businessGoal={businessGoal}
+          audienceProfile={audienceProfile}
+          projectConstraints={projectConstraints}
+          selectedModality={selectedModality}
+          blendModalities={blendModalities}
           sourceMaterials={sourceMaterials}
           onBack={() => setStep(7)}
+          onNext={() => setStep(9)}
+        />
+      )}
+
+      {step === 9 && (
+        <HierarchicalOutlineGenerator
+          projectBrief={projectBrief}
+          businessGoal={businessGoal}
+          audienceProfile={audienceProfile}
+          projectConstraints={projectConstraints}
+          selectedModality={selectedModality}
+          blendModalities={blendModalities}
+          learningObjectives={learningObjectives}
+          sourceMaterials={sourceMaterials}
+          onBack={() => setStep(8)}
         />
       )}
 

--- a/src/components/LearningDesignDocument.jsx
+++ b/src/components/LearningDesignDocument.jsx
@@ -17,6 +17,7 @@ const LearningDesignDocument = ({
   blendModalities = [],
   learningObjectives,
   courseOutline,
+  trainingPlan,
   sourceMaterials,
   onBack,
 }) => {
@@ -71,6 +72,7 @@ const LearningDesignDocument = ({
         blendModalities,
         learningObjectives,
         courseOutline,
+        trainingPlan,
         sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
       });
       setBaseDocument(data.document);
@@ -413,8 +415,9 @@ LearningDesignDocument.propTypes = {
   projectConstraints: PropTypes.string.isRequired,
   selectedModality: PropTypes.string.isRequired,
   blendModalities: PropTypes.array,
-  learningObjectives: PropTypes.object.isRequired,
-  courseOutline: PropTypes.string.isRequired,
+  learningObjectives: PropTypes.object,
+  courseOutline: PropTypes.string,
+  trainingPlan: PropTypes.string,
   sourceMaterials: PropTypes.array.isRequired,
   onBack: PropTypes.func.isRequired,
 };

--- a/src/components/PersonaDisplay.jsx
+++ b/src/components/PersonaDisplay.jsx
@@ -86,7 +86,11 @@ function PersonaDisplay({ persona, personaQualities, onUpdate, onRegenerate }) {
       </div>
       <div className="persona-bottom-row">
         <EditableField
-          label="Learning Preferences"
+          label={`Learning Preferences${
+            persona.learningPreferencesKeyword
+              ? ` - ${persona.learningPreferencesKeyword}`
+              : ""
+          }`}
           value={persona.learningPreferences}
           onSave={(v) => onUpdate("learningPreferences", v)}
           onRegenerate={() => onRegenerate("learningPreferences")}
@@ -96,7 +100,9 @@ function PersonaDisplay({ persona, personaQualities, onUpdate, onRegenerate }) {
           divider
         />
         <EditableField
-          label="Motivation"
+          label={`Motivation${
+            persona.motivation?.keyword ? ` - ${persona.motivation.keyword}` : ""
+          }`}
           value={persona.motivation?.text || ""}
           onSave={(v) =>
             onUpdate("motivation", { ...persona.motivation, text: v })
@@ -108,7 +114,9 @@ function PersonaDisplay({ persona, personaQualities, onUpdate, onRegenerate }) {
           divider
         />
         <EditableField
-          label="Challenges"
+          label={`Challenge${
+            persona.challenges?.keyword ? ` - ${persona.challenges.keyword}` : ""
+          }`}
           value={persona.challenges?.text || ""}
           onSave={(v) =>
             onUpdate("challenges", { ...persona.challenges, text: v })

--- a/src/components/TrainingPlanGenerator.jsx
+++ b/src/components/TrainingPlanGenerator.jsx
@@ -1,0 +1,149 @@
+import { useState, useEffect } from "react";
+import { getFunctions, httpsCallable } from "firebase/functions";
+import { useSearchParams } from "react-router-dom";
+import { app, auth } from "../firebase.js";
+import { saveInitiative } from "../utils/initiatives.js";
+import PropTypes from "prop-types";
+import "./AIToolsGenerators.css";
+
+const TrainingPlanGenerator = ({
+  projectBrief,
+  businessGoal,
+  audienceProfile,
+  projectConstraints,
+  selectedModality,
+  blendModalities = [],
+  sourceMaterials,
+  trainingPlan,
+  setTrainingPlan,
+  onBack,
+  onNext,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const functions = getFunctions(app, "us-central1");
+  const callGenerate = httpsCallable(functions, "generateTrainingPlan");
+  const [searchParams] = useSearchParams();
+  const initiativeId = searchParams.get("initiativeId") || "default";
+
+  useEffect(() => {
+    document.body.classList.toggle("pulsing", loading);
+    return () => document.body.classList.remove("pulsing");
+  }, [loading]);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const prompt = `You are a senior instructional designer. Using the information below, create a blended learning plan. For each selected modality, provide the rationale and recommended topics.\n\nProject Brief: ${projectBrief}\nBusiness Goal: ${businessGoal}\nAudience Profile: ${audienceProfile}\nProject Constraints: ${projectConstraints}\nSelected Approach: ${selectedModality}\nBlended Modalities: ${blendModalities.join(", ")}\nSource Material:\n${sourceMaterials
+        .map((f) => f.content)
+        .join("\n")}`;
+      const { data } = await callGenerate({ prompt });
+      setTrainingPlan(data.trainingPlan || "");
+      const uid = auth.currentUser?.uid;
+      if (uid) {
+        await saveInitiative(uid, initiativeId, { trainingPlan: data.trainingPlan || "" });
+      }
+    } catch (err) {
+      console.error("Error generating training plan:", err);
+      setError(err?.message || "Error generating training plan.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    try {
+      await saveInitiative(uid, initiativeId, { trainingPlan });
+    } catch (err) {
+      console.error("Error saving training plan:", err);
+      setError(err?.message || "Error saving training plan.");
+    }
+  };
+
+  const handleNext = async () => {
+    await handleSave();
+    if (onNext) onNext();
+  };
+
+  return (
+    <div className="initiative-card generator-result">
+      <h3>Training Plan</h3>
+      {!trainingPlan ? (
+        <>
+          <p>
+            Generate a detailed training plan outlining topics for each modality.
+          </p>
+          <div className="button-row">
+            <button
+              type="button"
+              onClick={onBack}
+              className="generator-button back-button"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={loading}
+              className="generator-button next-button"
+            >
+              {loading ? "Generating..." : "Generate Plan"}
+            </button>
+          </div>
+          {error && <p className="generator-error">{error}</p>}
+        </>
+      ) : (
+        <>
+          <textarea
+            className="generator-textarea"
+            value={trainingPlan}
+            onChange={(e) => setTrainingPlan(e.target.value)}
+          />
+          <div className="button-row">
+            <button
+              type="button"
+              onClick={onBack}
+              className="generator-button back-button"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="generator-button save-button"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              className="generator-button next-button"
+            >
+              Next
+            </button>
+          </div>
+          {error && <p className="generator-error">{error}</p>}
+        </>
+      )}
+    </div>
+  );
+};
+
+TrainingPlanGenerator.propTypes = {
+  projectBrief: PropTypes.string.isRequired,
+  businessGoal: PropTypes.string.isRequired,
+  audienceProfile: PropTypes.string.isRequired,
+  projectConstraints: PropTypes.string.isRequired,
+  selectedModality: PropTypes.string.isRequired,
+  blendModalities: PropTypes.array,
+  sourceMaterials: PropTypes.array.isRequired,
+  trainingPlan: PropTypes.string.isRequired,
+  setTrainingPlan: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+  onNext: PropTypes.func.isRequired,
+};
+
+export default TrainingPlanGenerator;

--- a/src/utils/personas.js
+++ b/src/utils/personas.js
@@ -34,6 +34,13 @@ export async function loadPersonas(uid, initiativeId) {
     techProficiencyOptions: [],
     learningPreferencesOptions: [],
     learningPreferenceOptionKeywords: [],
+    motivations: [],
+    motivation: null,
+    motivationOptions: [],
+    challengesList: [],
+    challenges: null,
+    challengeOptions: [],
+    avatar: null,
     ...d.data(),
   }));
 }
@@ -70,6 +77,13 @@ export async function savePersona(uid, initiativeId, persona) {
     techProficiencyOptions: [],
     learningPreferencesOptions: [],
     learningPreferenceOptionKeywords: [],
+    motivations: [],
+    motivation: null,
+    motivationOptions: [],
+    challengesList: [],
+    challenges: null,
+    challengeOptions: [],
+    avatar: null,
   };
   await callable({ initiativeId, personaId, persona: { ...defaults, ...persona } });
   return personaId;


### PR DESCRIPTION
## Summary
- ensure persona motivation and challenge fields persist by expanding saved defaults
- insert training plan step after approach selection and reorganize subsequent steps
- allow learning design document generation without objectives/outline and include training plan

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e2be462a4832babdb51032cc29002