### PR TITLE
Clamp hypothesis confidence between 0 and 1

### DIFF
--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -122,6 +122,13 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
   const [modalOpen, setModalOpen] = useState(false);
   const [newHypothesis, setNewHypothesis] = useState("");
 
+  const selectedPct = selected
+    ? Math.min(
+        100,
+        Math.max(0, Math.round((selected.data.confidence || 0) * 100)),
+      )
+    : 0;
+
   const sizesRef = useRef({}); // remember manual resizes across renders
 
   const persistSize = useCallback((id, width, height) => {
@@ -152,8 +159,16 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
     const hs = hypotheses.map((h, i) => {
       const id = typeof h === "object" && h.id ? h.id : `hypothesis-${i}`;
       const conf = typeof h === "object" ? h.confidence : undefined;
-      const baseLabel = typeof h === "string" ? h : `${h.id ? `${h.id}: ` : ""}${h.statement || h.label || ""}`;
-      const label = typeof conf === "number" ? `${baseLabel} (${Math.round(conf * 100)}%)` : baseLabel;
+      const baseLabel =
+        typeof h === "string"
+          ? h
+          : `${h.id ? `${h.id}: ` : ""}${h.statement || h.label || ""}`;
+      const pct = Math.min(
+        100,
+        Math.max(0, Math.round((conf || 0) * 100)),
+      );
+      const label =
+        typeof conf === "number" ? `${baseLabel} (${pct}%)` : baseLabel;
 
       // place evenly around x=0, spacing by card width + margin
       const offset = (i - (hypotheses.length - 1) / 2) * (CARD_W + marginX);
@@ -283,17 +298,22 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
         </Panel>
 
         {selected && (
-          <Panel position="bottom-left" className="bg-black/70 text-white rounded-xl px-3 py-2 shadow max-w-[42vw]">
+          <Panel
+            position="bottom-left"
+            className="bg-black/70 text-white rounded-xl px-3 py-2 shadow max-w-[42vw]"
+          >
             <div className="flex items-center gap-2">
               <span className="truncate">Selected: {selected.data.label}</span>
               <input
                 type="range"
                 min="0"
                 max="100"
-                value={Math.round((selected.data.confidence || 0) * 100)}
-                onChange={(e) => updateConfidence(selected.id, Number(e.target.value) / 100)}
+                value={selectedPct}
+                onChange={(e) =>
+                  updateConfidence(selected.id, Number(e.target.value) / 100)
+                }
               />
-              <span>{Math.round((selected.data.confidence || 0) * 100)}%</span>
+              <span>{selectedPct}%</span>
             </div>
           </Panel>
         )}

--- a/src/context/InquiryMapContext.jsx
+++ b/src/context/InquiryMapContext.jsx
@@ -20,14 +20,16 @@ const defaultState = {
   recommendations: [],
 };
 
+const normalizeConfidence = (c) => Math.min(1, Math.max(0, c));
+
 const scoreFromImpact = (impact) => {
   switch (impact) {
     case "High":
-      return 20;
+      return 0.2;
     case "Medium":
-      return 10;
+      return 0.1;
     default:
-      return 5;
+      return 0.05;
   }
 };
 
@@ -182,7 +184,7 @@ ${hypothesesList}
                       impact: link.impact,
                     },
                   ],
-                  confidence: (h.confidence || 0) + delta,
+                  confidence: normalizeConfidence((h.confidence || 0) + delta),
                 }
               : h,
           );
@@ -255,7 +257,9 @@ ${hypothesesList}
       const data = snap.data();
       const current = data?.inquiryMap?.hypotheses || [];
       const updated = current.map((h) =>
-        h.id === hypothesisId ? { ...h, confidence } : h
+        h.id === hypothesisId
+          ? { ...h, confidence: normalizeConfidence(confidence) }
+          : h
       );
       await updateDoc(ref, { "inquiryMap.hypotheses": updated });
     },
@@ -285,4 +289,6 @@ InquiryMapProvider.propTypes = {
 };
 
 export const useInquiryMap = () => useContext(InquiryMapContext);
+
+export { normalizeConfidence };
 

--- a/src/context/__tests__/InquiryMapContext.test.jsx
+++ b/src/context/__tests__/InquiryMapContext.test.jsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeConfidence } from '../InquiryMapContext.jsx';
+
+describe('normalizeConfidence', () => {
+  it('clamps values below 0 to 0', () => {
+    expect(normalizeConfidence(-0.5)).toBe(0);
+  });
+
+  it('allows values within range', () => {
+    expect(normalizeConfidence(0.4)).toBe(0.4);
+  });
+
+  it('clamps values above 1 to 1', () => {
+    expect(normalizeConfidence(1.7)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `normalizeConfidence` helper to cap updates within [0,1]
- scale impact scores to fractional weights
- show clamped percent values in inquiry map UI
- add unit tests for confidence normalization

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*


------
https://chatgpt.com/codex/tasks/task_e_68aa6536a1b8832ba5342384213fe1e7