### PR TITLE
feat: enhance suggested tasks workflow

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -39,6 +39,19 @@
   margin-bottom: 1rem;
 }
 
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  opacity: 0.9;
+  z-index: 1000;
+}
+
 .question-card {
   position: relative;
   margin-bottom: 1rem;

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -69,9 +69,32 @@ const colorPalette = [
   "#e2ccff",
 ];
 
+const parseContactNames = (whoRaw) => {
+  if (!whoRaw) return [];
+  const suffixMatch = whoRaw.trim().match(/\b(Teams?|Departments?|Groups?)$/i);
+  if (suffixMatch) {
+    const base = whoRaw.trim().slice(0, suffixMatch.index).trim();
+    const parts = base
+      .split(/\s*(?:,|and|&)\s*/i)
+      .map((p) => p.trim())
+      .filter(Boolean);
+    if (
+      parts.length > 1 &&
+      parts.every((p) => !/\b(Team|Department|Group)\b$/i.test(p))
+    ) {
+      const suffix = " " + suffixMatch[1].replace(/s$/i, "");
+      return parts.map((p) => p + suffix);
+    }
+  }
+  return whoRaw
+    .split(/\s*(?:,|and|&)\s*/i)
+    .map((p) => p.trim())
+    .filter(Boolean);
+};
+
 const normalizeContacts = (value) => {
   if (!value) return [];
-  return Array.isArray(value) ? value : [value];
+  return Array.isArray(value) ? value : parseContactNames(value);
 };
 
 const DiscoveryHub = () => {
@@ -117,6 +140,14 @@ const DiscoveryHub = () => {
   const [activeComposer, setActiveComposer] = useState(null);
   const [restoredDraftKey, setRestoredDraftKey] = useState(null);
   const [composerError, setComposerError] = useState(null);
+  const [toast, setToast] = useState(null);
+  const [assigneeChoices, setAssigneeChoices] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem("assigneeChoices") || "{}");
+    } catch {
+      return {};
+    }
+  });
   const restoredRef = useRef(false);
   const [analyzing, setAnalyzing] = useState(false);
   const [projectName, setProjectName] = useState("");
