### PR TITLE
Ensure status updates only include new documents since last update

### DIFF
--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -123,16 +123,18 @@ const ProjectStatus = ({
 
     const newDocuments = documents
       .filter((d) => {
-        if (!cutoff) return true;
         const added = d.addedAt || d.createdAt || d.uploadedAt;
-        if (!added) return true; // Default to including if no timestamp
+        if (!added) {
+          // Documents without timestamps should only be considered "new" on the first run
+          return !cutoff;
+        }
         const t =
           typeof added === "string"
             ? new Date(added)
             : added.toDate
             ? added.toDate()
             : new Date(added);
-        return t > cutoff;
+        return !cutoff || t > cutoff;
       })
       .map(
         (d) =>


### PR DESCRIPTION
## Summary
- Only treat documents without timestamps as new on the first update
- Preserve delta-based status updates by filtering document additions by cutoff date

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4eea8e7e8832ba74c7870a538fa64