### PR TITLE
Refine DiscoveryHub task card layout and labels

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -223,3 +223,81 @@
   margin-top: 0.5rem;
 }
 
+/* Project Tasks header alignment */
+.tasks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.tasks-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.task-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Task card tag and typography */
+.task-card {
+  position: relative;
+}
+
+.task-card-header {
+  display: flex;
+  flex-direction: column;
+}
+
+.task-contact {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.task-project {
+  font-size: 0.875rem;
+  opacity: 0.75;
+}
+
+.task-tag {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.task-tag.email {
+  background-color: #064e3b;
+  color: #bbf7d0;
+}
+
+.task-tag.call {
+  background-color: #164e63;
+  color: #a5f3fc;
+}
+
+.task-tag.meeting {
+  background-color: #78350f;
+  color: #fed7aa;
+}
+
+.task-tag.research {
+  background-color: #701a75;
+  color: #fbcfe8;
+}
+
+.task-tag.default {
+  background-color: #374151;
+  color: #d1d5db;
+}
+

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -120,14 +120,6 @@ const DiscoveryHub = () => {
   const [viewingStatus, setViewingStatus] = useState("");
   const navigate = useNavigate();
 
-  const tagStyles = {
-    email: "bg-green-500/20 text-green-300",
-    call: "bg-sky-500/20 text-sky-300",
-    meeting: "bg-orange-500/20 text-orange-300",
-    research: "bg-fuchsia-500/20 text-fuchsia-300",
-    default: "bg-gray-500/20 text-gray-300",
-  };
-
   const taskProjects = useMemo(() => {
     const set = new Set();
     projectTasks.forEach((t) => {
@@ -640,21 +632,11 @@ Respond ONLY in this JSON format:
     const contact = t.assignee || t.name || "Unassigned";
     const project = t.project || projectName || "General";
     return (
-      <div key={t.id} className="initiative-card space-y-3">
-        <div className="flex justify-between items-center">
-          <div className="flex gap-2">
-            <span className="font-semibold">{contact}</span>
-            <span className="text-sm opacity-75">{project}</span>
-          </div>
-          {t.tag && (
-            <span
-              className={`px-2 py-0.5 text-xs font-semibold rounded-full ${
-                tagStyles[t.tag] || tagStyles.default
-              }`}
-            >
-              {t.tag}
-            </span>
-          )}
+      <div key={t.id} className="initiative-card task-card space-y-3">
+        {t.tag && <span className={`task-tag ${t.tag}`}>{t.tag}</span>}
+        <div className="task-card-header">
+          <span className="task-contact">{contact}</span>
+          <span className="task-project">{project}</span>
         </div>
         <p>{t.message}</p>
         <div className="flex gap-2">{actionButtons}</div>
@@ -1382,12 +1364,10 @@ Respond ONLY in this JSON format:
         ) : active === "tasks" ? (
   <div className="flex w-full flex-col gap-4">
     {/* Header: Title on the left, buttons on the right */}
-    <div className="w-full flex flex-nowrap items-center gap-4 min-w-0">
-  <h2 className="m-0 min-w-0 flex-1 truncate text-2xl font-bold text-white">
-    Project Tasks
-  </h2>
+    <div className="tasks-header">
+      <h2 className="tasks-title">Project Tasks</h2>
 
-  <div className="ml-auto flex shrink-0 items-center gap-3 whitespace-nowrap">
+      <div className="task-actions">
     <button
       type="button"
       className="appearance-none flex w-36 items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold text-white shadow


### PR DESCRIPTION
## Summary
- Ensure Project Tasks header and action buttons share one flex row
- Add dedicated task-tag styles for each type and anchor them top-right on cards
- Tweak task card typography to emphasize contact name and subdue project name

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68669f078832ba0f2d3df33bf1dde