### PR TITLE
Refine question counters layout and logic

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -376,5 +376,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin: 0;
 }
 

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -359,11 +359,17 @@ const DiscoveryHub = () => {
     let open = 0;
     let answered = 0;
     questions.forEach((q) => {
-      const allAnswered =
-        q.contacts.length > 0 &&
-        q.contacts.every((n) => (q.answers?.[n]?.text || "").trim());
-      if (allAnswered && q.contacts.length > 0) answered++;
-      else open++;
+      if (q.contacts.length === 0) {
+        open++;
+      } else {
+        q.contacts.forEach((name) => {
+          if ((q.answers?.[name]?.text || "").trim()) {
+            answered++;
+          } else {
+            open++;
+          }
+        });
+      }
     });
     return { open, answered };
   }, [questions]);
@@ -2783,7 +2789,7 @@ Respond ONLY in this JSON format:
               )}
             </div>
             {statusFilter === "" && (
-              <div className="flex gap-4 flex-wrap mb-4">
+              <div className="flex gap-4 mb-4">
                 <div className="initiative-card counter-card">
                   <div className="text-sm opacity-80">Open Questions</div>
                   <div className="text-3xl font-bold">{questionCounts.open}</div>


### PR DESCRIPTION
## Summary
- Show open and answered question counters on a single row
- Count question status per recipient rather than per question

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d5f9f900832b99b03a672ca0f94e