### PR TITLE
feat: enhance discovery hub task completion and counters

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -369,3 +369,12 @@
   color: #d1d5db;
 }
 
+.counter-card {
+  width: auto;
+  text-align: center;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+


### PR DESCRIPTION
## Summary
- add completion modal for tasks with notes or files triggering answer analysis
- show counters for questions and tasks and display "caught up" blurb when lists are empty
- ensure task tag updates with subtype edits and add counter card styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8cd9f6758832b951d57b80d02d6f5