### PR TITLE
Improve task modals and contact handling in Discovery Hub

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -210,7 +210,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 10000;
 }
 
 .modal-content {

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from "react";
-import ReactDOM from "react-dom";
+import { createPortal } from "react-dom";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { onAuthStateChanged } from "firebase/auth";
 import { auth, db, functions, appCheck } from "../firebase";
@@ -9,6 +9,7 @@ import {
   collection,
   addDoc,
   serverTimestamp,
+  Timestamp,
   onSnapshot,
   updateDoc,
   deleteDoc,
@@ -605,7 +606,7 @@ Respond ONLY in this JSON format:
         ? {
             ...st,
             completed,
-            completedAt: completed ? serverTimestamp() : null,
+            completedAt: completed ? Timestamp.now() : null,
           }
         : st
     );
@@ -613,6 +614,9 @@ Respond ONLY in this JSON format:
       await updateDoc(
         doc(db, "users", uid, "initiatives", initiativeId, "tasks", taskId),
         { subTasks: updated }
+      );
+      setProjectTasks((prev) =>
+        prev.map((t) => (t.id === taskId ? { ...t, subTasks: updated } : t))
       );
     } catch (err) {
       console.error("handleSubTaskToggle error", err);
@@ -704,7 +708,10 @@ Respond ONLY in this JSON format:
           header = `Send an email to ${assignee}`;
           break;
         case "meeting":
-          header = `Set up a meeting with ${assignee}`;
+          header =
+            assignee === currentUserName
+              ? "Suggested meetings"
+              : `Set up a meeting with ${assignee}`;
           break;
         case "call":
           header = `Call ${assignee}`;
@@ -990,6 +997,45 @@ Respond ONLY in this JSON format:
       });
     }
     return name;
