### PR TITLE
feat: enhance clarifying questions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -470,13 +470,19 @@ export const generateProjectBrief = onCall(
       model: gemini("gemini-1.5-pro"),
     });
 
-    const contactsInfo = Array.isArray(keyContacts) && keyContacts.length
-      ? `\nKey Contacts: ${keyContacts.map((c) => `${c.name} (${c.role})`).join("; ")}`
-      : "";
-    const promptTemplate = `You are an expert Performance Consultant and Business Analyst. Using the information provided, create a project brief written in a clear, narrative style like a blog post, using distinct paragraphs for readability. Also list any questions that require clarification before moving forward.
+    const contactsInfo =
+      Array.isArray(keyContacts) && keyContacts.length
+        ? `\nKey Contacts: ${keyContacts
+            .map((c) => `${c.name} (${c.role})`)
+            .join("; ")}`
+        : "";
+    const promptTemplate =
+      `You are an expert Performance Consultant and Business Analyst. Using the information provided, create a project brief written in a clear, narrative style like a blog post, using distinct paragraphs for readability. Also list any questions that require clarification before moving forward. For each question, suggest the primary stakeholder roles that should be consulted and assign the question to one of these phases: "The Core Problem & Vision", "The Current State", or "The Project Constraints".
 Return a valid JSON object with the structure:{
   "projectBrief": "text of the brief",
-  "clarifyingQuestions": ["question1", "question2"]
+  "clarifyingQuestions": [
+    {"question":"text","stakeholders":["role1","role2"],"phase":"The Core Problem & Vision"}
+  ]
 }
 Do not include any code fences or additional formatting.
 
@@ -566,7 +572,9 @@ export const generateLearningStrategy = onCall(
 }`;
 
     const clarificationsBlock = (() => {
-      const pairs = clarifyingQuestions.map((q, i) => `Q: ${q}\nA: ${clarifyingAnswers[i] || ""}`);
+      const pairs = clarifyingQuestions.map(
+        (q, i) => `Q: ${q?.question || q}\nA: ${clarifyingAnswers[i] || ""}`
+      );
       return pairs.length ? `\nClarifications:\n${pairs.join("\n")}` : "";
     })();
 

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -305,11 +305,16 @@ const InitiativesNew = () => {
   const [clarifyingQuestions, setClarifyingQuestions] = useState([]);
   const [clarifyingAnswers, setClarifyingAnswers] = useState([]);
   const [questionPage, setQuestionPage] = useState(0);
-  const QUESTIONS_PER_PAGE = 3;
-  const totalQuestionPages = Math.max(
-    1,
-    Math.ceil(clarifyingQuestions.length / QUESTIONS_PER_PAGE)
+  const DEFAULT_PHASES = [
+    "The Core Problem & Vision",
+    "The Current State",
+    "The Project Constraints",
+  ];
+  const phases = DEFAULT_PHASES.filter((phase) =>
+    clarifyingQuestions.some((q) => q.phase === phase)
   );
+  const currentPhase = phases[questionPage];
+  const totalQuestionPages = Math.max(1, phases.length);
   const isFirstQuestionPage = questionPage === 0;
   const isLastQuestionPage = questionPage >= totalQuestionPages - 1;
 
@@ -612,7 +617,12 @@ const InitiativesNew = () => {
           );
           setProjectConstraints(data.projectConstraints || "");
           setProjectBrief(data.projectBrief || "");
-          const qs = (data.clarifyingQuestions || []).slice(0, 9);
+          const qsRaw = (data.clarifyingQuestions || []).slice(0, 9);
+          const qs = qsRaw.map((q) =>
+            typeof q === "string"
+              ? { question: q, stakeholders: [], phase: "General" }
+              : q
+          );
           const ans = (data.clarifyingAnswers || []).slice(0, 9);
           setClarifyingQuestions(qs);
           setClarifyingAnswers(qs.map((_, i) => ans[i] || ""));
@@ -863,7 +873,12 @@ const InitiativesNew = () => {
         keyContacts,
       });
 
-      const qs = (data.clarifyingQuestions || []).slice(0, 9);
+      const qsRaw = (data.clarifyingQuestions || []).slice(0, 9);
+      const qs = qsRaw.map((q) =>
+        typeof q === "string"
+          ? { question: q, stakeholders: [], phase: "General" }
+          : q
+      );
       setClarifyingQuestions(qs);
       setClarifyingAnswers(qs.map(() => ""));
       setQuestionPage(0);
@@ -1493,27 +1508,26 @@ const InitiativesNew = () => {
           <p className="page-indicator">
             Page {questionPage + 1} of {totalQuestionPages}
           </p>
+          <h4>{currentPhase}</h4>
           {clarifyingQuestions
-            .slice(
-              questionPage * QUESTIONS_PER_PAGE,
-              questionPage * QUESTIONS_PER_PAGE + QUESTIONS_PER_PAGE
-            )
-            .map((q, idx) => {
-              const overallIdx = questionPage * QUESTIONS_PER_PAGE + idx;
-              return (
-                <div key={overallIdx}>
-                  <p>{q}</p>
-                  <textarea
-                    className="generator-input clarify-textarea"
-                    value={clarifyingAnswers[overallIdx] || ""}
-                    onChange={(e) =>
-                      handleAnswerChange(overallIdx, e.target.value)
-                    }
-                    rows={3}
-                  />
-                </div>
-              );
-            })}
+            .map((q, idx) => ({ q, idx }))
+            .filter(({ q }) => q.phase === currentPhase)
+            .map(({ q, idx }) => (
+              <div key={idx}>
+                <p>{q.question}</p>
+                {q.stakeholders && q.stakeholders.length > 0 && (
+                  <p className="suggested-audience">
+                    Suggested Audience: {q.stakeholders.join(", ")}
+                  </p>
+                )}
+                <textarea
+                  className="generator-input clarify-textarea"
+                  value={clarifyingAnswers[idx] || ""}
+                  onChange={(e) => handleAnswerChange(idx, e.target.value)}
+                  rows={3}
+                />
+              </div>
+            ))}
           <p className="page-indicator">
             Page {questionPage + 1} of {totalQuestionPages}
           </p>


### PR DESCRIPTION
## Summary
- extend project brief prompt to output clarifying questions with stakeholder roles and phase categories
- group clarifying questions by phase in the UI and display suggested audiences
- ensure learning strategy generation consumes question objects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f45f0a8bc832b99af0894c469e164