### PR TITLE
Improve Gmail OAuth completion UX and draft email auth checks

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -128,9 +128,17 @@ export const emailOAuthCallback = functions.https.onRequest(async (req, res) => 
     } else {
       return res.status(400).send("Unknown provider");
     }
-    res.status(200).send(
-      "<p>Gmail account connected. You can close this window.</p>"
-    );
+    const appBase = process.env.APP_BASE_URL || "https://thoughtify.web.app";
+    res.status(200).send(`
+      <html><body><script>
+        if (window.opener) {
+          window.opener.location = '${appBase}/dashboard';
+          window.close();
+        } else {
+          window.location = '${appBase}/dashboard';
+        }
+      </script></body></html>
+    `);
   } catch (err) {
     console.error("emailOAuthCallback error", err);
     res

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -52,11 +52,16 @@ const DiscoveryHub = () => {
       }
       return;
     }
+    if (!auth.currentUser) {
+      alert("Please log in to draft emails.");
+      return;
+    }
     try {
+      await auth.currentUser.getIdToken();
       const callable = httpsCallable(functions, "sendQuestionEmail");
       await callable({
         provider: "gmail",
-        recipientEmail: auth.currentUser?.email || "",
+        recipientEmail: auth.currentUser.email || "",
         subject: q.question,
         message: q.question,
         questionId: q.id ?? q.idx,

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -26,7 +26,11 @@ const Settings = () => {
 
   const connectGmail = () => {
     if (!uid) return;
-    window.location.href = `${functionsBaseUrl}/getEmailAuthUrl?provider=gmail&state=${uid}`;
+    window.open(
+      `${functionsBaseUrl}/getEmailAuthUrl?provider=gmail&state=${uid}`,
+      "_blank",
+      "width=500,height=600"
+    );
   };
 
   const disconnectGmail = async () => {


### PR DESCRIPTION
## Summary
- Redirect Gmail OAuth callback back to dashboard and close popups
- Open Gmail connect in a new window from settings
- Validate authentication before drafting emails to prevent 401 errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0e89dc678832b99d73e212305caae