### PR TITLE
Revamp dashboard and launch discovery hub

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,8 @@ import InitiativesNew from "./components/InitiativesNew";
 import InitiativesList from "./components/InitiativesList";
 import LeadershipAssessmentWizard from "./components/LeadershipAssessmentWizard";
 import CustomDashboard from "./components/CustomDashboard";
+import ProjectSetup from "./components/ProjectSetup";
+import DiscoveryHub from "./components/DiscoveryHub";
 import ComingSoonPage from "./pages/ComingSoonPage";
 import Login from "./components/Login";
 import NavBar from "./components/NavBar";
@@ -82,6 +84,14 @@ export default function App() {
           }
         />
         <Route path="/dashboard" element={<CustomDashboard />} />
+        <Route
+          path="/project-setup"
+          element={user ? <ProjectSetup /> : <Navigate to="/login" />}
+        />
+        <Route
+          path="/discovery"
+          element={user ? <DiscoveryHub /> : <Navigate to="/login" />}
+        />
         <Route path="/settings" element={<Settings />} />
         <Route
           path="/leadership-assessment"

--- a/src/components/CustomDashboard.css
+++ b/src/components/CustomDashboard.css
@@ -1,50 +1,67 @@
 .dashboard-container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 20px;
-    background: #f5f5f568;
-    border-radius: 8px;
-    text-align: center;
-  }
-  
-  .todo-list {
-    margin-top: 20px;
-  }
-  
-  .todo-list ul {
-    list-style: none;
-    padding: 0;
-  }
-  
-  .todo-list li {
-    background: #8c259e;
-    color: #fff;
-    padding: 10px;
-    margin-bottom: 10px;
-    cursor: pointer;
-    border-radius: 4px;
-    transition: background 0.3s;
-  }
-  
-.todo-list li:hover {
-  background: #a742b2;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 100px 20px 20px;
+  background: transparent;
 }
 
