### PR TITLE
Revamp dashboard and launch discovery hub

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,8 @@ import InitiativesNew from "./components/InitiativesNew";
 import InitiativesList from "./components/InitiativesList";
 import LeadershipAssessmentWizard from "./components/LeadershipAssessmentWizard";
 import CustomDashboard from "./components/CustomDashboard";
+import ProjectSetup from "./components/ProjectSetup";
+import DiscoveryHub from "./components/DiscoveryHub";
 import ComingSoonPage from "./pages/ComingSoonPage";
 import Login from "./components/Login";
 import NavBar from "./components/NavBar";
@@ -82,6 +84,14 @@ export default function App() {
           }
         />
         <Route path="/dashboard" element={<CustomDashboard />} />
+        <Route
+          path="/project-setup"
+          element={user ? <ProjectSetup /> : <Navigate to="/login" />}
+        />
+        <Route
+          path="/discovery"
+          element={user ? <DiscoveryHub /> : <Navigate to="/login" />}
+        />
         <Route path="/settings" element={<Settings />} />
         <Route
           path="/leadership-assessment"

--- a/src/components/CustomDashboard.css
+++ b/src/components/CustomDashboard.css
@@ -1,50 +1,49 @@
 .dashboard-container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 20px;
-    background: #f5f5f568;
-    border-radius: 8px;
-    text-align: center;
-  }
-  
-  .todo-list {
-    margin-top: 20px;
-  }
-  
-  .todo-list ul {
-    list-style: none;
-    padding: 0;
-  }
-  
-  .todo-list li {
-    background: #8c259e;
-    color: #fff;
-    padding: 10px;
-    margin-bottom: 10px;
-    cursor: pointer;
-    border-radius: 4px;
-    transition: background 0.3s;
-  }
-  
-.todo-list li:hover {
-  background: #a742b2;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 100px 20px 20px;
+  background: transparent;
 }
 
-.ai-tools-access {
-  margin-top: 20px;
+.projects-card h2 {
+  margin-top: 0;
 }
 
-.ai-tools-button {
-  background: #007bff;
+.project-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.project-list li {
+  margin-bottom: 0.5rem;
+}
+
+.project-list a {
+  text-decoration: none;
+  color: inherit;
+  font-weight: 500;
+}
+
+.new-project-button {
+  margin-top: 1rem;
+  background: rgba(140, 37, 158, 0.2);
+  border: 1px solid rgba(140, 37, 158, 0.5);
   color: #fff;
   padding: 10px 20px;
-  border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: background 0.3s;
+  font-weight: 600;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: background 0.3s ease;
 }
 
-.ai-tools-button:hover {
-  background: #0056b3;
+.new-project-button:hover {
+  background: rgba(140, 37, 158, 0.35);
 }
-  
+
+.no-projects {
+  margin: 1rem 0;
+}
+

--- a/src/components/CustomDashboard.jsx
+++ b/src/components/CustomDashboard.jsx
@@ -1,7 +1,7 @@
 // src/CustomDashboard.jsx
 
 import { useEffect, useState } from "react";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import {
   getFirestore,
   collection,
@@ -12,18 +12,21 @@ import {
   getDoc,
   setDoc,
 } from "firebase/firestore";
-import { onAuthStateChanged, signOut } from "firebase/auth";
+import { onAuthStateChanged } from "firebase/auth";
 import { app, auth } from "../firebase";
 import AccountCreation from "./AccountCreation";
+import { loadInitiatives } from "../utils/initiatives";
+import "./AIToolsGenerators.css";
 import "./CustomDashboard.css";
 
 const CustomDashboard = () => {
   const [searchParams] = useSearchParams();
   const invitationCode = searchParams.get("invite");
-  const [displayName, setDisplayName] = useState("");
+  const [, setDisplayName] = useState("");
   const [dataLoaded, setDataLoaded] = useState(false);
   const [error, setError] = useState("");
   const [userLoggedIn, setUserLoggedIn] = useState(false);
+  const [initiatives, setInitiatives] = useState([]);
   const navigate = useNavigate();
   const db = getFirestore(app);
 
@@ -98,20 +101,18 @@ const CustomDashboard = () => {
           console.error("Error fetching invitation or profile data:", err);
           setError("Error fetching invitation or profile data.");
         }
+        const uid = user.uid;
+        try {
+          const data = await loadInitiatives(uid);
+          setInitiatives(data);
+        } catch (loadErr) {
+          console.error("Error loading initiatives:", loadErr);
+        }
         setDataLoaded(true);
       }
     });
     return () => unsubscribe();
   }, [invitationCode, db]);
