### PR TITLE
Include project context in answer analysis

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -205,7 +205,7 @@
 }
 
 .modal-content {
-  max-width: 600px;
+  max-width: 800px;
 }
 
 .modal-actions {


### PR DESCRIPTION
## Summary
- track project metadata (name, goal, audience, constraints) in DiscoveryHub state
- load project metadata when an initiative is opened
- embed full project context, existing Q&A, contacts, and sources into answer analysis prompt
- include the discovery question in the analysis prompt and limit follow-up suggestions to clarifications for that question
- avoid redundant tasks by only showing task creation when suggestions exist
- refocus answer analysis on discovery-only actions and avoid duplicating existing clarifying questions
- widen modal to better display lengthy responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a22edb89bc832b96037a3f70b57038