### PR TITLE
Improve Gmail OAuth completion UX and draft email auth checks

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -52,15 +52,21 @@ const DiscoveryHub = () => {
       }
       return;
     }
+    if (!auth.currentUser) {
+      alert("Please log in to draft emails.");
+      return;
+    }
     try {
+      const idToken = await auth.currentUser.getIdToken(true);
       const callable = httpsCallable(functions, "sendQuestionEmail");
       await callable({
         provider: "gmail",
-        recipientEmail: auth.currentUser?.email || "",
+        recipientEmail: auth.currentUser.email || "",
         subject: q.question,
         message: q.question,
         questionId: q.id ?? q.idx,
         draft: true,
+        idToken,
       });
       alert("Draft created in Gmail");
     } catch (err) {

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -26,7 +26,11 @@ const Settings = () => {
 
   const connectGmail = () => {
     if (!uid) return;
-    window.location.href = `${functionsBaseUrl}/getEmailAuthUrl?provider=gmail&state=${uid}`;
+    window.open(
+      `${functionsBaseUrl}/getEmailAuthUrl?provider=gmail&state=${uid}`,
+      "_blank",
+      "width=500,height=600"
+    );
   };
 
   const disconnectGmail = async () => {


### PR DESCRIPTION
## Summary
- Redirect Gmail OAuth callback back to dashboard and close popups
- Open Gmail connect in a new window from settings
- Validate authentication before drafting emails to prevent 401 errors
- Verify Firebase ID token in email draft function and send it from the client to avoid `Auth required` 401s

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0e89dc678832b99d73e212305caae