### PR TITLE
Ensure question subcollection created when emailing

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -263,6 +263,9 @@ export const sendQuestionEmail = onCall(
       });
       const messageId = resp.data.id || "";
 
+      // Ensure user document exists so the questions subcollection is visible
+      await db.collection("users").doc(uid).set({}, { merge: true });
+
       await db
         .collection("users")
         .doc(uid)


### PR DESCRIPTION
## Summary
- Create user document before saving sent email's message ID to the questions subcollection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1e8c48aa8832b98fa802ddb396337