### PR TITLE
Simplify auth handling for question email

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -166,31 +166,7 @@ async function getToken(uid, provider) {
 
 // 3. Send or draft email and record provider message ID
 export const sendQuestionEmail = functions.https.onCall(async (data, context) => {
-  let uid = context.auth?.uid;
-
-  if (!uid) {
-    let token = data.idToken;
-
-    if (!token) {
-      const authHeader = context.rawRequest?.headers?.authorization;
-      if (authHeader?.startsWith("Bearer ")) {
-        token = authHeader.split(" ")[1];
-      }
-    }
-
-    if (token) {
-      try {
-        const decoded = await admin.auth().verifyIdToken(token);
-        uid = decoded.uid;
-      } catch (err) {
-        console.error("verifyIdToken error", err);
-        throw new functions.https.HttpsError(
-          "unauthenticated",
-          "Invalid ID token"
-        );
-      }
-    }
-  }
+  const uid = context.auth?.uid;
 
   if (!uid) {
     throw new functions.https.HttpsError("unauthenticated", "Auth required");

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -57,7 +57,6 @@ const DiscoveryHub = () => {
       return;
     }
     try {
-      const idToken = await auth.currentUser.getIdToken(true);
       const callable = httpsCallable(functions, "sendQuestionEmail");
       await callable({
         provider: "gmail",
@@ -66,7 +65,6 @@ const DiscoveryHub = () => {
         message: q.question,
         questionId: q.id ?? q.idx,
         draft: true,
-        idToken,
       });
       alert("Draft created in Gmail");
     } catch (err) {


### PR DESCRIPTION
## Summary
- Simplify `sendQuestionEmail` to rely on Firebase callable auth context
- Remove manual ID token passing from `DiscoveryHub` email draft helper

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5a954e4832bb2c1b64b6936a3a3