### PR TITLE
feat: add firebase app check

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -60,7 +60,8 @@ const DiscoveryHub = () => {
     try {
       const token = await auth.currentUser.getIdToken(true);
       console.log("Refreshed token:", token);
-      const callable = httpsCallable(functions, "sendQuestionEmail");
+      const functionsInstance = await functions;
+      const callable = httpsCallable(functionsInstance, "sendQuestionEmail");
       await callable({
         provider: "gmail",
         recipientEmail: auth.currentUser.email || "",


### PR DESCRIPTION
## Summary
- initialize Firebase App Check with reCAPTCHA v3 and debug support
- delay callable Functions instantiation until App Check token is retrieved
- guard App Check init when VITE_RECAPTCHA_SITE_KEY is unset to prevent runtime errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a122435e7c832b8029230cb482eb8a