+  };
+
+  const addNamedContact = (name) => {
+    const role = prompt(`Role for ${name}? (optional)`) || "";
+    const email = prompt(`Email for ${name}? (optional)`) || "";
+    const color = colorPalette[contacts.length % colorPalette.length];
+    const newContact = { role, name, email, color };
+    const updated = [...contacts, newContact];
+    setContacts(updated);
+    if (uid) {
+      saveInitiative(uid, initiativeId, {
+        keyContacts: updated.map(({ name, role, email }) => ({
+          name,
+          role,
+          email,
+        })),
+      });
+    }
+  };
+
+  const ensureContactsForSuggestions = async (suggestions) => {
+    const existing = new Set(contacts.map((c) => c.name.toLowerCase()));
+    const newNames = [];
+    suggestions.forEach((s) => {
+      const assignee = (s.assignee || "").trim();
+      if (
+        assignee &&
+        assignee.toLowerCase() !== currentUserName.toLowerCase() &&
+        !existing.has(assignee.toLowerCase())
+      ) {
+        newNames.push(assignee);
+        existing.add(assignee.toLowerCase());
+      }
+    });
+    for (const name of newNames) {
+      if (window.confirm(`Create new contact "${name}"?`)) {
+        addNamedContact(name);
+      }
+    }
   };
 
   const addContactToQuestion = (idx, name) => {
@@ -1721,23 +1767,18 @@ Respond ONLY in this JSON format:
     )}
 
     {synergyQueue.length > 0 &&
-      ReactDOM.createPortal(
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="w-full max-w-md rounded-lg bg-white p-6 text-black">
-            <h3 className="mb-2 text-lg font-semibold">Synergize Tasks</h3>
-            <h4 className="mb-2 font-medium">
-              {synergyQueue[synergyIndex].header}
-            </h4>
+      createPortal(
+        <div className="modal-overlay">
+          <div className="initiative-card modal-content">
+            <h3>Synergize Tasks</h3>
+            <h4>{synergyQueue[synergyIndex].header}</h4>
             <ul className="mb-4 list-inside list-disc text-sm">
               {synergyQueue[synergyIndex].bullets.map((m, idx) => (
                 <li key={idx}>{m}</li>
               ))}
             </ul>
-            <div className="flex justify-end gap-2">
-              <button
-                className="generator-button"
-                onClick={nextSynergy}
-              >
+            <div className="modal-actions">
+              <button className="generator-button" onClick={nextSynergy}>
                 Skip
               </button>
               <button
@@ -1758,10 +1799,10 @@ Respond ONLY in this JSON format:
         document.body
       )}
     {editTask &&
-      ReactDOM.createPortal(
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 text-black">
-            <h3 className="text-lg font-semibold">Edit Task</h3>
+      createPortal(
+        <div className="modal-overlay">
+          <div className="initiative-card modal-content space-y-4">
+            <h3>Edit Task</h3>
             <div>
               <label className="block text-sm font-medium">Contact</label>
               <select
@@ -1816,7 +1857,7 @@ Respond ONLY in this JSON format:
                 Add Subtask
               </button>
             </div>
-            <div className="flex justify-end gap-2">
+            <div className="modal-actions">
               <button
                 className="generator-button"
                 onClick={() => setEditTask(null)}
@@ -2122,9 +2163,12 @@ Respond ONLY in this JSON format:
                 <button
                   className="generator-button"
                   onClick={async () => {
+                    await ensureContactsForSuggestions(
+                      analysisModal.selected
+                    );
                     await createTasksFromAnalysis(
                       analysisModal.name,
-                      analysisModal.selected,
+                      analysisModal.selected
                     );
                     setAnalysisModal(null);
                   }}

--- a/src/components/TaskQueue.jsx
+++ b/src/components/TaskQueue.jsx
@@ -1,6 +1,6 @@
 // src/TaskQueue.jsx
 import { useState, useMemo } from "react";
-import ReactDOM from "react-dom";
+import { createPortal } from "react-dom";
 import PropTypes from "prop-types";
 import { generate } from "../ai";
 import { dedupeByMessage } from "../utils/taskUtils";
@@ -156,9 +156,15 @@ export default function TaskQueue({
         case "email":
           header = `Send an email to ${assignee}`;
           break;
-        case "meeting":
-          header = `Set up a meeting with ${assignee}`;
+        case "meeting": {
+          const current =
+            auth.currentUser?.displayName || auth.currentUser?.email || "";
+          header =
+            assignee === current
+              ? "Suggested meetings"
+              : `Set up a meeting with ${assignee}`;
           break;
+        }
         case "call":
           header = `Call ${assignee}`;
           break;
@@ -351,7 +357,7 @@ export default function TaskQueue({
       </div>
 
       {selectedItem &&
-        ReactDOM.createPortal(
+      createPortal(
           <div className="modal-overlay">
             <div className="task-modal">
               <h3>Reply to {selectedItem.name}</h3>
@@ -386,7 +392,7 @@ export default function TaskQueue({
         )}
 
       {synergyQueue.length > 0 &&
-        ReactDOM.createPortal(
+      createPortal(
           <div className="modal-overlay">
             <div className="task-modal">
               <h3>Synergize Tasks</h3>
@@ -419,7 +425,7 @@ export default function TaskQueue({
         )}
 
       {prioritized &&
-        ReactDOM.createPortal(
+      createPortal(
           <div className="modal-overlay">
             <div className="task-modal">
               <h3>Prioritized Tasks</h3>

--- a/src/pages/admin.css
+++ b/src/pages/admin.css
@@ -178,7 +178,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 10000;
   }
   
   /* Modal box centered on screen */
@@ -275,7 +275,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 10000;
   }
   
   .modal {


### PR DESCRIPTION
## Summary
- Render synergy and edit dialogs with existing modal overlay classes so they appear above task lists
- Replace unsupported `serverTimestamp` usage in subtask array with `Timestamp.now`
- Prompt to create new contacts when AI-suggested tasks reference unknown people

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a79b01a90c832b9472782ad7615a60