### PR TITLE
Add provenance chips to tasks and status reports

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -141,6 +141,30 @@
   cursor: pointer;
 }
 
+.provenance-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.provenance-group {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.prov-chip {
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  padding: 0.1rem 0.3rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.highlight-question {
+  outline: 2px solid #f59e0b;
+}
+
 .contact-tag button {
   background: none;
   border: none;

--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -147,6 +147,16 @@ const ProjectStatus = ({
     (t) => `- ${t.message || ""} (${t.status || "open"})`
   );
 
+  const provenanceNotes = tasks
+    .filter((t) => Array.isArray(t.provenance) && t.provenance.length)
+    .map((t) => {
+      const refs = t.provenance
+        .map((p) => `Q${p.question + 1}/A${p.answer + 1}`)
+        .join(", ");
+      return `- ${t.message || ""} (${refs})`;
+    })
+    .join("\n");
+
   const allOutstanding = [...outstandingQuestionsArr, ...taskListArr].join("\n");
 
   const sponsor = contacts.find((c) => /sponsor/i.test(c.role || ""));
@@ -234,9 +244,12 @@ ${allOutstanding || "None"}`;
   try {
     const { text } = await ai.generate(prompt);
     const clean = text.trim();
-    setSummary(clean);
+    const final = provenanceNotes
+      ? `${clean}\n\nProvenance notes:\n${provenanceNotes}`
+      : clean;
+    setSummary(final);
     const now = new Date().toISOString();
-    const entry = { date: now, summary: clean, sent: false };
+    const entry = { date: now, summary: final, sent: false };
     const colRef = collection(
       db,
       "users",

--- a/src/pages/admin.css
+++ b/src/pages/admin.css
@@ -238,6 +238,26 @@
     justify-content: space-between;
     margin-top: 10px;
   }
+
+  .provenance-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 4px;
+  }
+
+  .provenance-group {
+    display: flex;
+    gap: 4px;
+  }
+
+  .prov-chip {
+    background: rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
   
   .complete-button {
     background-color: #64ffda;


### PR DESCRIPTION
## Summary
- capture question/answer provenance when generating tasks
- display provenance chips with deep links to source questions
- merge tasks while preserving provenance and report provenance notes in status updates

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a87e2d4e5c832b93329ccee9ba75ab