-.ai-tools-access {
-  margin-top: 20px;
+.projects-card h2 {
+  margin-top: 0;
 }
 
-.ai-tools-button {
-  background: #007bff;
+.project-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.project-list li {
+  margin-bottom: 0.5rem;
+}
+
+.project-list a {
+  text-decoration: none;
+  color: inherit;
+  font-weight: 500;
+}
+
+.project-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.project-actions button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+
+.project-actions button:hover {
+  text-decoration: underline;
+}
+
+.new-project-button {
+  margin-top: 1rem;
+  background: rgba(140, 37, 158, 0.2);
+  border: 1px solid rgba(140, 37, 158, 0.5);
   color: #fff;
   padding: 10px 20px;
-  border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: background 0.3s;
+  font-weight: 600;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: background 0.3s ease;
 }
 
-.ai-tools-button:hover {
-  background: #0056b3;
+.new-project-button:hover {
+  background: rgba(140, 37, 158, 0.35);
 }
-  
+
+.no-projects {
+  margin: 1rem 0;
+}
+

--- a/src/components/CustomDashboard.jsx
+++ b/src/components/CustomDashboard.jsx
@@ -1,7 +1,7 @@
 // src/CustomDashboard.jsx
 
 import { useEffect, useState } from "react";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import {
   getFirestore,
   collection,
@@ -12,18 +12,25 @@ import {
   getDoc,
   setDoc,
 } from "firebase/firestore";
-import { onAuthStateChanged, signOut } from "firebase/auth";
+import { onAuthStateChanged } from "firebase/auth";
 import { app, auth } from "../firebase";
 import AccountCreation from "./AccountCreation";
+import {
+  loadInitiatives,
+  deleteInitiative,
+} from "../utils/initiatives";
+import "./AIToolsGenerators.css";
 import "./CustomDashboard.css";
 
 const CustomDashboard = () => {
   const [searchParams] = useSearchParams();
   const invitationCode = searchParams.get("invite");
-  const [displayName, setDisplayName] = useState("");
+  const [, setDisplayName] = useState("");
   const [dataLoaded, setDataLoaded] = useState(false);
   const [error, setError] = useState("");
   const [userLoggedIn, setUserLoggedIn] = useState(false);
+  const [initiatives, setInitiatives] = useState([]);
+  const [uid, setUid] = useState(null);
   const navigate = useNavigate();
   const db = getFirestore(app);
 
@@ -51,6 +58,7 @@ const CustomDashboard = () => {
         setDataLoaded(true);
       } else {
         setUserLoggedIn(true);
+        setUid(user.uid);
         try {
           if (invitationCode) {
             // Try to fetch the invitation document by invitationCode.
@@ -98,20 +106,18 @@ const CustomDashboard = () => {
           console.error("Error fetching invitation or profile data:", err);
           setError("Error fetching invitation or profile data.");
         }
+        const userId = user.uid;
+        try {
+          const data = await loadInitiatives(userId);
+          setInitiatives(data);
+        } catch (loadErr) {
+          console.error("Error loading initiatives:", loadErr);
+        }
         setDataLoaded(true);
       }
     });
     return () => unsubscribe();
   }, [invitationCode, db]);
-
-  const handleLogout = async () => {
-    try {
-      await signOut(auth);
-      navigate("/login");
-    } catch (error) {
-      console.error("Error signing out:", error);
-    }
-  };
 
   if (!dataLoaded) {
     return (
@@ -134,29 +140,49 @@ const CustomDashboard = () => {
     return <AccountCreation />;
   }
 
+  const handleNewProject = () => {
+    const newId = crypto.randomUUID();
+    navigate(`/project-setup?initiativeId=${newId}`);
+  };
+
+  const handleEdit = (id) => {
+    navigate(`/project-setup?initiativeId=${id}`);
+  };
+
+  const handleDelete = async (id) => {
+    if (!uid) return;
+    if (!window.confirm("Delete this project?")) return;
+    try {
+      await deleteInitiative(uid, id);
+      setInitiatives((prev) => prev.filter((p) => p.id !== id));
+    } catch (err) {
+      console.error("Failed to delete initiative", err);
+    }
+  };
+
   return (
     <div className="dashboard-container">
-      <header className="dashboard-header" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <h1>Welcome, {displayName}</h1>
-        <button onClick={handleLogout} className="logout-button">
-          Logout
-        </button>
-      </header>
-      <div className="todo-list">
-        <h3>To-Do List</h3>
-        <ul>
-          <li onClick={() => navigate("/leadership-assessment")}>
-            Complete Training Needs Assessment
-          </li>
-          {/* Additional to-do items can be added here */}
-        </ul>
-      </div>
-      <div className="ai-tools-access">
-        <button
-          onClick={() => navigate("/ai-tools")}
-          className="ai-tools-button"
-        >
-          Go to AI Tools
+      <div className="initiative-card projects-card">
+        <h2>Projects</h2>
+        {initiatives.length > 0 ? (
+          <ul className="project-list">
+            {initiatives.map((init) => (
+              <li key={init.id} className="project-item">
+                <Link to={`/discovery?initiativeId=${init.id}`}>
+                  {init.projectName || init.businessGoal || init.id}
+                </Link>
+                <span className="project-actions">
+                  <button onClick={() => handleEdit(init.id)}>Edit</button>
+                  <button onClick={() => handleDelete(init.id)}>Delete</button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="no-projects">No projects yet.</p>
+        )}
+        <button onClick={handleNewProject} className="new-project-button">
+          Start New Project
         </button>
       </div>
     </div>

--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -1,0 +1,180 @@
+.discovery-hub {
+  display: flex;
+  min-height: 100%;
+}
+
+.sidebar {
+  width: 200px;
+  padding: 1rem;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  cursor: pointer;
+  margin: 0.5rem 0;
+}
+
+.sidebar .sub-menu {
+  margin-left: 1rem;
+}
+
+.sidebar li.active {
+  font-weight: bold;
+}
+
+.main-content {
+  flex: 1;
+  padding: 1rem;
+}
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.question-card {
+  margin-bottom: 1rem;
+}
+
+.question-card.answered {
+  background: rgba(0, 128, 0, 0.1);
+}
+
+.question-card .answer {
+  white-space: pre-wrap;
+}
+
+.question-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.status-tag {
+  margin-left: auto;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.contact-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.contact-tag {
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #000;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.contact-select {
+  flex: 1;
+}
+
+.ask-selected {
+  margin-left: auto;
+}
+
+.group-section {
+  margin-bottom: 1rem;
+}
+
+.answer-block {
+  margin-top: 0.5rem;
+}
+
+.contact-tag button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.document-section {
+  max-width: 600px;
+}
+
+.document-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.document-item {
+  position: relative;
+  padding: 0.5rem 2rem 0.5rem 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.doc-actions {
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 0.25rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.document-item:hover .doc-actions {
+  opacity: 1;
+}
+
+.doc-actions button {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 0.8rem;
+}
+
+.drop-zone {
+  border: 2px dashed rgba(255, 255, 255, 0.4);
+  padding: 1rem;
+  text-align: center;
+  border-radius: 6px;
+}
+
+.drop-zone input {
+  display: none;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  max-width: 600px;
+}
+

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -1,0 +1,521 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../firebase";
+import { loadInitiative, saveInitiative } from "../utils/initiatives";
+import "./AIToolsGenerators.css";
+import "./DiscoveryHub.css";
+
+const colorPalette = [
+  "#f8d7da",
+  "#d1ecf1",
+  "#d4edda",
+  "#fff3cd",
+  "#cce5ff",
+  "#e2ccff",
+];
+
+const normalizeContacts = (value) => {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+};
+
+const DiscoveryHub = () => {
+  const [searchParams] = useSearchParams();
+  const initiativeId = searchParams.get("initiativeId");
+  const [questions, setQuestions] = useState([]);
+  const [contacts, setContacts] = useState([]);
+  const [documents, setDocuments] = useState([]);
+  const [contactFilter, setContactFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [groupBy, setGroupBy] = useState("");
+  const [selected, setSelected] = useState([]);
+  const [uid, setUid] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+  const [active, setActive] = useState("questions");
+  const [summary, setSummary] = useState("");
+  const [showSummary, setShowSummary] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        setUid(user.uid);
+        if (initiativeId) {
+          const init = await loadInitiative(user.uid, initiativeId);
+          const contactsInit = (init?.keyContacts || []).map((c, i) => ({
+            ...c,
+            color: colorPalette[i % colorPalette.length],
+          }));
+          setContacts(contactsInit);
+          const qs = (init?.clarifyingQuestions || []).map((q, idx) => {
+            const contactValue =
+              init?.clarifyingContacts?.[idx] ?? q.stakeholders ?? [];
+            return {
+              question: typeof q === "string" ? q : q.question,
+              contacts: normalizeContacts(contactValue),
+              answers: init?.clarifyingAnswers?.[idx] || {},
+              asked: init?.clarifyingAsked?.[idx] || false,
+              id: idx,
+            };
+          });
+          setQuestions(qs);
+          setDocuments(init?.sourceMaterials || []);
+        }
+        setLoaded(true);
+      } else {
+        setLoaded(true);
+      }
+    });
+    return () => unsubscribe();
+  }, [initiativeId]);
+
+  const updateAnswer = (idx, role, value) => {
+    setQuestions((prev) => {
+      const updated = [...prev];
+      const q = updated[idx];
+      q.answers = { ...q.answers, [role]: value };
+      if (uid) {
+        saveInitiative(uid, initiativeId, {
+          clarifyingAnswers: updated.map((qq) => qq.answers),
+        });
+      }
+      return updated;
+    });
+  };
+
+  const addContact = () => {
+    const role = prompt("Contact role?");
+    if (!role) return null;
+    const name = prompt("Contact name? (optional)") || "";
+    const color = colorPalette[contacts.length % colorPalette.length];
+    const newContact = { role, name, color };
+    const updated = [...contacts, newContact];
+    setContacts(updated);
+    if (uid) {
+      saveInitiative(uid, initiativeId, {
+        keyContacts: updated.map(({ name, role }) => ({ name, role })),
+      });
+    }
+    return role;
+  };
+
+  const addContactToQuestion = (idx, role) => {
+    setQuestions((prev) => {
+      const updated = [...prev];
+      const q = updated[idx];
+      if (!q.contacts.includes(role)) {
+        q.contacts = [...q.contacts, role];
+      }
+      if (uid) {
+        saveInitiative(uid, initiativeId, {
+          clarifyingContacts: updated.map((qq) => qq.contacts),
+        });
+      }
+      return updated;
+    });
+  };
+
+  const removeContactFromQuestion = (idx, role) => {
+    setQuestions((prev) => {
+      const updated = [...prev];
+      const q = updated[idx];
+      q.contacts = q.contacts.filter((r) => r !== role);
+      if (q.answers[role]) {
+        delete q.answers[role];
+      }
+      if (uid) {
+        saveInitiative(uid, initiativeId, {
+          clarifyingContacts: updated.map((qq) => qq.contacts),
+          clarifyingAnswers: updated.map((qq) => qq.answers),
+        });
+      }
+      return updated;
+    });
+  };
+
+  const handleContactSelect = (idx, value) => {
+    if (value === "__add__") {
+      const newRole = addContact();
+      if (newRole) addContactToQuestion(idx, newRole);
+    } else if (value) {
+      addContactToQuestion(idx, value);
+    }
+  };
+
+  const markAsked = (idxs) => {
+    const indices = Array.isArray(idxs) ? idxs : [idxs];
+    const texts = [];
+    setQuestions((prev) => {
+      const updated = [...prev];
+      indices.forEach((i) => {
+        updated[i].asked = true;
+        texts.push(updated[i].question);
+      });
+      if (uid) {
+        saveInitiative(uid, initiativeId, {
+          clarifyingAsked: updated.map((qq) => qq.asked),
+        });
+      }
+      return updated;
+    });
+    if (navigator.clipboard && texts.length) {
+      navigator.clipboard.writeText(texts.join("\n\n"));
+    }
+    setSelected((prev) => prev.filter((i) => !indices.includes(i)));
+  };
+
+  const moveToToAsk = (idx) => {
+    setQuestions((prev) => {
+      const updated = [...prev];
+      const q = updated[idx];
+      q.asked = false;
+      q.answers = {};
+      if (uid) {
+        saveInitiative(uid, initiativeId, {
+          clarifyingAsked: updated.map((qq) => qq.asked),
+          clarifyingAnswers: updated.map((qq) => qq.answers),
+        });
+      }
+      return updated;
+    });
+  };
+
+  const handleDocFiles = async (files) => {
+    const newDocs = [];
+    for (const file of Array.from(files)) {
+      const content = await file.text();
+      newDocs.push({ name: file.name, content });
+    }
+    setDocuments((prev) => {
+      const updated = [...prev, ...newDocs];
+      if (uid) {
+        saveInitiative(uid, initiativeId, { sourceMaterials: updated });
+      }
+      return updated;
+    });
+  };
+
+  const handleDocInput = (e) => {
+    if (e.target.files) handleDocFiles(e.target.files);
+  };
+
+  const handleDocDrop = (e) => {
+    e.preventDefault();
+    if (e.dataTransfer.files) handleDocFiles(e.dataTransfer.files);
+  };
+
+  const handleDocDragOver = (e) => {
+    e.preventDefault();
+  };
+
+  const removeDocument = (idx) => {
+    setDocuments((prev) => {
+      const updated = prev.filter((_, i) => i !== idx);
+      if (uid) {
+        saveInitiative(uid, initiativeId, { sourceMaterials: updated });
+      }
+      return updated;
+    });
+  };
+
+  const summarizeText = (text) => {
+    const words = text.trim().split(/\s+/);
+    return words.slice(0, 50).join(" ") + (words.length > 50 ? "..." : "");
+  };
+
+  const handleSummarize = (text) => {
+    setSummary(summarizeText(text));
+    setShowSummary(true);
+  };
+
+  const handleSummarizeAll = () => {
+    const combined = documents.map((d) => d.content).join(" ");
+    handleSummarize(combined);
+  };
+
+  const toggleSelect = (idx) => {
+    setSelected((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+    );
+  };
+
+  const askSelected = () => {
+    if (selected.length) {
+      markAsked(selected);
+    }
+  };
+
+  const getColor = (role) =>
+    contacts.find((c) => c.role === role)?.color || "#e9ecef";
+
+  if (!loaded) {
+    return (
+      <div className="dashboard-container">
+        <h2>Loading...</h2>
+      </div>
+    );
+  }
+  const statusLabel = (s) =>
+    s === "toask" ? "To Ask" : s === "asked" ? "Asked" : "Answered";
+
+  const items = questions.map((q, idx) => {
+    const allAnswered =
+      q.contacts.length && q.contacts.every((r) => (q.answers[r] || "").trim());
+    const status = !q.asked ? "toask" : allAnswered ? "answered" : "asked";
+    return { ...q, idx, status };
+    });
+
+  let filtered = items.filter(
+    (q) =>
+      (!contactFilter || q.contacts.includes(contactFilter)) &&
+      (!statusFilter || q.status === statusFilter)
+  );
+
+  let grouped = { All: filtered };
+  if (groupBy === "contact") {
+    grouped = {};
+    filtered.forEach((q) => {
+      const roles = q.contacts.length ? q.contacts : ["Unassigned"];
+      roles.forEach((r) => {
+        grouped[r] = grouped[r] || [];
+        grouped[r].push(q);
+      });
+    });
+  } else if (groupBy === "status") {
+    grouped = {};
+    filtered.forEach((q) => {
+      const label = statusLabel(q.status);
+      grouped[label] = grouped[label] || [];
+      grouped[label].push(q);
+    });
+  }
+
+  return (
+    <div className="dashboard-container discovery-hub">
+      <aside className="sidebar">
+        <h2>Discovery Hub</h2>
+        <ul>
+          <li
+            className={active === "documents" ? "active" : ""}
+            onClick={() => setActive("documents")}
+          >
+            Documents
+          </li>
+          <li className={active === "questions" ? "active" : ""}>
+            <span
+              className="questions"
+              onClick={() => {
+                setActive("questions");
+                setStatusFilter("");
+              }}
+            >
+              Questions
+            </span>
+            {active === "questions" && (
+              <ul className="sub-menu">
+                <li
+                  className={statusFilter === "toask" ? "active" : ""}
+                  onClick={() => setStatusFilter("toask")}
+                >
+                  Ask
+                </li>
+                <li
+                  className={statusFilter === "asked" ? "active" : ""}
+                  onClick={() => setStatusFilter("asked")}
+                >
+                  Asked
+                </li>
+                <li
+                  className={statusFilter === "answered" ? "active" : ""}
+                  onClick={() => setStatusFilter("answered")}
+                >
+                  Answered
+                </li>
+              </ul>
+            )}
+          </li>
+        </ul>
+      </aside>
+      <div className="main-content">
+        {active === "documents" ? (
+          <div className="document-section">
+            {documents.length > 0 && (
+              <button
+                className="generator-button summarize-all"
+                onClick={handleSummarizeAll}
+              >
+                Summarize All Files
+              </button>
+            )}
+            <ul className="document-list">
+              {documents.map((doc, idx) => (
+                <li key={idx} className="document-item">
+                  {doc.name}
+                  <span className="doc-actions">
+                    <button onClick={() => handleSummarize(doc.content)}>
+                      Summarize
+                    </button>
+                    <button onClick={() => removeDocument(idx)}>Remove</button>
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <div
+              className="drop-zone"
+              onDrop={handleDocDrop}
+              onDragOver={handleDocDragOver}
+            >
+              Drag & Drop Documents Here
+              <input type="file" multiple onChange={handleDocInput} />
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="filter-bar">
+              <label>
+                Contact:
+                <select
+                  value={contactFilter}
+                  onChange={(e) => setContactFilter(e.target.value)}
+                >
+                  <option value="">All</option>
+                  {contacts.map((c) => (
+                    <option key={c.role} value={c.role}>
+                      {c.role}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Status:
+                <select
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value)}
+                >
+                  <option value="">All</option>
+                  <option value="toask">To Ask</option>
+                  <option value="asked">Asked</option>
+                  <option value="answered">Answered</option>
+                </select>
+              </label>
+              <label>
+                Group by:
+                <select
+                  value={groupBy}
+                  onChange={(e) => setGroupBy(e.target.value)}
+                >
+                  <option value="">None</option>
+                  <option value="contact">Contact</option>
+                  <option value="status">Status</option>
+                </select>
+              </label>
+              <button className="generator-button" onClick={addContact}>
+                Add Contact
+              </button>
+              {selected.length > 0 && (
+                <button
+                  className="generator-button ask-selected"
+                  onClick={askSelected}
+                >
+                  Ask Selected
+                </button>
+              )}
+            </div>
+            {Object.entries(grouped).map(([grp, items]) => (
+              <div key={grp} className="group-section">
+                {groupBy && <h3>{grp}</h3>}
+                {items.map((q) => (
+                  <div
+                    key={q.idx}
+                    className={`initiative-card question-card ${q.status}`}
+                  >
+                    <div className="question-header">
+                      <input
+                        type="checkbox"
+                        checked={selected.includes(q.idx)}
+                        onChange={() => toggleSelect(q.idx)}
+                      />
+                      <p>{q.question}</p>
+                      <span className="status-tag">{statusLabel(q.status)}</span>
+                    </div>
+                    <div className="contact-row">
+                      {q.contacts.map((r) => (
+                        <span
+                          key={r}
+                          className="contact-tag"
+                          style={{ backgroundColor: getColor(r) }}
+                        >
+                          {r}
+                          <button onClick={() => removeContactFromQuestion(q.idx, r)}>
+                            ×
+                          </button>
+                        </span>
+                      ))}
+                      <select
+                        className="contact-select"
+                        value=""
+                        onChange={(e) => handleContactSelect(q.idx, e.target.value)}
+                      >
+                        <option value="">Add Contact</option>
+                        {contacts
+                          .filter((c) => !q.contacts.includes(c.role))
+                          .map((c) => (
+                            <option key={c.role} value={c.role}>
+                              {c.role}
+                            </option>
+                          ))}
+                        <option value="__add__">Add New Contact</option>
+                      </select>
+                    </div>
+                    {q.status !== "toask" &&
+                      q.contacts.map((r) => (
+                        <div key={r} className="answer-block">
+                          <strong>{r}:</strong>
+                          <textarea
+                            className="generator-input"
+                            placeholder="Paste Answer/Notes Here"
+                            value={q.answers[r] || ""}
+                            onChange={(e) => updateAnswer(q.idx, r, e.target.value)}
+                            rows={3}
+                          />
+                        </div>
+                      ))}
+                    {q.status === "toask" ? (
+                      <button
+                        className="generator-button"
+                        onClick={() => markAsked(q.idx)}
+                      >
+                        Ask
+                      </button>
+                    ) : (
+                      <button
+                        className="generator-button secondary"
+                        onClick={() => moveToToAsk(q.idx)}
+                      >
+                        Move to To Ask
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+      {showSummary && (
+        <div className="modal-overlay" onClick={() => setShowSummary(false)}>
+          <div className="initiative-card modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Summary</h3>
+            <p>{summary}</p>
+            <button className="generator-button" onClick={() => setShowSummary(false)}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DiscoveryHub;
+

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,9 +1,21 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../firebase";
 
 // src/components/NavBar.jsx
 // Updated header component using glass effect and profile actions
 
 const NavBar = () => {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setLoggedIn(!!user);
+    });
+    return () => unsubscribe();
+  }, []);
+
   return (
     <header className="glass-header">
       <nav className="nav-container">
@@ -30,7 +42,7 @@ const NavBar = () => {
         </div>
 
         <div className="nav-links">
-          <Link to="/" className="nav-link active">
+          <Link to={loggedIn ? "/dashboard" : "/"} className="nav-link active">
             Home
           </Link>
           <Link to="/ai-tools" className="nav-link">

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -1,0 +1,344 @@
+import { useState, useEffect } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { getFunctions, httpsCallable } from "firebase/functions";
+import { onAuthStateChanged } from "firebase/auth";
+import { app, auth } from "../firebase";
+import { saveInitiative, loadInitiative } from "../utils/initiatives";
+import "./AIToolsGenerators.css";
+
+const ProjectSetup = () => {
+  const [searchParams] = useSearchParams();
+  const initiativeId = searchParams.get("initiativeId");
+  const navigate = useNavigate();
+
+  const functions = getFunctions(app, "us-central1");
+  const generateClarifyingQuestions = httpsCallable(
+    functions,
+    "generateClarifyingQuestions"
+  );
+
+  const [projectName, setProjectName] = useState("");
+  const [businessGoal, setBusinessGoal] = useState("");
+  const [audienceProfile, setAudienceProfile] = useState("");
+  const [projectConstraints, setProjectConstraints] = useState("");
+  const [keyContacts, setKeyContacts] = useState([{ name: "", role: "" }]);
+  const [sourceMaterials, setSourceMaterials] = useState([]);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      if (user && initiativeId) {
+        const init = await loadInitiative(user.uid, initiativeId);
+        if (init) {
+          setProjectName(init.projectName || "");
+          setBusinessGoal(init.businessGoal || "");
+          setAudienceProfile(init.audienceProfile || "");
+          setProjectConstraints(init.projectConstraints || "");
+          setKeyContacts(init.keyContacts || [{ name: "", role: "" }]);
+          setSourceMaterials(init.sourceMaterials || []);
+        }
+      }
+    });
+    return () => unsub();
+  }, [initiativeId]);
+
+  const getCombinedSource = () =>
+    sourceMaterials.map((f) => f.content).join("\n");
+
+  const extractTextFromPdf = async (buffer) => {
+    const BASE = "https://cdn.jsdelivr.net/npm/pdfjs-dist@5.4.54";
+    const pdfjs = await import(
+      /* @vite-ignore */
+      `${BASE}/build/pdf.mjs`
+    );
+    pdfjs.GlobalWorkerOptions.workerSrc = `${BASE}/build/pdf.worker.mjs`;
+    const pdf = await pdfjs.getDocument({ data: buffer }).promise;
+    let text = "";
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const content = await page.getTextContent();
+      text += content.items.map((item) => item.str).join(" ") + "\n";
+    }
+    return text.trim();
+  };
+
+  const extractTextFromDocx = async (buffer) => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.DecompressionStream === "undefined"
+    )
+      return "";
+    const view = new DataView(buffer);
+    const decoder = new TextDecoder();
+    let offset = buffer.byteLength - 22;
+    while (offset >= 0 && view.getUint32(offset, true) !== 0x06054b50) {
+      offset--;
+    }
+    if (offset < 0) return "";
+    const entries = view.getUint16(offset + 8, true);
+    const cdOffset = view.getUint32(offset + 16, true);
+    offset = cdOffset;
+    for (let i = 0; i < entries; i++) {
+      if (view.getUint32(offset, true) !== 0x02014b50) break;
+      const nameLen = view.getUint16(offset + 28, true);
+      const extraLen = view.getUint16(offset + 30, true);
+      const commentLen = view.getUint16(offset + 32, true);
+      const localOffset = view.getUint32(offset + 42, true);
+      const name = decoder.decode(
+        new Uint8Array(buffer, offset + 46, nameLen)
+      );
+      if (name === "word/document.xml") {
+        const lhNameLen = view.getUint16(localOffset + 26, true);
+        const lhExtraLen = view.getUint16(localOffset + 28, true);
+        const compSize = view.getUint32(localOffset + 18, true);
+        const dataStart = localOffset + 30 + lhNameLen + lhExtraLen;
+        const compressed = buffer.slice(dataStart, dataStart + compSize);
+        const ds = new window.DecompressionStream("deflate-raw");
+        const stream = new Response(new Blob([compressed]).stream().pipeThrough(ds));
+        const xml = await stream.text();
+        return xml
+          .replace(/<w:p[^>]*>/g, "\n")
+          .replace(/<[^>]+>/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+      }
+      offset += 46 + nameLen + extraLen + commentLen;
+    }
+    return "";
+  };
+
+  const handleFiles = async (files) => {
+    for (const file of Array.from(files)) {
+      try {
+        if (file.name.toLowerCase().endsWith(".pdf")) {
+          const buffer = await file.arrayBuffer();
+          let text = await extractTextFromPdf(buffer);
+          if (!text) text = await file.text();
+          setSourceMaterials((prev) => [...prev, { name: file.name, content: text }]);
+        } else if (file.name.toLowerCase().endsWith(".docx")) {
+          const buffer = await file.arrayBuffer();
+          const text = await extractTextFromDocx(buffer);
+          setSourceMaterials((prev) => [...prev, { name: file.name, content: text }]);
+        } else {
+          const text = await file.text();
+          setSourceMaterials((prev) => [...prev, { name: file.name, content: text }]);
+        }
+      } catch (err) {
+        console.error("Failed to read file", err);
+        setError(`Failed to process ${file.name}`);
+      }
+    }
+  };
+
+  const handleFileInput = (e) => {
+    const { files } = e.target;
+    if (files) handleFiles(files);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    if (e.dataTransfer.files) handleFiles(e.dataTransfer.files);
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+  };
+
+  const removeFile = (index) => {
+    setSourceMaterials((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleContactChange = (index, field, value) => {
+    setKeyContacts((prev) => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const addKeyContact = () => {
+    setKeyContacts((prev) => [...prev, { name: "", role: "" }]);
+  };
+
+  const removeKeyContact = (index) => {
+    setKeyContacts((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const { data } = await generateClarifyingQuestions({
+        businessGoal,
+        audienceProfile,
+        sourceMaterial: getCombinedSource(),
+        projectConstraints,
+        keyContacts,
+      });
+      const qsRaw = (data.clarifyingQuestions || []).slice(0, 9);
+      const qs = qsRaw.map((q) =>
+        typeof q === "string" ? { question: q, stakeholders: [], phase: "General" } : q
+      );
+      const uid = auth.currentUser?.uid;
+      if (uid) {
+        await saveInitiative(uid, initiativeId, {
+          projectName,
+          businessGoal,
+          audienceProfile,
+          sourceMaterials,
+          projectConstraints,
+          keyContacts,
+          clarifyingQuestions: qs,
+          clarifyingContacts: qs.map((q) => q.stakeholders || []),
+          clarifyingAnswers: qs.map(() => ({})),
+          clarifyingAsked: qs.map(() => false),
+        });
+      }
+      navigate(`/discovery?initiativeId=${initiativeId}`);
+    } catch (err) {
+      console.error("Error generating clarifying questions:", err);
+      setError(err?.message || "Error generating clarifying questions.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="dashboard-container">
+      <div className={`initiative-card ${loading ? "pulsing" : ""}`}>
+        <form onSubmit={handleSubmit} className="generator-form">
+          <h3>Project Intake</h3>
+          <p>Tell us about your project. The more detail, the better.</p>
+          <div className="intake-grid">
+            <div className="intake-left">
+              <label>
+                Project Name
+                <input
+                  type="text"
+                  value={projectName}
+                  placeholder="e.g., 'Q3 Sales Onboarding'"
+                  onChange={(e) => setProjectName(e.target.value)}
+                  className="generator-input"
+                />
+              </label>
+              <label>
+                What is the primary business goal?
+                <input
+                  type="text"
+                  value={businessGoal}
+                  placeholder="e.g., 'Reduce support tickets for Product X by 20%'"
+                  onChange={(e) => setBusinessGoal(e.target.value)}
+                  className="generator-input"
+                />
+              </label>
+              <label>
+                Who is the target audience?
+                <textarea
+                  value={audienceProfile}
+                  placeholder="e.g., 'New sales hires, age 22-28, with no prior industry experience'"
+                  onChange={(e) => setAudienceProfile(e.target.value)}
+                  className="generator-input"
+                  rows={3}
+                />
+              </label>
+              <div className="contacts-section">
+                <p>Key Contacts</p>
+                {keyContacts.map((c, idx) => (
+                  <div key={idx} className="contact-row">
+                    <input
+                      type="text"
+                      value={c.name}
+                      placeholder="Name"
+                      onChange={(e) => handleContactChange(idx, "name", e.target.value)}
+                      className="generator-input"
+                    />
+                    <input
+                      type="text"
+                      value={c.role}
+                      placeholder="Role"
+                      onChange={(e) => handleContactChange(idx, "role", e.target.value)}
+                      className="generator-input"
+                    />
+                    {keyContacts.length > 1 && (
+                      <button
+                        type="button"
+                        className="remove-file"
+                        onClick={() => removeKeyContact(idx)}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  className="generator-button add-contact-button"
+                  onClick={addKeyContact}
+                >
+                  +
+                </button>
+              </div>
+              <label>
+                Project Constraints or Limitations
+                <textarea
+                  value={projectConstraints}
+                  onChange={(e) => setProjectConstraints(e.target.value)}
+                  className="generator-input"
+                  rows={3}
+                />
+              </label>
+            </div>
+            <div
+              className="upload-card"
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+            >
+              <input
+                type="file"
+                onChange={handleFileInput}
+                className="file-input"
+                accept=".pdf,.docx,.txt"
+                multiple
+              />
+              <div className="upload-title">Upload Source Material (Optional)</div>
+              <div className="upload-subtitle">Click to upload or drag and drop</div>
+              <div className="upload-hint">PDF, DOCX, TXT (MAX. 10MB)</div>
+              {sourceMaterials.length > 0 && (
+                <ul className="file-list">
+                  {sourceMaterials.map((f, idx) => (
+                    <li key={idx}>
+                      {f.name}
+                      <button
+                        type="button"
+                        className="remove-file"
+                        onClick={() => removeFile(idx)}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+          <div className="button-row">
+            <button
+              type="submit"
+              disabled={loading}
+              className="generator-button next-button"
+            >
+              {loading ? "Analyzing..." : "Next"}
+            </button>
+          </div>
+          {error && <p className="generator-error">{error}</p>}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectSetup;
+


### PR DESCRIPTION
## Summary
- Allow editing or deleting projects from the dashboard and route edits back to project setup
- Add a Documents tab in the Discovery Hub with drag-and-drop uploads, removal, and per-file or bulk summaries
- Preload existing project info on the Project Setup screen for easy edits

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f825cb0a8832b8e5d436a6e5a4297