### PR TITLE
fix: allow zero questionId

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -206,7 +206,13 @@ export const sendQuestionEmail = functions.https.onCall(async (data, context) =>
     questionId,
     draft = false,
   } = data;
-  if (!provider || !recipientEmail || !subject || !message || !questionId) {
+  if (
+    !provider ||
+    !recipientEmail ||
+    !subject ||
+    !message ||
+    questionId == null
+  ) {
     throw new functions.https.HttpsError("invalid-argument", "Missing fields");
   }
   try {

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -65,7 +65,7 @@ const DiscoveryHub = () => {
         recipientEmail: auth.currentUser.email || "",
         subject: q.question,
         message: q.question,
-        questionId: q.id ?? q.idx,
+        questionId: q.id,
         draft: true,
       });
       alert("Draft created in Gmail");


### PR DESCRIPTION
## Summary
- allow questionId=0 by checking for `null`/`undefined` instead of truthiness
- ensure DiscoveryHub drafts email with explicit questionId

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `(cd functions && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a111f5febc832bb5321c80b3c193d2