@@ -170,6 +201,16 @@ const DiscoveryHub = () => {
   }, [questions]);
 
   useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  useEffect(() => {
+    localStorage.setItem("assigneeChoices", JSON.stringify(assigneeChoices));
+  }, [assigneeChoices]);
+
+  useEffect(() => {
     const focus = searchParams.get("focus");
     if (focus !== null) {
       const idx = parseInt(focus, 10);
@@ -190,8 +231,13 @@ const DiscoveryHub = () => {
   const taskContacts = useMemo(() => {
     const set = new Set();
     projectTasks.forEach((t) => {
-      const assignee = t.assignee || currentUserName;
-      set.add(assignee === currentUserName ? "My Tasks" : assignee);
+      const assignees =
+        t.assignees && t.assignees.length
+          ? t.assignees
+          : [t.assignee || currentUserName];
+      assignees.forEach((a) => {
+        set.add(a === currentUserName ? "My Tasks" : a);
+      });
     });
     return Array.from(set);
   }, [projectTasks, currentUserName]);
@@ -215,9 +261,14 @@ const DiscoveryHub = () => {
     }
     if (taskContactFilter !== "all") {
       tasks = tasks.filter((t) => {
-        const assignee = t.assignee || currentUserName;
-        const label = assignee === currentUserName ? "My Tasks" : assignee;
-        return label === taskContactFilter;
+        const assignees =
+          t.assignees && t.assignees.length
+            ? t.assignees
+            : [t.assignee || currentUserName];
+        const labels = assignees.map((a) =>
+          a === currentUserName ? "My Tasks" : a
+        );
+        return labels.includes(taskContactFilter);
       });
     }
     if (taskTypeFilter !== "all") {
@@ -236,10 +287,15 @@ const DiscoveryHub = () => {
   const tasksByAssignee = useMemo(() => {
     const map = {};
     displayedTasks.forEach((t) => {
-      const assignee = t.assignee || currentUserName;
-      const label = assignee === currentUserName ? "My Tasks" : assignee;
-      if (!map[label]) map[label] = [];
-      map[label].push(t);
+      const assignees =
+        t.assignees && t.assignees.length
+          ? t.assignees
+          : [t.assignee || currentUserName];
+      assignees.forEach((a) => {
+        const label = a === currentUserName ? "My Tasks" : a;
+        if (!map[label]) map[label] = [];
+        map[label].push(t);
+      });
     });
     return map;
   }, [displayedTasks, currentUserName]);
@@ -553,8 +609,8 @@ Respond ONLY in this JSON format:
 
     const questionsToAdd = [];
     const tasksToAdd = [];
+    let addedCount = 0;
 
-    const existingTaskSet = new Set(projectTasks.map((t) => t.message.toLowerCase()));
     const existingQuestionSet = new Set(
       questions.map((q) => q.question.toLowerCase())
     );
@@ -565,56 +621,103 @@ Respond ONLY in this JSON format:
       Object.keys(answerObj).indexOf(name)
     );
     const answerText = answerObj[name]?.text || "";
-    const preview = answerText
+    const answerPreview = answerText
       .split(/(?<=\.)\s+/)
       .slice(0, 2)
       .join(" ")
       .slice(0, 200);
+    const questionText = questions[idx]?.question || "";
+    const questionPreview = questionText.slice(0, 200);
 
     try {
       for (const s of suggestions) {
         const lowerText = s.text.toLowerCase();
-        if (existingTaskSet.has(lowerText) || existingQuestionSet.has(lowerText))
-          continue;
+        if (existingQuestionSet.has(lowerText)) continue;
 
-        let match = contacts.find(
-          (c) =>
-            c.name.toLowerCase() === (s.who || "").toLowerCase() ||
-            (c.role || "").toLowerCase() === (s.who || "").toLowerCase()
+        const duplicateTasks = projectTasks.filter(
+          (t) => t.message.toLowerCase() === lowerText
         );
+        if (duplicateTasks.length > 0) {
+          const choice = prompt(
+            `Task with the same intent already exists:\n${duplicateTasks
+              .map((t) => `- ${t.message}`)
+              .join("\n")}\nAdd anyway (a) / Skip (s) / Merge now (m)?`,
+            "s"
+          );
+          const c = (choice || "").toLowerCase();
+          if (c === "" || c === "s") {
+            continue;
+          }
+          if (c === "m") {
+            const existing = duplicateTasks[0];
+            const merged = prompt(
+              `Existing: ${existing.message}\nNew: ${s.text}\nMerged task:`,
+              `${existing.message}; ${s.text}`
+            );
+            if (merged) {
+              const tag = await classifyTask(merged);
+              await updateDoc(
+                doc(
+                  db,
+                  "users",
+                  uid,
+                  "initiatives",
+                  initiativeId,
+                  "tasks",
+                  existing.id
+                ),
+                { message: merged, tag }
+              );
+            }
+            continue;
+          }
+        }
+
+        const assigneeNames =
+          s.assignees && s.assignees.length
+            ? s.assignees
+            : parseContactNames(s.who || "");
 
         if (s.category === "question") {
-          const assignedContact = match ? match.name : name;
-
+          const contactsList = assigneeNames.length ? assigneeNames : [name];
+          const asked = contactsList.reduce(
+            (acc, c) => ({ ...acc, [c]: false }),
+            {}
+          );
           questionsToAdd.push({
             question: s.text,
-            contacts: assignedContact ? [assignedContact] : [],
+            contacts: contactsList,
             answers: {},
-            asked: assignedContact ? { [assignedContact]: false } : {},
+            asked,
           });
           existingQuestionSet.add(lowerText);
         } else {
           const tag = await classifyTask(s.text);
-          const assignee = match ? match.name : currentUserName;
+          const finalAssignees = assigneeNames.length
+            ? assigneeNames
+            : [currentUserName];
           const provenance = [
             {
               question: idx,
               answer: answerIndex,
-              preview,
+              questionPreview,
+              answerPreview,
+              preview: answerPreview,
               ruleId: s.ruleId || s.templateId || null,
             },
           ];
           tasksToAdd.push({
             name,
             message: s.text,
-            assignee,
+            assignees: finalAssignees,
+            assignee: finalAssignees[0],
             subType: s.category,
             status: "open",
             createdAt: serverTimestamp(),
             tag,
             provenance,
           });
-          existingTaskSet.add(lowerText);
+          addedCount += 1;
         }
       }
 
@@ -650,6 +753,7 @@ Respond ONLY in this JSON format:
           return updatedQuestions;
         });
       }
+      return addedCount;
     } catch (err) {
       console.error("createTasksFromAnalysis error", err);
     }
@@ -715,7 +819,10 @@ Respond ONLY in this JSON format:
   const openEditModal = (task) => {
     setEditTask({
       id: task.id,
-      assignee: task.assignee || currentUserName,
+      assignees:
+        task.assignees && task.assignees.length
+          ? [...task.assignees]
+          : [task.assignee || currentUserName],
       subType: task.subType || "task",
       subTasks: task.subTasks ? task.subTasks.map((st) => ({ ...st })) : [],
     });
@@ -750,13 +857,16 @@ Respond ONLY in this JSON format:
 
   const saveEditTask = async () => {
     if (!uid || !initiativeId || !editTask) return;
-    const assignee =
-      editTask.assignee === "My Tasks" ? currentUserName : editTask.assignee;
+    const assignees =
+      editTask.assignees && editTask.assignees.length
+        ? editTask.assignees
+        : [currentUserName];
     try {
       await updateDoc(
         doc(db, "users", uid, "initiatives", initiativeId, "tasks", editTask.id),
         {
-          assignee,
+          assignees,
+          assignee: assignees[0],
           subType: editTask.subType,
           subTasks: editTask.subTasks,
         }
@@ -772,7 +882,11 @@ Respond ONLY in this JSON format:
     displayedTasks
       .filter((t) => (t.status || "open") === "open")
       .forEach((t) => {
-        const key = `${t.assignee || t.name || ""}-${
+        const assignees =
+          t.assignees && t.assignees.length
+            ? t.assignees
+            : [t.assignee || t.name || ""];
+        const key = `${assignees.slice().sort().join("|")}-${
           t.subType || t.tag || "other"
         }`;
         if (!map[key]) map[key] = [];
@@ -789,24 +903,28 @@ Respond ONLY in this JSON format:
     }
     const proposals = bundles.map((b) => {
       const first = b[0];
-      const assignee = first.assignee || first.name || "";
+      const assignees =
+        first.assignees && first.assignees.length
+          ? first.assignees
+          : [first.assignee || first.name || ""];
+      const assigneeLabel = assignees.join(", ");
       const type = first.subType || first.tag || "";
       let header;
       switch (type) {
         case "email":
-          header = `Send an email to ${assignee}`;
+          header = `Send an email to ${assigneeLabel}`;
           break;
         case "meeting":
           header =
-            assignee === currentUserName
+            assignees.length === 1 && assignees[0] === currentUserName
               ? "Suggested meetings"
-              : `Set up a meeting with ${assignee}`;
+              : `Set up a meeting with ${assigneeLabel}`;
           break;
         case "call":
-          header = `Call ${assignee}`;
+          header = `Call ${assigneeLabel}`;
           break;
         default:
-          header = `Work with ${assignee}`;
+          header = `Work with ${assigneeLabel}`;
       }
       const bullets = dedupeByMessage(b).map((t) => t.message);
       const text = [header, ...bullets.map((m) => `- ${m}`)].join("\n");
@@ -911,14 +1029,25 @@ Respond ONLY in this JSON format:
   };
 
   const renderTaskCard = (t, actionButtons) => {
-    const contact = t.assignee || currentUserName;
-    const contactLabel = contact === currentUserName ? "My Tasks" : contact;
+    const contactsArr =
+      t.assignees && t.assignees.length
+        ? t.assignees
+        : [t.assignee || currentUserName];
+    const contactLabels = contactsArr.map((c) =>
+      c === currentUserName ? "My Tasks" : c
+    );
     const project = t.project || projectName || "General";
     return (
       <div key={t.id} className="initiative-card task-card space-y-3">
         {t.tag && <span className={`task-tag ${t.tag}`}>{t.tag}</span>}
         <div className="task-card-header">
-          <span className="task-contact">{contactLabel}</span>
+          <div className="flex flex-wrap gap-1">
+            {contactLabels.map((lbl) => (
+              <span key={lbl} className="task-contact">
+                {lbl}
+              </span>
+            ))}
+          </div>
           <span className="task-project">{project}</span>
         </div>
         <p>{t.message}</p>
@@ -928,14 +1057,14 @@ Respond ONLY in this JSON format:
               <div key={idxP} className="provenance-group">
                 <span
                   className="prov-chip"
-                  title={p.preview}
+                  title={p.questionPreview || p.preview}
                   onClick={() => focusQuestionCard(p.question)}
                 >
                   {`Q${p.question + 1}`}
                 </span>
                 <span
                   className="prov-chip"
-                  title={p.preview}
+                  title={p.answerPreview || p.preview}
                   onClick={() => focusQuestionCard(p.question)}
                 >
                   {`A${p.answer + 1}`}
@@ -943,7 +1072,7 @@ Respond ONLY in this JSON format:
                 {p.ruleId && (
                   <span
                     className="prov-chip"
-                    title={p.preview}
+                    title={p.answerPreview || p.preview}
                     onClick={() => focusQuestionCard(p.question)}
                   >
                     {p.ruleId}
@@ -1177,16 +1306,74 @@ Respond ONLY in this JSON format:
     return name;
   };
 
-  const filterSuggestionsForContacts = (suggestions) => {
-    const known = new Set(contacts.map((c) => c.name.toLowerCase()));
-    return suggestions.filter((s) => {
-      const who = (s.who || "").trim().toLowerCase();
-      return (
-        !who ||
-        who === currentUserName.toLowerCase() ||
-        known.has(who)
-      );
-    });
+  const resolveSuggestionsForContacts = async (suggestions) => {
+    let updatedContacts = [...contacts];
+    const known = new Set(updatedContacts.map((c) => c.name.toLowerCase()));
+    const resolved = [];
+    for (const s of suggestions) {
+      const names = parseContactNames(s.who || "");
+      if (!names.length) {
+        resolved.push({ ...s, assignees: [] });
+        continue;
+      }
+      const finalNames = [];
+      for (const name of names) {
+        const lower = name.toLowerCase();
+        if (
+          !name ||
+          lower === "current user" ||
+          lower === currentUserName.toLowerCase()
+        ) {
+          finalNames.push(currentUserName);
+          continue;
+        }
+        if (known.has(lower)) {
+          finalNames.push(name);
+          continue;
+        }
+        if (assigneeChoices[lower]) {
+          if (assigneeChoices[lower] === "create") {
+            finalNames.push(name);
+            known.add(lower);
+          } else {
+            finalNames.push(currentUserName);
+          }
+          continue;
+        }
+        const create = window.confirm(
+          `${name} is not a project contact.\nClick OK to create this contact or Cancel to assign to yourself.`
+        );
+        setAssigneeChoices((prev) => ({
+          ...prev,
+          [lower]: create ? "create" : "self",
+        }));
+        if (create) {
+          const color = colorPalette[updatedContacts.length % colorPalette.length];
+          const newContact = { role: "", name, email: "", color };
+          updatedContacts = [...updatedContacts, newContact];
+          setContacts(updatedContacts);
+          if (uid) {
+            saveInitiative(uid, initiativeId, {
+              keyContacts: updatedContacts.map(({ name, role, email }) => ({
+                name,
+                role,
+                email,
+              })),
+            });
+          }
+          known.add(lower);
+          finalNames.push(name);
+        } else {
+          finalNames.push(currentUserName);
+        }
+      }
+      resolved.push({
+        ...s,
+        who: finalNames.join(", "),
+        assignees: finalNames,
+      });
+    }
+    return resolved;
   };
 
   const addContactToQuestion = (idx, name) => {
@@ -1688,6 +1875,7 @@ Respond ONLY in this JSON format:
 
   return (
     <div className="dashboard-container discovery-hub">
+      {toast && <div className="toast">{toast}</div>}
       <aside className="sidebar">
         <h2>Discovery Hub</h2>
         <ul>
@@ -2048,17 +2236,19 @@ Respond ONLY in this JSON format:
           <div className="initiative-card modal-content space-y-4">
             <h3>Edit Task</h3>
             <div>
-              <label className="block text-sm font-medium">Contact</label>
+              <label className="block text-sm font-medium">Contacts</label>
               <select
-                value={
-                  editTask.assignee === currentUserName
-                    ? "My Tasks"
-                    : editTask.assignee
+                multiple
+                value={editTask.assignees}
+                onChange={(e) =>
+                  updateEditTaskField(
+                    "assignees",
+                    Array.from(e.target.selectedOptions, (o) => o.value)
+                  )
                 }
-                onChange={(e) => updateEditTaskField("assignee", e.target.value)}
                 className="w-full rounded-md border px-2 py-1"
               >
-                <option value="My Tasks">My Tasks</option>
+                <option value={currentUserName}>My Tasks</option>
                 {contacts.map((c) => (
                   <option key={c.name} value={c.name}>
                     {c.name}
@@ -2441,21 +2631,46 @@ Respond ONLY in this JSON format:
                   analysisModal.suggestions.length > 0 && (
                     <>
                       <p>Suggested tasks:</p>
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={
+                            analysisModal.selected.length ===
+                              analysisModal.suggestions.length &&
+                            analysisModal.suggestions.length > 0
+                          }
+                          onChange={(e) =>
+                            setAnalysisModal((prev) => ({
+                              ...prev,
+                              selected: e.target.checked
+                                ? prev.suggestions
+                                : [],
+                            }))
+                          }
+                        />
+                        Select All
+                      </label>
                       <ul>
-                        {analysisModal.suggestions.map((s, i) => (
-                          <li key={i}>
-                            <label>
-                              <input
-                                type="checkbox"
-                                checked={analysisModal.selected.some(
-                                  (item) => item.text === s.text
-                                )}
-                                onChange={() => toggleSuggestion(s)}
-                              />
-                              {suggestionIcon(s.category)} {`[${s.category}] ${s.text} (${s.who})`}
-                            </label>
-                          </li>
-                        ))}
+                        {analysisModal.suggestions.map((s, i) => {
+                          const whoDisplay = Array.isArray(s.assignees)
+                            ? s.assignees.join(", ")
+                            : s.who;
+                          return (
+                            <li key={i}>
+                              <label>
+                                <input
+                                  type="checkbox"
+                                  checked={analysisModal.selected.some(
+                                    (item) => item.text === s.text
+                                  )}
+                                  onChange={() => toggleSuggestion(s)}
+                                />
+                                {suggestionIcon(s.category)} {`[${s.category}] ${s.text}`}
+                                {whoDisplay ? ` (${whoDisplay})` : ""}
+                              </label>
+                            </li>
+                          );
+                        })}
                       </ul>
                     </>
                   )}
@@ -2477,29 +2692,21 @@ Respond ONLY in this JSON format:
                     <button
                       className="generator-button"
                       onClick={async () => {
-                        const filtered = filterSuggestionsForContacts(
+                        const resolved = await resolveSuggestionsForContacts(
                           analysisModal.selected
                         );
-                        if (filtered.length === 0) {
-                          alert(
-                            "No tasks added: assignees must be existing project contacts."
-                          );
-                          return;
-                        }
-                        if (filtered.length < analysisModal.selected.length) {
-                          alert(
-                            "Some tasks were skipped because the assignees are not project contacts."
-                          );
-                        }
-                        await createTasksFromAnalysis(
+                        const added = await createTasksFromAnalysis(
                           analysisModal.idx,
                           analysisModal.name,
-                          filtered
+                          resolved
                         );
+                        if (added > 0) {
+                          setToast(`Added ${added} tasks.`);
+                        }
                         setAnalysisModal(null);
                       }}
                     >
-                      Add Selected Items
+                      {`Add ${analysisModal.selected.length} tasks`}
                     </button>
                   )}
                   <button

--- a/src/components/TaskQueue.jsx
+++ b/src/components/TaskQueue.jsx
@@ -150,7 +150,11 @@ export default function TaskQueue({
     tasks
       .filter((t) => (t.status || "open") === "open")
       .forEach((t) => {
-        const key = `${t.assignee || t.name || ""}-${
+        const assignees =
+          t.assignees && t.assignees.length
+            ? t.assignees
+            : [t.assignee || t.name || ""];
+        const key = `${assignees.slice().sort().join("|")}-${
           t.subType || t.tag || "other"
         }`;
         if (!map[key]) map[key] = [];
@@ -167,27 +171,31 @@ export default function TaskQueue({
     }
     const proposals = bundles.map((b) => {
       const first = b[0];
-      const assignee = first.assignee || first.name || "";
+      const assignees =
+        first.assignees && first.assignees.length
+          ? first.assignees
+          : [first.assignee || first.name || ""];
+      const assigneeLabel = assignees.join(", ");
       const type = first.subType || first.tag || "";
       let header;
       switch (type) {
         case "email":
-          header = `Send an email to ${assignee}`;
+          header = `Send an email to ${assigneeLabel}`;
           break;
         case "meeting": {
           const current =
             auth.currentUser?.displayName || auth.currentUser?.email || "";
           header =
-            assignee === current
+            assignees.length === 1 && assignees[0] === current
               ? "Suggested meetings"
-              : `Set up a meeting with ${assignee}`;
+              : `Set up a meeting with ${assigneeLabel}`;
           break;
         }
         case "call":
-          header = `Call ${assignee}`;
+          header = `Call ${assigneeLabel}`;
           break;
         default:
-          header = `Work with ${assignee}`;
+          header = `Work with ${assigneeLabel}`;
       }
       const bullets = dedupeByMessage(b).map((t) => t.message);
       const text = [header, ...bullets.map((m) => `- ${m}`)].join("\n");
@@ -246,7 +254,9 @@ export default function TaskQueue({
   const renderTask = (task) => (
     <li key={task.id} className="task-item">
       <strong>
-        {task.name} ({task.email})
+        {task.assignees && task.assignees.length
+          ? task.assignees.join(", ")
+          : `${task.name} (${task.email})`}
       </strong>
       {task.tag && <span className={`tag-badge tag-${task.tag}`}>{task.tag}</span>}
       <p>{task.message}</p>
@@ -256,14 +266,14 @@ export default function TaskQueue({
             <div key={idx} className="provenance-group">
               <span
                 className="prov-chip"
-                title={p.preview}
+                title={p.questionPreview || p.preview}
                 onClick={() => navigate(`/discovery?focus=${p.question}`)}
               >
                 {`Q${p.question + 1}`}
               </span>
               <span
                 className="prov-chip"
-                title={p.preview}
+                title={p.answerPreview || p.preview}
                 onClick={() => navigate(`/discovery?focus=${p.question}`)}
               >
                 {`A${p.answer + 1}`}
@@ -271,7 +281,7 @@ export default function TaskQueue({
               {p.ruleId && (
                 <span
                   className="prov-chip"
-                  title={p.preview}
+                  title={p.answerPreview || p.preview}
                   onClick={() => navigate(`/discovery?focus=${p.question}`)}
                 >
                   {p.ruleId}


### PR DESCRIPTION
## Summary
- Persist assignee decisions and auto-assign "Current User" without prompts
- Create and edit tasks with multiple assignees while keeping group context for synergy
- Show all task contacts and only synergize tasks with identical assignee groups

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a881b477a8832b8f229a5aa1bbe4b2