### PR TITLE
feat: configure AI client via Remote Config

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,8 +1,9 @@
 // src/ai.js
-import aiClient from './aiClient';
+import aiClient, { modelName } from './aiClient';
 import { getGenerativeModel } from 'firebase/ai';
 
-const model = getGenerativeModel(aiClient, { model: 'gemini-1.5-flash' });
+// Use model name from Remote Config (with defaults handled in aiClient)
+const model = getGenerativeModel(aiClient, { model: modelName });
 
 /**
  * Simple wrapper around the Firebase AI client that mirrors the

--- a/src/aiClient.js
+++ b/src/aiClient.js
@@ -1,8 +1,40 @@
 // src/aiClient.js
-import { getAI, GoogleAIBackend } from 'firebase/ai';
+import { getAI, GoogleAIBackend, VertexAIBackend } from 'firebase/ai';
+import { getRemoteConfig, fetchAndActivate, getValue } from 'firebase/remote-config';
 import { app } from './firebase';
 
-// Initialize the Firebase AI client using the Google AI backend.
-const aiClient = getAI(app, { backend: new GoogleAIBackend() });
+// Default Remote Config values for offline or first-run scenarios
+const DEFAULTS = {
+  aiProvider: 'google',
+  modelName: 'gemini-1.5-flash',
+};
 
+// Set up Remote Config
+const remoteConfig = getRemoteConfig(app);
+remoteConfig.settings = { minimumFetchIntervalMillis: 3600000 };
+remoteConfig.defaultConfig = DEFAULTS;
+
+let aiProvider = DEFAULTS.aiProvider;
+let modelName = DEFAULTS.modelName;
+
+try {
+  await fetchAndActivate(remoteConfig);
+  aiProvider = getValue(remoteConfig, 'aiProvider').asString() || DEFAULTS.aiProvider;
+  modelName = getValue(remoteConfig, 'modelName').asString() || DEFAULTS.modelName;
+} catch (err) {
+  // If fetching remote config fails (offline/first run), fall back to defaults
+  console.warn('Remote Config fetch failed, using defaults', err);
+}
+
+// Choose backend based on provider
+const backend =
+  aiProvider.toLowerCase() === 'vertex' || aiProvider.toLowerCase() === 'vertex-ai'
+    ? new VertexAIBackend()
+    : new GoogleAIBackend();
+
+// Initialize the Firebase AI client using the selected backend
+const aiClient = getAI(app, { backend });
+
+// Export both the AI client and model name for consumers
+export { modelName };
 export default aiClient;


### PR DESCRIPTION
## Summary
- configure Firebase AI backend using Remote Config `aiProvider`
- expose Remote Config `modelName` and use it for model selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a21540ff10832b8c7dc812ef6d63ae