### PR TITLE
Embed timestamps in clarifying answers

### DIFF
--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -7,7 +7,6 @@ import {
   getDocs,
   addDoc,
   orderBy,
-  limit,
   updateDoc,
   doc,
 } from "firebase/firestore";


### PR DESCRIPTION
## Summary
- store clarifying answer timestamps alongside their text
- remove stale answerDates mapping and unused Firestore import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc36719c832bb014c9cb5ea18f4e