### PR TITLE
feat: add firebase app check

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -60,7 +60,8 @@ const DiscoveryHub = () => {
     try {
       const token = await auth.currentUser.getIdToken(true);
       console.log("Refreshed token:", token);
-      const callable = httpsCallable(functions, "sendQuestionEmail");
+      const functionsInstance = await functions;
+      const callable = httpsCallable(functionsInstance, "sendQuestionEmail");
       await callable({
         provider: "gmail",
         recipientEmail: auth.currentUser.email || "",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,8 +1,13 @@
 
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
-import { getFunctions } from "firebase/functions"; 
+import { getFunctions } from "firebase/functions";
 import { getAuth } from "firebase/auth";
+import {
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+  getToken,
+} from "firebase/app-check";
 
 const firebaseConfig = {
     apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -15,8 +20,21 @@ const firebaseConfig = {
   };
 
 const app = initializeApp(firebaseConfig);
+
+if (import.meta.env.DEV && import.meta.env.VITE_APPCHECK_DEBUG_TOKEN) {
+  globalThis.FIREBASE_APPCHECK_DEBUG_TOKEN =
+    import.meta.env.VITE_APPCHECK_DEBUG_TOKEN;
+}
+
+const appCheck = initializeAppCheck(app, {
+  provider: new ReCaptchaV3Provider(import.meta.env.VITE_RECAPTCHA_SITE_KEY),
+  isTokenAutoRefreshEnabled: true,
+});
+
+const functions = getToken(appCheck).then(() =>
+  getFunctions(app, "us-central1")
+);
 const db = getFirestore(app);
-const functions = getFunctions(app, "us-central1"); // <-- important
 const auth = getAuth(app);
 
 export { app, db, functions, auth };


### PR DESCRIPTION
## Summary
- initialize Firebase App Check with reCAPTCHA v3 and debug support
- delay callable Functions instantiation until App Check token is retrieved
- await Functions instance in DiscoveryHub before drafting email

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a122435e7c832b8029230cb482eb8a