### PR TITLE
feat: add header-based task synergy

### DIFF
--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -7,6 +7,24 @@ import { generate } from "../ai";
  * @returns {Promise<string>} tag
  */
 export async function classifyTask(message) {
+  const lower = (message || "").toLowerCase();
+  const researchKeywords = [
+    "research",
+    "analysis",
+    "analyze",
+    "analyse",
+    "assess",
+    "review",
+    "investigate",
+    "evaluate",
+    "explore",
+    "study",
+    "examine",
+  ];
+  if (researchKeywords.some((k) => lower.includes(k))) {
+    return "research";
+  }
+
   const prompt = `You are a smart assistant that decides how to handle tasks.\nChoose exactly one of: email, call, meeting, research.\nTask: ${message}`;
   try {
     const { text } = await generate(prompt);


### PR DESCRIPTION
## Summary
- bundle tasks by assignee and subtype/tag
- replace AI-generated synergy with deterministic header and bullet aggregation
- show new header-and-bullets preview when approving task synergy
- map suggested task assignees to existing contacts when roles match
- detect research tasks via keywords before fallback classification to avoid mislabeling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7385ed5a4832b8c0877183f03f767