### PR TITLE
Redesign question cards layout

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -40,6 +40,7 @@
 }
 
 .question-card {
+  position: relative;
   margin-bottom: 1rem;
 }
 
@@ -58,11 +59,19 @@
 }
 
 .status-tag {
-  margin-left: auto;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
   font-size: 0.8rem;
   padding: 0.2rem 0.5rem;
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.05);
+}
+
+.question-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .contact-row {


### PR DESCRIPTION
## Summary
- Move question status badge to the top-right corner of each card
- Add a dedicated actions row with Draft Email, Edit, and Delete buttons
- Introduce edit and delete handlers with persistence to initiative data

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5fb910b30832ba9e527f6111f7d76