### PR TITLE
feat: configure AI client via Remote Config

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,8 +1,21 @@
 // src/ai.js
-import aiClient from './aiClient';
 import { getGenerativeModel } from 'firebase/ai';
+import { initAIClient } from './aiClient';
 
-const model = getGenerativeModel(aiClient, { model: 'gemini-1.5-flash' });
+let modelPromise;
+
+/**
+ * Lazily load the generative model configured via Remote Config.
+ * @returns {Promise<import('firebase/ai').GenerativeModel>}
+ */
+async function getModel() {
+  if (!modelPromise) {
+    modelPromise = initAIClient().then(({ aiClient, modelName }) =>
+      getGenerativeModel(aiClient, { model: modelName }),
+    );
+  }
+  return modelPromise;
+}
 
 /**
  * Simple wrapper around the Firebase AI client that mirrors the
@@ -11,8 +24,10 @@ const model = getGenerativeModel(aiClient, { model: 'gemini-1.5-flash' });
  * @returns {Promise<{text: string}>}
  */
 export async function generate(prompt) {
+  const model = await getModel();
   const result = await model.generateContent(prompt);
   return { text: result.response.text() };
 }
 
 export default { generate };
+

--- a/src/aiClient.js
+++ b/src/aiClient.js
@@ -1,8 +1,46 @@
 // src/aiClient.js
-import { getAI, GoogleAIBackend } from 'firebase/ai';
+import { getAI, GoogleAIBackend, VertexAIBackend } from 'firebase/ai';
+import { getRemoteConfig, fetchAndActivate, getValue } from 'firebase/remote-config';
 import { app } from './firebase';
 
-// Initialize the Firebase AI client using the Google AI backend.
-const aiClient = getAI(app, { backend: new GoogleAIBackend() });
+// Default Remote Config values for offline or first-run scenarios
+const DEFAULTS = {
+  aiProvider: 'google',
+  modelName: 'gemini-1.5-flash',
+};
 
-export default aiClient;
+// Set up Remote Config
+const remoteConfig = getRemoteConfig(app);
+remoteConfig.settings = { minimumFetchIntervalMillis: 3600000 };
+remoteConfig.defaultConfig = DEFAULTS;
+
+/**
+ * Initialize the Firebase AI client using Remote Config.
+ * Falls back to sensible defaults when offline or on first run.
+ * @returns {Promise<{ aiClient: import('firebase/ai').AIClient; modelName: string }>}
+ */
+export async function initAIClient() {
+  let aiProvider = DEFAULTS.aiProvider;
+  let modelName = DEFAULTS.modelName;
+
+  try {
+    await fetchAndActivate(remoteConfig);
+    aiProvider = getValue(remoteConfig, 'aiProvider').asString() || DEFAULTS.aiProvider;
+    modelName = getValue(remoteConfig, 'modelName').asString() || DEFAULTS.modelName;
+  } catch (err) {
+    // If fetching remote config fails (offline/first run), fall back to defaults
+    console.warn('Remote Config fetch failed, using defaults', err);
+  }
+
+  // Choose backend based on provider
+  const backend =
+    aiProvider.toLowerCase() === 'vertex' || aiProvider.toLowerCase() === 'vertex-ai'
+      ? new VertexAIBackend()
+      : new GoogleAIBackend();
+
+  // Initialize the Firebase AI client using the selected backend
+  const aiClient = getAI(app, { backend });
+
+  return { aiClient, modelName };
+}
+


### PR DESCRIPTION
## Summary
- asynchronously initialize Firebase AI client using Remote Config with safe defaults
- lazily load generative model based on Remote Config `modelName`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a21540ff10832b8c7dc812ef6d63ae