### PR TITLE
feat: enhance task analysis and prioritization

### DIFF
--- a/src/components/TaskQueue.jsx
+++ b/src/components/TaskQueue.jsx
@@ -3,6 +3,7 @@ import { useState, useMemo } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { generate } from "../ai";
+import { dedupeByMessage } from "../utils/taskUtils";
 import { auth, db } from "../firebase";
 import { updateDoc, deleteDoc, doc, serverTimestamp } from "firebase/firestore";
 import "../pages/admin.css";
@@ -23,7 +24,6 @@ export default function TaskQueue({
   const [tagFilter, setTagFilter] = useState("all");
   const [synergyQueue, setSynergyQueue] = useState([]);
   const [synergyIndex, setSynergyIndex] = useState(0);
-  const [synergyText, setSynergyText] = useState("");
   const [prioritized, setPrioritized] = useState(null);
 
   const projects = useMemo(() => {
@@ -129,34 +129,49 @@ export default function TaskQueue({
 
   const computeBundles = () => {
     const map = {};
-    tasks.forEach((t) => {
-      const key = `${t.project || "General"}-${t.tag || "other"}-${t.name || ""}`;
-      if (!map[key]) map[key] = [];
-      map[key].push(t);
-    });
+    tasks
+      .filter((t) => (t.status || "open") === "open")
+      .forEach((t) => {
+        const key = `${t.assignee || t.name || ""}-${
+          t.subType || t.tag || "other"
+        }`;
+        if (!map[key]) map[key] = [];
+        map[key].push(t);
+      });
     return Object.values(map).filter((b) => b.length > 1);
   };
 
-  const startSynergy = async () => {
+  const startSynergy = () => {
     const bundles = computeBundles();
-    const proposals = [];
-    for (const b of bundles) {
-      try {
-        const { text } = await generate(
-          `Combine the following tasks into one task description:\n${b
-            .map((t) => `- ${t.message}`)
-            .join("\n")}`
-        );
-        proposals.push({ bundle: b, text: text.trim() });
-      } catch (err) {
-        console.error("synergize", err);
-        proposals.push({ bundle: b, text: b.map((t) => t.message).join(" ") });
-      }
+    if (!bundles.length) {
+      alert("No synergy opportunities found.");
+      return;
     }
+    const proposals = bundles.map((b) => {
+      const first = b[0];
+      const assignee = first.assignee || first.name || "";
+      const type = first.subType || first.tag || "";
+      let header;
+      switch (type) {
+        case "email":
+          header = `Send an email to ${assignee}`;
+          break;
+        case "meeting":
+          header = `Set up a meeting with ${assignee}`;
+          break;
+        case "call":
+          header = `Call ${assignee}`;
+          break;
+        default:
+          header = `Work with ${assignee}`;
+      }
+      const bullets = dedupeByMessage(b).map((t) => t.message);
+      const text = [header, ...bullets.map((m) => `- ${m}`)].join("\n");
+      return { bundle: b, text, header, bullets };
+    });
     if (proposals.length) {
       setSynergyQueue(proposals);
       setSynergyIndex(0);
-      setSynergyText(proposals[0].text);
     }
   };
 
@@ -164,24 +179,24 @@ export default function TaskQueue({
     const next = synergyIndex + 1;
     if (next < synergyQueue.length) {
       setSynergyIndex(next);
-      setSynergyText(synergyQueue[next].text);
     } else {
       setSynergyQueue([]);
       setSynergyIndex(0);
-      setSynergyText("");
     }
   };
 
   const startPrioritize = async () => {
     try {
+      const openTasks = tasks.filter((t) => (t.status || "open") === "open");
       const { text } = await generate(
-        `Order the following tasks by priority and return a JSON array of ids in order:\n${tasks
+        `Order the following tasks by priority and return a JSON array of ids in order:\n${openTasks
           .map((t) => `${t.id}: ${t.message}`)
           .join("\n")}`
       );
-      const ids = JSON.parse(text.trim());
+      const match = text.match(/\[[^\]]*\]/);
+      const ids = match ? JSON.parse(match[0]) : [];
       const ordered = ids
-        .map((id) => tasks.find((t) => t.id === id))
+        .map((id) => openTasks.find((t) => t.id === id))
         .filter(Boolean);
       if (ordered.length) {
         setPrioritized(ordered);
@@ -190,7 +205,8 @@ export default function TaskQueue({
     } catch (err) {
       console.error("prioritize", err);
     }
-    setPrioritized([...tasks]);
+    const openTasks = tasks.filter((t) => (t.status || "open") === "open");
+    setPrioritized([...openTasks]);
   };
 
   const movePriority = (index, delta) => {
@@ -374,23 +390,19 @@ export default function TaskQueue({
           <div className="modal-overlay">
             <div className="task-modal">
               <h3>Synergize Tasks</h3>
+              <h4>{synergyQueue[synergyIndex].header}</h4>
               <ul className="task-list">
-                {synergyQueue[synergyIndex].bundle.map((t) => (
-                  <li key={t.id}>{t.message}</li>
+                {synergyQueue[synergyIndex].bullets.map((m, idx) => (
+                  <li key={idx}>{m}</li>
                 ))}
               </ul>
-              <textarea
-                value={synergyText}
-                onChange={(e) => setSynergyText(e.target.value)}
-                style={{ width: "100%", height: "80px", marginBottom: "10px" }}
-              />
               <div className="modal-buttons">
                 <button
                   className="reply-button"
-                  onClick={() => {
-                    handleSynergize(
+                  onClick={async () => {
+                    await handleSynergize(
                       synergyQueue[synergyIndex].bundle,
-                      synergyText
+                      synergyQueue[synergyIndex].text
                     );
                     nextSynergy();
                   }}
@@ -414,6 +426,7 @@ export default function TaskQueue({
               <ul className="task-list">
                 {prioritized.map((task, idx) => (
                   <li key={task.id} className="task-item">
+                    <span className="priority-index">{idx + 1}.</span>
                     <strong>
                       {task.name} ({task.email})
                     </strong>

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -7,6 +7,24 @@ import { generate } from "../ai";
  * @returns {Promise<string>} tag
  */
 export async function classifyTask(message) {
+  const lower = (message || "").toLowerCase();
+  const researchKeywords = [
+    "research",
+    "analysis",
+    "analyze",
+    "analyse",
+    "assess",
+    "review",
+    "investigate",
+    "evaluate",
+    "explore",
+    "study",
+    "examine",
+  ];
+  if (researchKeywords.some((k) => lower.includes(k))) {
+    return "research";
+  }
+
   const prompt = `You are a smart assistant that decides how to handle tasks.\nChoose exactly one of: email, call, meeting, research.\nTask: ${message}`;
   try {
     const { text } = await generate(prompt);
@@ -54,4 +72,26 @@ export async function isQuestionTask(message) {
   }
 }
 
-export default { classifyTask, isQuestionTask };
+/**
+ * Remove duplicate tasks based on their message text.
+ * Comparison is case-insensitive and ignores punctuation and extra spaces.
+ * Keeps the first occurrence of each unique message.
+ * @param {Array<{message: string}>} tasks
+ * @returns {Array}
+ */
+export function dedupeByMessage(tasks) {
+  const normalize = (s) =>
+    (s || "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim();
+  const seen = new Set();
+  return tasks.filter((t) => {
+    const key = normalize(t.message);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export default { classifyTask, isQuestionTask, dedupeByMessage };


### PR DESCRIPTION
## Summary
- prevent duplicate follow-up tasks by feeding existing tasks and questions into answer analysis
- allow prioritization to rank open tasks numerically and show ranked order
- refine task synergy to only combine open tasks and notify when no opportunities exist
- strip duplicate messages when bundling synergy tasks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7385ed5a4832b8c0877183f03f767