### PR TITLE
Log AppCheck and ID tokens

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -61,9 +61,11 @@ const DiscoveryHub = () => {
     try {
       // Ensure fresh App Check token and auth token before calling the function
       if (appCheck) {
-        await getAppCheckToken(appCheck);
+        const token = await getAppCheckToken(appCheck);
+        console.log("AppCheck token", token.token);
       }
-      await auth.currentUser.getIdToken(true);
+      const idToken = await auth.currentUser.getIdToken(true);
+      console.log("ID token", idToken);
       const callable = httpsCallable(functions, "sendQuestionEmail");
       await callable({
         provider: "gmail",


### PR DESCRIPTION
## Summary
- log AppCheck token after fetching it
- log ID token retrieved from current user

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`
- `node` to simulate draftEmail and confirm token logs


------
https://chatgpt.com/codex/tasks/task_e_68a151f42398832b9e6f3625698ad388