-
-  const handleLogout = async () => {
-    try {
-      await signOut(auth);
-      navigate("/login");
-    } catch (error) {
-      console.error("Error signing out:", error);
-    }
-  };
 
   if (!dataLoaded) {
     return (
@@ -134,29 +135,30 @@ const CustomDashboard = () => {
     return <AccountCreation />;
   }
 
+  const handleNewProject = () => {
+    const newId = crypto.randomUUID();
+    navigate(`/project-setup?initiativeId=${newId}`);
+  };
+
   return (
     <div className="dashboard-container">
-      <header className="dashboard-header" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <h1>Welcome, {displayName}</h1>
-        <button onClick={handleLogout} className="logout-button">
-          Logout
-        </button>
-      </header>
-      <div className="todo-list">
-        <h3>To-Do List</h3>
-        <ul>
-          <li onClick={() => navigate("/leadership-assessment")}>
-            Complete Training Needs Assessment
-          </li>
-          {/* Additional to-do items can be added here */}
-        </ul>
-      </div>
-      <div className="ai-tools-access">
-        <button
-          onClick={() => navigate("/ai-tools")}
-          className="ai-tools-button"
-        >
-          Go to AI Tools
+      <div className="initiative-card projects-card">
+        <h2>Projects</h2>
+        {initiatives.length > 0 ? (
+          <ul className="project-list">
+            {initiatives.map((init) => (
+              <li key={init.id}>
+                <Link to={`/discovery?initiativeId=${init.id}`}>
+                  {init.projectName || init.businessGoal || init.id}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="no-projects">No projects yet.</p>
+        )}
+        <button onClick={handleNewProject} className="new-project-button">
+          Start New Project
         </button>
       </div>
     </div>

--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -1,0 +1,22 @@
+.discovery-hub .columns {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.discovery-hub .column {
+  flex: 1;
+}
+
+.question-card {
+  margin-bottom: 1rem;
+}
+
+.question-card.answered {
+  background: rgba(0, 128, 0, 0.1);
+}
+
+.question-card .answer {
+  white-space: pre-wrap;
+}
+

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../firebase";
+import { loadInitiative, saveInitiative } from "../utils/initiatives";
+import "./AIToolsGenerators.css";
+import "./DiscoveryHub.css";
+
+const DiscoveryHub = () => {
+  const [searchParams] = useSearchParams();
+  const initiativeId = searchParams.get("initiativeId");
+  const [questions, setQuestions] = useState([]);
+  const [uid, setUid] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        setUid(user.uid);
+        if (initiativeId) {
+          const init = await loadInitiative(user.uid, initiativeId);
+          const qs = (init?.clarifyingQuestions || []).map((q, idx) => ({
+            ...q,
+            answer: init?.clarifyingAnswers?.[idx] || "",
+            status: init?.clarifyingAnswers?.[idx] ? "answered" : "toask",
+          }));
+          setQuestions(qs);
+        }
+        setLoaded(true);
+      } else {
+        setLoaded(true);
+      }
+    });
+    return () => unsubscribe();
+  }, [initiativeId]);
+
+  const updateAnswer = (idx, value) => {
+    setQuestions((prev) => {
+      const updated = [...prev];
+      updated[idx].answer = value;
+      updated[idx].status = value ? "answered" : updated[idx].status;
+      return updated;
+    });
+    if (uid) {
+      const answers = questions.map((q, i) => (i === idx ? value : q.answer));
+      saveInitiative(uid, initiativeId, { clarifyingAnswers: answers });
+    }
+  };
+
+  const markAsked = (idx) => {
+    setQuestions((prev) => {
+      const updated = [...prev];
+      updated[idx].status = "asked";
+      return updated;
+    });
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(questions[idx].question);
+    }
+  };
+
+  if (!loaded) {
+    return (
+      <div className="dashboard-container">
+        <h2>Loading...</h2>
+      </div>
+    );
+  }
+
+  const toAsk = questions.filter((q) => q.status === "toask");
+  const asked = questions.filter((q) => q.status === "asked" && !q.answer);
+  const answered = questions.filter((q) => q.answer);
+
+  return (
+    <div className="dashboard-container discovery-hub">
+      <h2>Discovery Hub</h2>
+      <div className="columns">
+        <div className="column">
+          <h3>To Ask</h3>
+          {toAsk.map((q, idx) => (
+            <div key={idx} className="initiative-card question-card">
+              <p>{q.question}</p>
+              <button className="generator-button" onClick={() => markAsked(questions.indexOf(q))}>
+                Ask
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="column">
+          <h3>Asked</h3>
+          {asked.map((q, idx) => {
+            const qIndex = questions.indexOf(q);
+            return (
+              <div key={idx} className="initiative-card question-card">
+                <p>{q.question}</p>
+                <textarea
+                  className="generator-input"
+                  placeholder="Paste Answer/Notes Here"
+                  value={q.answer}
+                  onChange={(e) => updateAnswer(qIndex, e.target.value)}
+                  rows={3}
+                />
+              </div>
+            );
+          })}
+        </div>
+        <div className="column">
+          <h3>Answered</h3>
+          {answered.map((q, idx) => (
+            <div key={idx} className="initiative-card question-card answered">
+              <p>{q.question}</p>
+              <p className="answer">{q.answer}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DiscoveryHub;
+

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,9 +1,21 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../firebase";
 
 // src/components/NavBar.jsx
 // Updated header component using glass effect and profile actions
 
 const NavBar = () => {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setLoggedIn(!!user);
+    });
+    return () => unsubscribe();
+  }, []);
+
   return (
     <header className="glass-header">
       <nav className="nav-container">
@@ -30,7 +42,7 @@ const NavBar = () => {
         </div>
 
         <div className="nav-links">
-          <Link to="/" className="nav-link active">
+          <Link to={loggedIn ? "/dashboard" : "/"} className="nav-link active">
             Home
           </Link>
           <Link to="/ai-tools" className="nav-link">

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -1,0 +1,324 @@
+import { useState } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { getFunctions, httpsCallable } from "firebase/functions";
+import { app, auth } from "../firebase";
+import { saveInitiative } from "../utils/initiatives";
+import "./AIToolsGenerators.css";
+
+const ProjectSetup = () => {
+  const [searchParams] = useSearchParams();
+  const initiativeId = searchParams.get("initiativeId");
+  const navigate = useNavigate();
+
+  const functions = getFunctions(app, "us-central1");
+  const generateClarifyingQuestions = httpsCallable(
+    functions,
+    "generateClarifyingQuestions"
+  );
+
+  const [projectName, setProjectName] = useState("");
+  const [businessGoal, setBusinessGoal] = useState("");
+  const [audienceProfile, setAudienceProfile] = useState("");
+  const [projectConstraints, setProjectConstraints] = useState("");
+  const [keyContacts, setKeyContacts] = useState([{ name: "", role: "" }]);
+  const [sourceMaterials, setSourceMaterials] = useState([]);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const getCombinedSource = () =>
+    sourceMaterials.map((f) => f.content).join("\n");
+
+  const extractTextFromPdf = async (buffer) => {
+    const BASE = "https://cdn.jsdelivr.net/npm/pdfjs-dist@5.4.54";
+    const pdfjs = await import(
+      /* @vite-ignore */
+      `${BASE}/build/pdf.mjs`
+    );
+    pdfjs.GlobalWorkerOptions.workerSrc = `${BASE}/build/pdf.worker.mjs`;
+    const pdf = await pdfjs.getDocument({ data: buffer }).promise;
+    let text = "";
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const content = await page.getTextContent();
+      text += content.items.map((item) => item.str).join(" ") + "\n";
+    }
+    return text.trim();
+  };
+
+  const extractTextFromDocx = async (buffer) => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.DecompressionStream === "undefined"
+    )
+      return "";
+    const view = new DataView(buffer);
+    const decoder = new TextDecoder();
+    let offset = buffer.byteLength - 22;
+    while (offset >= 0 && view.getUint32(offset, true) !== 0x06054b50) {
+      offset--;
+    }
+    if (offset < 0) return "";
+    const entries = view.getUint16(offset + 8, true);
+    const cdOffset = view.getUint32(offset + 16, true);
+    offset = cdOffset;
+    for (let i = 0; i < entries; i++) {
+      if (view.getUint32(offset, true) !== 0x02014b50) break;
+      const nameLen = view.getUint16(offset + 28, true);
+      const extraLen = view.getUint16(offset + 30, true);
+      const commentLen = view.getUint16(offset + 32, true);
+      const localOffset = view.getUint32(offset + 42, true);
+      const name = decoder.decode(
+        new Uint8Array(buffer, offset + 46, nameLen)
+      );
+      if (name === "word/document.xml") {
+        const lhNameLen = view.getUint16(localOffset + 26, true);
+        const lhExtraLen = view.getUint16(localOffset + 28, true);
+        const compSize = view.getUint32(localOffset + 18, true);
+        const dataStart = localOffset + 30 + lhNameLen + lhExtraLen;
+        const compressed = buffer.slice(dataStart, dataStart + compSize);
+        const ds = new window.DecompressionStream("deflate-raw");
+        const stream = new Response(new Blob([compressed]).stream().pipeThrough(ds));
+        const xml = await stream.text();
+        return xml
+          .replace(/<w:p[^>]*>/g, "\n")
+          .replace(/<[^>]+>/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+      }
+      offset += 46 + nameLen + extraLen + commentLen;
+    }
+    return "";
+  };
+
+  const handleFiles = async (files) => {
+    for (const file of Array.from(files)) {
+      try {
+        if (file.name.toLowerCase().endsWith(".pdf")) {
+          const buffer = await file.arrayBuffer();
+          let text = await extractTextFromPdf(buffer);
+          if (!text) text = await file.text();
+          setSourceMaterials((prev) => [...prev, { name: file.name, content: text }]);
+        } else if (file.name.toLowerCase().endsWith(".docx")) {
+          const buffer = await file.arrayBuffer();
+          const text = await extractTextFromDocx(buffer);
+          setSourceMaterials((prev) => [...prev, { name: file.name, content: text }]);
+        } else {
+          const text = await file.text();
+          setSourceMaterials((prev) => [...prev, { name: file.name, content: text }]);
+        }
+      } catch (err) {
+        console.error("Failed to read file", err);
+        setError(`Failed to process ${file.name}`);
+      }
+    }
+  };
+
+  const handleFileInput = (e) => {
+    const { files } = e.target;
+    if (files) handleFiles(files);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    if (e.dataTransfer.files) handleFiles(e.dataTransfer.files);
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+  };
+
+  const removeFile = (index) => {
+    setSourceMaterials((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleContactChange = (index, field, value) => {
+    setKeyContacts((prev) => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const addKeyContact = () => {
+    setKeyContacts((prev) => [...prev, { name: "", role: "" }]);
+  };
+
+  const removeKeyContact = (index) => {
+    setKeyContacts((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const { data } = await generateClarifyingQuestions({
+        businessGoal,
+        audienceProfile,
+        sourceMaterial: getCombinedSource(),
+        projectConstraints,
+        keyContacts,
+      });
+      const qsRaw = (data.clarifyingQuestions || []).slice(0, 9);
+      const qs = qsRaw.map((q) =>
+        typeof q === "string" ? { question: q, stakeholders: [], phase: "General" } : q
+      );
+      const uid = auth.currentUser?.uid;
+      if (uid) {
+        await saveInitiative(uid, initiativeId, {
+          projectName,
+          businessGoal,
+          audienceProfile,
+          sourceMaterials,
+          projectConstraints,
+          keyContacts,
+          clarifyingQuestions: qs,
+          clarifyingAnswers: qs.map(() => ""),
+        });
+      }
+      navigate(`/discovery?initiativeId=${initiativeId}`);
+    } catch (err) {
+      console.error("Error generating clarifying questions:", err);
+      setError(err?.message || "Error generating clarifying questions.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="dashboard-container">
+      <div className={`initiative-card ${loading ? "pulsing" : ""}`}>
+        <form onSubmit={handleSubmit} className="generator-form">
+          <h3>Project Intake</h3>
+          <p>Tell us about your project. The more detail, the better.</p>
+          <div className="intake-grid">
+            <div className="intake-left">
+              <label>
+                Project Name
+                <input
+                  type="text"
+                  value={projectName}
+                  placeholder="e.g., 'Q3 Sales Onboarding'"
+                  onChange={(e) => setProjectName(e.target.value)}
+                  className="generator-input"
+                />
+              </label>
+              <label>
+                What is the primary business goal?
+                <input
+                  type="text"
+                  value={businessGoal}
+                  placeholder="e.g., 'Reduce support tickets for Product X by 20%'"
+                  onChange={(e) => setBusinessGoal(e.target.value)}
+                  className="generator-input"
+                />
+              </label>
+              <label>
+                Who is the target audience?
+                <textarea
+                  value={audienceProfile}
+                  placeholder="e.g., 'New sales hires, age 22-28, with no prior industry experience'"
+                  onChange={(e) => setAudienceProfile(e.target.value)}
+                  className="generator-input"
+                  rows={3}
+                />
+              </label>
+              <div className="contacts-section">
+                <p>Key Contacts</p>
+                {keyContacts.map((c, idx) => (
+                  <div key={idx} className="contact-row">
+                    <input
+                      type="text"
+                      value={c.name}
+                      placeholder="Name"
+                      onChange={(e) => handleContactChange(idx, "name", e.target.value)}
+                      className="generator-input"
+                    />
+                    <input
+                      type="text"
+                      value={c.role}
+                      placeholder="Role"
+                      onChange={(e) => handleContactChange(idx, "role", e.target.value)}
+                      className="generator-input"
+                    />
+                    {keyContacts.length > 1 && (
+                      <button
+                        type="button"
+                        className="remove-file"
+                        onClick={() => removeKeyContact(idx)}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  className="generator-button add-contact-button"
+                  onClick={addKeyContact}
+                >
+                  +
+                </button>
+              </div>
+              <label>
+                Project Constraints or Limitations
+                <textarea
+                  value={projectConstraints}
+                  onChange={(e) => setProjectConstraints(e.target.value)}
+                  className="generator-input"
+                  rows={3}
+                />
+              </label>
+            </div>
+            <div
+              className="upload-card"
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+            >
+              <input
+                type="file"
+                onChange={handleFileInput}
+                className="file-input"
+                accept=".pdf,.docx,.txt"
+                multiple
+              />
+              <div className="upload-title">Upload Source Material (Optional)</div>
+              <div className="upload-subtitle">Click to upload or drag and drop</div>
+              <div className="upload-hint">PDF, DOCX, TXT (MAX. 10MB)</div>
+              {sourceMaterials.length > 0 && (
+                <ul className="file-list">
+                  {sourceMaterials.map((f, idx) => (
+                    <li key={idx}>
+                      {f.name}
+                      <button
+                        type="button"
+                        className="remove-file"
+                        onClick={() => removeFile(idx)}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+          <div className="button-row">
+            <button
+              type="submit"
+              disabled={loading}
+              className="generator-button next-button"
+            >
+              {loading ? "Analyzing..." : "Next"}
+            </button>
+          </div>
+          {error && <p className="generator-error">{error}</p>}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectSetup;
+


### PR DESCRIPTION
## Summary
- Remove dashboard background and show project names linking to Discovery Hub
- Add standalone Project Setup screen based on the first initiative step
- Introduce Discovery Hub with Kanban-style question tracking

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f825cb0a8832b8e5d436a6e5a4297