### PR TITLE
Revamp dashboard with projects card

### DIFF
--- a/src/components/CustomDashboard.css
+++ b/src/components/CustomDashboard.css
@@ -1,50 +1,48 @@
 .dashboard-container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 20px;
-    background: #f5f5f568;
-    border-radius: 8px;
-    text-align: center;
-  }
-  
-  .todo-list {
-    margin-top: 20px;
-  }
-  
-  .todo-list ul {
-    list-style: none;
-    padding: 0;
-  }
-  
-  .todo-list li {
-    background: #8c259e;
-    color: #fff;
-    padding: 10px;
-    margin-bottom: 10px;
-    cursor: pointer;
-    border-radius: 4px;
-    transition: background 0.3s;
-  }
-  
-.todo-list li:hover {
-  background: #a742b2;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 100px 20px 20px;
 }
 
-.ai-tools-access {
-  margin-top: 20px;
+.projects-card h2 {
+  margin-top: 0;
 }
 
-.ai-tools-button {
-  background: #007bff;
+.project-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.project-list li {
+  margin-bottom: 0.5rem;
+}
+
+.project-list a {
+  text-decoration: none;
+  color: inherit;
+  font-weight: 500;
+}
+
+.new-project-button {
+  margin-top: 1rem;
+  background: rgba(140, 37, 158, 0.2);
+  border: 1px solid rgba(140, 37, 158, 0.5);
   color: #fff;
   padding: 10px 20px;
-  border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: background 0.3s;
+  font-weight: 600;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: background 0.3s ease;
 }
 
-.ai-tools-button:hover {
-  background: #0056b3;
+.new-project-button:hover {
+  background: rgba(140, 37, 158, 0.35);
 }
-  
+
+.no-projects {
+  margin: 1rem 0;
+}
+

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,9 +1,21 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../firebase";
 
 // src/components/NavBar.jsx
 // Updated header component using glass effect and profile actions
 
 const NavBar = () => {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setLoggedIn(!!user);
+    });
+    return () => unsubscribe();
+  }, []);
+
   return (
     <header className="glass-header">
       <nav className="nav-container">
@@ -30,7 +42,7 @@ const NavBar = () => {
         </div>
 
         <div className="nav-links">
-          <Link to="/" className="nav-link active">
+          <Link to={loggedIn ? "/dashboard" : "/"} className="nav-link active">
             Home
           </Link>
           <Link to="/ai-tools" className="nav-link">


### PR DESCRIPTION
## Summary
- Position dashboard below fixed header and reuse initiative card styling for Projects
- Add purple glass effect to "Start New Project" button
- Import initiative styles and drop unused glass card

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f825cb0a8832b8e5d436a6e5a4297