### PR TITLE
feat: enhance suggested tasks workflow

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -39,6 +39,19 @@
   margin-bottom: 1rem;
 }
 
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  opacity: 0.9;
+  z-index: 1000;
+}
+
 .question-card {
   position: relative;
   margin-bottom: 1rem;

--- a/src/components/TaskQueue.jsx
+++ b/src/components/TaskQueue.jsx
@@ -256,14 +256,14 @@ export default function TaskQueue({
             <div key={idx} className="provenance-group">
               <span
                 className="prov-chip"
-                title={p.preview}
+                title={p.questionPreview || p.preview}
                 onClick={() => navigate(`/discovery?focus=${p.question}`)}
               >
                 {`Q${p.question + 1}`}
               </span>
               <span
                 className="prov-chip"
-                title={p.preview}
+                title={p.answerPreview || p.preview}
                 onClick={() => navigate(`/discovery?focus=${p.question}`)}
               >
                 {`A${p.answer + 1}`}
@@ -271,7 +271,7 @@ export default function TaskQueue({
               {p.ruleId && (
                 <span
                   className="prov-chip"
-                  title={p.preview}
+                  title={p.answerPreview || p.preview}
                   onClick={() => navigate(`/discovery?focus=${p.question}`)}
                 >
                   {p.ruleId}


### PR DESCRIPTION
## Summary
- Prompt to create contacts or reassign when suggested task assignee is unknown, parsing multiple contacts individually
- Add select-all checkbox and dynamic "Add N tasks" button with toast confirmation
- Detect duplicate tasks and offer add/skip/merge options with simple merge prompt
- Fix provenance chip tooltip to show respective question or answer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a881b477a8832b8f229a5aa1bbe4b2