### PR TITLE
Ensure role-based tasks show under My Tasks and add Instructional Design type

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -359,6 +359,11 @@
   color: #fbcfe8;
 }
 
+.task-tag.instructional-design {
+  background-color: #4c1d95;
+  color: #ddd6fe;
+}
+
 .task-tag.default {
   background-color: #374151;
   color: #d1d5db;

--- a/src/components/TaskQueue.jsx
+++ b/src/components/TaskQueue.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { createPortal } from "react-dom";
 import PropTypes from "prop-types";
 import { generate } from "../ai";
-import { dedupeByMessage } from "../utils/taskUtils";
+import { dedupeByMessage, normalizeAssigneeName } from "../utils/taskUtils";
 import { auth, db } from "../firebase";
 import { updateDoc, deleteDoc, doc, serverTimestamp } from "firebase/firestore";
 import "../pages/admin.css";
@@ -28,23 +28,45 @@ export default function TaskQueue({
   const [prioritized, setPrioritized] = useState(null);
   const navigate = useNavigate();
 
+  const currentUserName =
+    auth.currentUser?.displayName || auth.currentUser?.email || "";
+
+  const normalizedTasks = useMemo(
+    () =>
+      tasks.map((t) => {
+        const assignees =
+          t.assignees && t.assignees.length
+            ? t.assignees.map((a) =>
+                normalizeAssigneeName(a, currentUserName),
+              )
+            : [
+                normalizeAssigneeName(
+                  t.assignee || t.name || "",
+                  currentUserName,
+                ),
+              ];
+        return { ...t, assignees, assignee: assignees[0] };
+      }),
+    [tasks, currentUserName],
+  );
+
   const projects = useMemo(() => {
     const set = new Set();
-    tasks.forEach((t) => {
+    normalizedTasks.forEach((t) => {
       set.add(t.project || "General");
     });
     return Array.from(set);
-  }, [tasks]);
+  }, [normalizedTasks]);
 
   const filteredTasks = useMemo(
     () =>
-      tasks.filter(
+      normalizedTasks.filter(
         (t) =>
           (statusFilter === "all" || (t.status || "open") === statusFilter) &&
           (projectFilter === "all" || t.project === projectFilter) &&
           (tagFilter === "all" || t.tag === tagFilter)
       ),
-    [tasks, statusFilter, projectFilter, tagFilter]
+    [normalizedTasks, statusFilter, projectFilter, tagFilter]
   );
 
   const groupedTasks = useMemo(() => {
@@ -147,7 +169,7 @@ export default function TaskQueue({
 
   const computeBundles = () => {
     const map = {};
-    tasks
+    normalizedTasks
       .filter((t) => (t.status || "open") === "open")
       .forEach((t) => {
         const assignees =
@@ -175,7 +197,7 @@ export default function TaskQueue({
         first.assignees && first.assignees.length
           ? first.assignees
           : [first.assignee || first.name || ""];
-      const assigneeLabel = assignees.join(", ");
+      const assigneeLabel = Array.from(new Set(assignees)).join(", ");
       const type = first.subType || first.tag || "";
       let header;
       switch (type) {
@@ -219,7 +241,9 @@ export default function TaskQueue({
 
   const startPrioritize = async () => {
     try {
-      const openTasks = tasks.filter((t) => (t.status || "open") === "open");
+      const openTasks = normalizedTasks.filter(
+        (t) => (t.status || "open") === "open",
+      );
       const { text } = await generate(
         `Order the following tasks by priority and return a JSON array of ids in order:\n${openTasks
           .map((t) => `${t.id}: ${t.message}`)
@@ -237,7 +261,9 @@ export default function TaskQueue({
     } catch (err) {
       console.error("prioritize", err);
     }
-    const openTasks = tasks.filter((t) => (t.status || "open") === "open");
+    const openTasks = normalizedTasks.filter(
+      (t) => (t.status || "open") === "open",
+    );
     setPrioritized([...openTasks]);
   };
 
@@ -262,33 +288,39 @@ export default function TaskQueue({
       <p>{task.message}</p>
       {Array.isArray(task.provenance) && task.provenance.length > 0 && (
         <div className="provenance-chips">
-          {task.provenance.map((p, idx) => (
-            <div key={idx} className="provenance-group">
-              <span
-                className="prov-chip"
-                title={p.questionPreview || p.preview}
-                onClick={() => navigate(`/discovery?focus=${p.question}`)}
-              >
-                {`Q${p.question + 1}`}
-              </span>
-              <span
-                className="prov-chip"
-                title={p.answerPreview || p.preview}
-                onClick={() => navigate(`/discovery?focus=${p.question}`)}
-              >
-                {`A${p.answer + 1}`}
-              </span>
-              {p.ruleId && (
+          {task.provenance.map((p, idx) => {
+            const params = new URLSearchParams();
+            if (task.project) params.set("initiativeId", task.project);
+            params.set("focus", p.question);
+            const link = `/discovery?${params.toString()}`;
+            return (
+              <div key={idx} className="provenance-group">
+                <span
+                  className="prov-chip"
+                  title={p.questionPreview || p.preview}
+                  onClick={() => navigate(link)}
+                >
+                  {`Q${p.question + 1}`}
+                </span>
                 <span
                   className="prov-chip"
                   title={p.answerPreview || p.preview}
-                  onClick={() => navigate(`/discovery?focus=${p.question}`)}
+                  onClick={() => navigate(link)}
                 >
-                  {p.ruleId}
+                  {`A${p.answer + 1}`}
                 </span>
-              )}
-            </div>
-          ))}
+                {p.ruleId && (
+                  <span
+                    className="prov-chip"
+                    title={p.answerPreview || p.preview}
+                    onClick={() => navigate(link)}
+                  >
+                    {p.ruleId}
+                  </span>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
       <div className="task-actions">
@@ -339,12 +371,13 @@ export default function TaskQueue({
           </select>
           <select value={tagFilter} onChange={(e) => setTagFilter(e.target.value)}>
             <option value="all">All Tags</option>
-            <option value="email">email</option>
-            <option value="call">call</option>
-            <option value="meeting">meeting</option>
-            <option value="research">research</option>
-          </select>
-        </div>
+          <option value="email">email</option>
+          <option value="call">call</option>
+          <option value="meeting">meeting</option>
+          <option value="research">research</option>
+          <option value="instructional-design">instructional-design</option>
+        </select>
+      </div>
 
         {/* Render the Task Queue items */}
         <h3>Tasks</h3>

--- a/src/pages/admin.css
+++ b/src/pages/admin.css
@@ -161,6 +161,10 @@
     background-color: #f5a623;
   }
 
+  .tag-instructional-design {
+    background-color: #4c1d95;
+  }
+
   .bundle-group {
     border: 1px dashed #8C259E;
     padding: 10px;

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -25,7 +25,23 @@ export async function classifyTask(message) {
     return "research";
   }
 
-  const prompt = `You are a smart assistant that decides how to handle tasks.\nChoose exactly one of: email, call, meeting, research.\nTask: ${message}`;
+  const designKeywords = [
+    "design",
+    "develop",
+    "create",
+    "build",
+    "draft",
+    "write",
+    "outline",
+    "storyboard",
+    "instructional",
+    "content",
+  ];
+  if (designKeywords.some((k) => lower.includes(k))) {
+    return "instructional-design";
+  }
+
+  const prompt = `You are a smart assistant that decides how to handle tasks.\nChoose exactly one of: email, call, meeting, research, instructional-design.\nTask: ${message}`;
   try {
     const { text } = await generate(prompt);
     const response = text.trim().toLowerCase();
@@ -33,6 +49,8 @@ export async function classifyTask(message) {
     if (response.includes("call")) return "call";
     if (response.includes("chat")) return "call";
     if (response.includes("research")) return "research";
+    if (response.includes("instructional-design") || response.includes("design"))
+      return "instructional-design";
     return "email";
   } catch (err) {
     console.error("classifyTask error", err);
@@ -94,4 +112,17 @@ export function dedupeByMessage(tasks) {
   });
 }
 
-export default { classifyTask, isQuestionTask, dedupeByMessage };
+export function normalizeAssigneeName(name, currentUser) {
+  const user = currentUser || "";
+  const normalized = (name || "").trim();
+  return /instructional\s*designer|performance\s*consultant/i.test(normalized)
+    ? user
+    : normalized || user;
+}
+
+export default {
+  classifyTask,
+  isQuestionTask,
+  dedupeByMessage,
+  normalizeAssigneeName,
+};


### PR DESCRIPTION
## Summary
- Normalize placeholder Instructional Designer/Performance Consultant assignees to the current user across the app
- Introduce an **Instructional Design** task type with distinct tag/color and generation support

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8a18117b0832bb1afb2525935057d