### PR TITLE
feat: add my tasks card and task editor

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -86,6 +86,7 @@ const DiscoveryHub = () => {
   const [taskStatusFilter, setTaskStatusFilter] = useState("all");
   const [taskProjectFilter, setTaskProjectFilter] = useState("all");
   const [taskContactFilter, setTaskContactFilter] = useState("all");
+  const [taskTypeFilter, setTaskTypeFilter] = useState("all");
   const [synergyQueue, setSynergyQueue] = useState([]);
   const [synergyIndex, setSynergyIndex] = useState(0);
   const [prioritized, setPrioritized] = useState(null);
@@ -93,6 +94,7 @@ const DiscoveryHub = () => {
   const [selected, setSelected] = useState([]);
   const [selectMode, setSelectMode] = useState(false);
   const [uid, setUid] = useState(null);
+  const [currentUserName, setCurrentUserName] = useState("");
   const [loaded, setLoaded] = useState(false);
   const [active, setActive] = useState("questions");
   const [summary, setSummary] = useState("");
@@ -101,6 +103,7 @@ const DiscoveryHub = () => {
   const [menu, setMenu] = useState(null);
   const [focusRole, setFocusRole] = useState("");
   const [editData, setEditData] = useState(null);
+  const [editTask, setEditTask] = useState(null);
   const [emailConnected, setEmailConnected] = useState(false);
   const [emailDraft, setEmailDraft] = useState(null);
   const [generatingEmail, setGeneratingEmail] = useState(false);
@@ -130,7 +133,16 @@ const DiscoveryHub = () => {
   const taskContacts = useMemo(() => {
     const set = new Set();
     projectTasks.forEach((t) => {
-      set.add(t.assignee || t.name || "Unassigned");
+      const assignee = t.assignee || currentUserName;
+      set.add(assignee === currentUserName ? "My Tasks" : assignee);
+    });
+    return Array.from(set);
+  }, [projectTasks, currentUserName]);
+
+  const taskTypeOptions = useMemo(() => {
+    const set = new Set();
+    projectTasks.forEach((t) => {
+      set.add(t.subType || "other");
     });
     return Array.from(set);
   }, [projectTasks]);
@@ -145,12 +157,35 @@ const DiscoveryHub = () => {
       );
     }
     if (taskContactFilter !== "all") {
-      tasks = tasks.filter(
-        (t) => (t.assignee || t.name || "Unassigned") === taskContactFilter
-      );
+      tasks = tasks.filter((t) => {
+        const assignee = t.assignee || currentUserName;
+        const label = assignee === currentUserName ? "My Tasks" : assignee;
+        return label === taskContactFilter;
+      });
+    }
+    if (taskTypeFilter !== "all") {
+      tasks = tasks.filter((t) => (t.subType || "other") === taskTypeFilter);
     }
     return tasks;
-  }, [projectTasks, taskStatusFilter, taskProjectFilter, taskContactFilter]);
+  }, [
+    projectTasks,
+    taskStatusFilter,
+    taskProjectFilter,
+    taskContactFilter,
+    taskTypeFilter,
+    currentUserName,
+  ]);
+
+  const tasksByAssignee = useMemo(() => {
+    const map = {};
+    displayedTasks.forEach((t) => {
+      const assignee = t.assignee || currentUserName;
+      const label = assignee === currentUserName ? "My Tasks" : assignee;
+      if (!map[label]) map[label] = [];
+      map[label].push(t);
+    });
+    return map;
+  }, [displayedTasks, currentUserName]);
 
   const taskSubTypeIcon = (subType) => {
     switch (subType) {
@@ -476,11 +511,7 @@ Respond ONLY in this JSON format:
         }
 
         if (s.type === "question") {
-          const assignedContact = match
-            ? match.name
-            : s.assignee
-              ? s.assignee
-              : name;
+          const assignedContact = match ? match.name : name;
 
           questionsToAdd.push({
             question: s.text,
@@ -493,7 +524,7 @@ Respond ONLY in this JSON format:
           const tag = await classifyTask(s.text);
           const assignee = match
             ? match.name
-            : s.assignee || "Unassigned";
+            : currentUserName;
           // --- MODIFICATION: Save assignee and subType with the task ---
           tasksToAdd.push({
             name,
@@ -537,10 +568,13 @@ Respond ONLY in this JSON format:
   const updateTaskStatus = async (id, status, extra = {}) => {
     if (!uid || !initiativeId) return;
     try {
-      // This is the only part needed to update the task status
+      const data = { status, statusChangedAt: serverTimestamp(), ...extra };
+      if (status === "completed") {
+        data.completedAt = serverTimestamp();
+      }
       await updateDoc(
         doc(db, "users", uid, "initiatives", initiativeId, "tasks", id),
-        { status, statusChangedAt: serverTimestamp(), ...extra }
+        data
       );
     } catch (err) {
       console.error("updateTaskStatus error", err);
@@ -559,6 +593,84 @@ Respond ONLY in this JSON format:
       );
     } catch (err) {
       console.error("deleteTask error", err);
+    }
+  };
+
+  const handleSubTaskToggle = async (taskId, index, completed) => {
+    if (!uid || !initiativeId) return;
+    const task = projectTasks.find((t) => t.id === taskId);
+    if (!task) return;
+    const updated = task.subTasks.map((st, i) =>
+      i === index
+        ? {
+            ...st,
+            completed,
+            completedAt: completed ? serverTimestamp() : null,
+          }
+        : st
+    );
+    try {
+      await updateDoc(
+        doc(db, "users", uid, "initiatives", initiativeId, "tasks", taskId),
+        { subTasks: updated }
+      );
+    } catch (err) {
+      console.error("handleSubTaskToggle error", err);
+    }
+  };
+
+  const openEditModal = (task) => {
+    setEditTask({
+      id: task.id,
+      assignee: task.assignee || currentUserName,
+      subType: task.subType || "task",
+      subTasks: task.subTasks ? task.subTasks.map((st) => ({ ...st })) : [],
+    });
+  };
+
+  const updateEditTaskField = (field, value) => {
+    setEditTask((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const addEditSubTask = () => {
+    setEditTask((prev) => ({
+      ...prev,
+      subTasks: [...(prev.subTasks || []), { text: "", completed: false }],
+    }));
+  };
+
+  const updateEditSubTask = (idx, text) => {
+    setEditTask((prev) => ({
+      ...prev,
+      subTasks: prev.subTasks.map((st, i) =>
+        i === idx ? { ...st, text } : st
+      ),
+    }));
+  };
+
+  const removeEditSubTask = (idx) => {
+    setEditTask((prev) => ({
+      ...prev,
+      subTasks: prev.subTasks.filter((_, i) => i !== idx),
+    }));
+  };
+
+  const saveEditTask = async () => {
+    if (!uid || !initiativeId || !editTask) return;
+    const assignee =
+      editTask.assignee === "My Tasks" ? currentUserName : editTask.assignee;
+    try {
+      await updateDoc(
+        doc(db, "users", uid, "initiatives", initiativeId, "tasks", editTask.id),
+        {
+          assignee,
+          subType: editTask.subType,
+          subTasks: editTask.subTasks,
+        }
+      );
+      setEditTask(null);
+    } catch (err) {
+      console.error("saveEditTask error", err);
     }
   };
 
@@ -620,12 +732,13 @@ Respond ONLY in this JSON format:
     }
   };
 
-  const handleSynergize = async (bundle, message) => {
+  const handleSynergize = async (bundle, header, bullets) => {
     if (!uid || !initiativeId || !bundle.length) return;
     const [first, ...rest] = bundle;
+    const subTasks = bullets.map((m) => ({ text: m, completed: false }));
     await updateDoc(
       doc(db, "users", uid, "initiatives", initiativeId, "tasks", first.id),
-      { message }
+      { message: header, subTasks }
     );
     for (const t of rest) {
       await deleteDoc(
@@ -687,16 +800,35 @@ Respond ONLY in this JSON format:
   };
 
   const renderTaskCard = (t, actionButtons) => {
-    const contact = t.assignee || t.name || "Unassigned";
+    const contact = t.assignee || currentUserName;
+    const contactLabel = contact === currentUserName ? "My Tasks" : contact;
     const project = t.project || projectName || "General";
     return (
       <div key={t.id} className="initiative-card task-card space-y-3">
         {t.tag && <span className={`task-tag ${t.tag}`}>{t.tag}</span>}
         <div className="task-card-header">
-          <span className="task-contact">{contact}</span>
+          <span className="task-contact">{contactLabel}</span>
           <span className="task-project">{project}</span>
         </div>
         <p>{t.message}</p>
+        {t.subTasks && t.subTasks.length > 0 && (
+          <ul className="ml-4 list-disc space-y-1">
+            {t.subTasks.map((st, idx) => (
+              <li key={idx} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={!!st.completed}
+                  onChange={(e) =>
+                    handleSubTaskToggle(t.id, idx, e.target.checked)
+                  }
+                />
+                <span className={st.completed ? "line-through" : ""}>
+                  {st.text}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
         <div className="flex gap-2">{actionButtons}</div>
       </div>
     );
@@ -735,6 +867,7 @@ Respond ONLY in this JSON format:
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         setUid(user.uid);
+        setCurrentUserName(user.displayName || user.email || "My Tasks");
         const tokenSnap = await getDoc(
           doc(db, "users", user.uid, "emailTokens", "gmail")
         );
@@ -1476,6 +1609,18 @@ Respond ONLY in this JSON format:
           </option>
         ))}
       </select>
+      <select
+        value={taskTypeFilter}
+        onChange={(e) => setTaskTypeFilter(e.target.value)}
+        className="rounded-md bg-gray-700 px-3 py-1 text-gray-300"
+      >
+        <option value="all">All Types</option>
+        {taskTypeOptions.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
     </div>
 
     {/* Task List */}
@@ -1498,6 +1643,12 @@ Respond ONLY in this JSON format:
                   onClick={() => movePriority(i, 1)}
                 >
                   ↓
+                </button>
+                <button
+                  className="generator-button"
+                  onClick={() => openEditModal(t)}
+                >
+                  Edit
                 </button>
                 <button
                   className="generator-button"
@@ -1527,31 +1678,42 @@ Respond ONLY in this JSON format:
       </div>
     ) : (
       <div className="space-y-4">
-        {displayedTasks.map((t) =>
-          renderTaskCard(
-            t,
-            <>
-              <button
-                className="generator-button"
-                onClick={() => handleCompleteTask(t.id)}
-              >
-                Complete
-              </button>
-              <button
-                className="generator-button"
-                onClick={() => handleScheduleTask(t.id)}
-              >
-                Schedule
-              </button>
-              <button
-                className="generator-button"
-                onClick={() => handleDeleteTask(t.id)}
-              >
-                Delete
-              </button>
-            </>
-          )
-        )}
+        {Object.entries(tasksByAssignee).map(([assignee, tasks]) => (
+          <div key={assignee} className="initiative-card space-y-2">
+            <h3 className="font-semibold">{assignee}</h3>
+            {tasks.map((t) =>
+              renderTaskCard(
+                t,
+                <>
+                  <button
+                    className="generator-button"
+                    onClick={() => openEditModal(t)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="generator-button"
+                    onClick={() => handleCompleteTask(t.id)}
+                  >
+                    Complete
+                  </button>
+                  <button
+                    className="generator-button"
+                    onClick={() => handleScheduleTask(t.id)}
+                  >
+                    Schedule
+                  </button>
+                  <button
+                    className="generator-button"
+                    onClick={() => handleDeleteTask(t.id)}
+                  >
+                    Delete
+                  </button>
+                </>
+              )
+            )}
+          </div>
+        ))}
         {displayedTasks.length === 0 && (
           <p className="text-gray-400">No tasks.</p>
         )}
@@ -1583,11 +1745,86 @@ Respond ONLY in this JSON format:
                 onClick={() =>
                   handleSynergize(
                     synergyQueue[synergyIndex].bundle,
-                    synergyQueue[synergyIndex].text
+                    synergyQueue[synergyIndex].header,
+                    synergyQueue[synergyIndex].bullets
                   )
                 }
               >
                 Approve
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    {editTask &&
+      ReactDOM.createPortal(
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 text-black">
+            <h3 className="text-lg font-semibold">Edit Task</h3>
+            <div>
+              <label className="block text-sm font-medium">Contact</label>
+              <select
+                value={
+                  editTask.assignee === currentUserName
+                    ? "My Tasks"
+                    : editTask.assignee
+                }
+                onChange={(e) => updateEditTaskField("assignee", e.target.value)}
+                className="w-full rounded-md border px-2 py-1"
+              >
+                <option value="My Tasks">My Tasks</option>
+                {contacts.map((c) => (
+                  <option key={c.name} value={c.name}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium">Type</label>
+              <select
+                value={editTask.subType}
+                onChange={(e) => updateEditTaskField("subType", e.target.value)}
+                className="w-full rounded-md border px-2 py-1"
+              >
+                <option value="task">task</option>
+                <option value="meeting">meeting</option>
+                <option value="communication">communication</option>
+                <option value="research">research</option>
+                <option value="other">other</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label className="block text-sm font-medium">Subtasks</label>
+              {editTask.subTasks.map((st, idx) => (
+                <div key={idx} className="flex gap-2">
+                  <input
+                    className="flex-1 rounded-md border px-2 py-1"
+                    value={st.text}
+                    onChange={(e) => updateEditSubTask(idx, e.target.value)}
+                  />
+                  <button
+                    className="generator-button"
+                    onClick={() => removeEditSubTask(idx)}
+                  >
+                    X
+                  </button>
+                </div>
+              ))}
+              <button className="generator-button" onClick={addEditSubTask}>
+                Add Subtask
+              </button>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                className="generator-button"
+                onClick={() => setEditTask(null)}
+              >
+                Cancel
+              </button>
+              <button className="generator-button" onClick={saveEditTask}>
+                Save
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show unassigned items in a dedicated **My Tasks** card and default new tasks to the current user
- add modal editor to update task assignee, type, and subtasks for easy reassignment
- preserve sub-task checkbox state without collapsing tasks
- resolve duplicate `taskTypes` declaration error by renaming the options list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a77bc41ad8832b96bf24e77e6885e4