### PR TITLE
Log auth and app context for email send

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -184,8 +184,14 @@ export const sendQuestionEmail = functions.https.onCall(async (data, context) =>
   }
 
   const uid = context.auth?.uid;
+  console.log("sendQuestionEmail context.auth", context.auth);
+  console.log("sendQuestionEmail context.app", context.app);
   if (!uid) {
-    const msg = "Authentication required: missing context.auth";
+    const msg =
+      "Authentication required: missing context.auth" +
+      (context.app
+        ? ""
+        : "; App Check token required – ensure your client includes a valid App Check token.");
     console.error("sendQuestionEmail unauthenticated", msg);
     throw new functions.https.HttpsError("unauthenticated", msg);
   }


### PR DESCRIPTION
## Summary
- log `context.auth` and `context.app` in `sendQuestionEmail`
- clarify unauthenticated error when App Check token is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a11f3ee034832b9b262e73dbf7b1f1