### PR TITLE
feat: add task classification and filtering

### DIFF
--- a/src/components/TaskQueue.jsx
+++ b/src/components/TaskQueue.jsx
@@ -1,5 +1,5 @@
 // src/TaskQueue.jsx
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import "../pages/admin.css";
@@ -7,34 +7,116 @@ import "../pages/admin.css";
 export default function TaskQueue({ tasks, inquiries, onComplete, onReplyTask, onDelete }) {
   const [selectedItem, setSelectedItem] = useState(null);
   const [replyText, setReplyText] = useState("");
+  const [projectFilter, setProjectFilter] = useState("all");
+  const [tagFilter, setTagFilter] = useState("all");
+
+  const projects = useMemo(() => {
+    const set = new Set();
+    tasks.forEach((t) => {
+      set.add(t.project || "General");
+    });
+    return Array.from(set);
+  }, [tasks]);
+
+  const filteredTasks = useMemo(
+    () =>
+      tasks.filter(
+        (t) =>
+          (projectFilter === "all" || t.project === projectFilter) &&
+          (tagFilter === "all" || t.tag === tagFilter)
+      ),
+    [tasks, projectFilter, tagFilter]
+  );
+
+  const groupedTasks = useMemo(() => {
+    return filteredTasks.reduce((acc, task) => {
+      const project = task.project || "General";
+      if (!acc[project]) acc[project] = [];
+      acc[project].push(task);
+      return acc;
+    }, {});
+  }, [filteredTasks]);
+
+  const renderTask = (task) => (
+    <li key={task.id} className="task-item">
+      <strong>
+        {task.name} ({task.email})
+      </strong>
+      {task.tag && <span className={`tag-badge tag-${task.tag}`}>{task.tag}</span>}
+      <p>{task.message}</p>
+      <div className="task-actions">
+        <button className="complete-button" onClick={() => onComplete(task)}>
+          Complete
+        </button>
+        <button
+          className="reply-button"
+          onClick={() => {
+            setSelectedItem(task);
+            setReplyText("");
+          }}
+        >
+          Reply
+        </button>
+        <button className="delete-button" onClick={() => onDelete(task.id)}>
+          Delete
+        </button>
+      </div>
+    </li>
+  );
 
   return (
     <div className="card glass-card">
       <h2>Task Queue</h2>
 
+      <div className="filter-row">
+        <select value={projectFilter} onChange={(e) => setProjectFilter(e.target.value)}>
+          <option value="all">All Projects</option>
+          {projects.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <select value={tagFilter} onChange={(e) => setTagFilter(e.target.value)}>
+          <option value="all">All Tags</option>
+          <option value="email">email</option>
+          <option value="call">call</option>
+          <option value="meeting">meeting</option>
+          <option value="research">research</option>
+        </select>
+      </div>
+
       {/* Render the Task Queue items */}
       <h3>Tasks</h3>
       <ul className="task-list">
-        {tasks.length === 0 ? (
+        {Object.keys(groupedTasks).length === 0 ? (
           <p>No pending tasks.</p>
         ) : (
-          tasks.map((task) => (
-            <li key={task.id} className="task-item">
-              <strong>{task.name} ({task.email})</strong>
-              <p>{task.message}</p>
-              <div className="task-actions">
-                <button className="complete-button" onClick={() => onComplete(task)}>
-                  Complete
-                </button>
-                <button className="reply-button" onClick={() => { setSelectedItem(task); setReplyText(""); }}>
-                  Reply
-                </button>
-                <button className="delete-button" onClick={() => onDelete(task.id)}>
-                  Delete
-                </button>
-              </div>
-            </li>
-          ))
+          Object.entries(groupedTasks).map(([project, projectTasks]) => {
+            const bundles = projectTasks.reduce((acc, t) => {
+              const key = `${t.tag || "other"}-${t.name || ""}`;
+              if (!acc[key]) acc[key] = [];
+              acc[key].push(t);
+              return acc;
+            }, {});
+            return (
+              <li key={project}>
+                <h4>{project}</h4>
+                {Object.values(bundles).map((bundle, idx) =>
+                  bundle.length > 1 ? (
+                    <div className="bundle-group" key={idx}>
+                      <strong>
+                        {bundle[0].tag || ""} with {bundle[0].name} ({bundle.length} items)
+                      </strong>
+                      <ul>{bundle.map((t) => renderTask(t))}</ul>
+                    </div>
+                  ) : (
+                    renderTask(bundle[0])
+                  )
+                )}
+              </li>
+            );
+          })
         )}
       </ul>
 
@@ -46,13 +128,21 @@ export default function TaskQueue({ tasks, inquiries, onComplete, onReplyTask, o
         ) : (
           inquiries.map((inquiry) => (
             <li key={inquiry.id} className="task-item">
-              <strong>{inquiry.name} ({inquiry.email})</strong>
+              <strong>
+                {inquiry.name} ({inquiry.email})
+              </strong>
               <p>{inquiry.message}</p>
               <div className="task-actions">
                 <button className="complete-button" onClick={() => onComplete(inquiry)}>
                   Complete
                 </button>
-                <button className="reply-button" onClick={() => { setSelectedItem(inquiry); setReplyText(""); }}>
+                <button
+                  className="reply-button"
+                  onClick={() => {
+                    setSelectedItem(inquiry);
+                    setReplyText("");
+                  }}
+                >
                   Reply
                 </button>
                 <button className="delete-button" onClick={() => onDelete(inquiry.id)}>

--- a/src/pages/admin.css
+++ b/src/pages/admin.css
@@ -126,6 +126,46 @@
   .task-item button:hover {
     background-color: #e66f20;
   }
+
+  .filter-row {
+    margin-bottom: 10px;
+  }
+
+  .filter-row select {
+    margin-right: 10px;
+    padding: 4px;
+  }
+
+  .tag-badge {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    margin-left: 6px;
+    color: #fff;
+  }
+
+  .tag-email {
+    background-color: #4a90e2;
+  }
+
+  .tag-call {
+    background-color: #7b61ff;
+  }
+
+  .tag-meeting {
+    background-color: #2d9c6f;
+  }
+
+  .tag-research {
+    background-color: #f5a623;
+  }
+
+  .bundle-group {
+    border: 1px dashed #8C259E;
+    padding: 10px;
+    margin-bottom: 10px;
+  }
   
 /* Full-screen overlay */
 .modal-overlay {

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -1,0 +1,57 @@
+import { generate } from "../ai";
+
+/**
+ * Classify a task message into a recommended communication method tag.
+ * Falls back to "email" on error.
+ * @param {string} message
+ * @returns {Promise<string>} tag
+ */
+export async function classifyTask(message) {
+  const prompt = `You are a smart assistant that decides how to handle tasks.\nChoose exactly one of: email, call, meeting, research.\nTask: ${message}`;
+  try {
+    const { text } = await generate(prompt);
+    const response = text.trim().toLowerCase();
+    if (response.includes("meeting")) return "meeting";
+    if (response.includes("call")) return "call";
+    if (response.includes("chat")) return "call";
+    if (response.includes("research")) return "research";
+    return "email";
+  } catch (err) {
+    console.error("classifyTask error", err);
+    return "email";
+  }
+}
+
+/**
+ * Determine if the message is actually a question that should be tracked
+ * separately instead of being a task.
+ * @param {string} message
+ * @returns {Promise<boolean>}
+ */
+export async function isQuestionTask(message) {
+  const lower = (message || "").toLowerCase().trim();
+  if (!lower) return false;
+  const questionPrefixes = [
+    "ask",
+    "who",
+    "what",
+    "when",
+    "where",
+    "why",
+    "how",
+    "should",
+  ];
+  if (lower.includes("?") || questionPrefixes.some((p) => lower.startsWith(p))) {
+    return true;
+  }
+  const prompt = `Does the following text represent a question that is asking someone for information? Answer yes or no.\nText: ${message}`;
+  try {
+    const { text } = await generate(prompt);
+    return text.trim().toLowerCase().startsWith("yes");
+  } catch (err) {
+    console.error("isQuestionTask error", err);
+    return false;
+  }
+}
+
+export default { classifyTask, isQuestionTask };


### PR DESCRIPTION
## Summary
- classify new tasks with AI helper and tag email/call/meeting/research
- detect question-like tasks, extract contact names, and store in question bank
- filter task queue by project and tag with bundle grouping
- route question-type tasks into project question bank instead of disappearing
- split multi-line analysis suggestions so every bullet becomes a task or question

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a51a6d9b3c832bad079394dbdf9975