### PR TITLE
Apply logistic scaling to confidence evaluation

### DIFF
--- a/docs/confidence.md
+++ b/docs/confidence.md
@@ -1,0 +1,9 @@
+# Confidence Scaling
+
+Hypothesis confidence is derived from a weighted sum of supporting and refuting evidence. After each triage event, the raw score is passed through a logistic function to keep values between `0` and `1`:
+
+```
+confidence = 1 / (1 + Math.exp(-slope * raw))
+```
+
+The `slope` parameter (default `1.0`) controls how quickly confidence reacts to new evidence. It is defined in `src/utils/confidence.js` and can be adjusted to tune sensitivity. Large positive scores asymptotically approach `1.0`, while large negative scores approach `0`.

--- a/src/context/InquiryMapContext.jsx
+++ b/src/context/InquiryMapContext.jsx
@@ -11,6 +11,7 @@ import { db } from "../firebase";
 import { doc, getDoc, updateDoc, onSnapshot } from "firebase/firestore";
 import { generate } from "../ai";
 import { parseJsonFromText } from "../utils/json";
+import { logisticConfidence } from "../utils/confidence";
 
 const InquiryMapContext = createContext();
 
@@ -184,7 +185,7 @@ ${hypothesesList}
                       impact: link.impact,
                     },
                   ],
-                  confidence: normalizeConfidence((h.confidence || 0) + delta),
+                  confidence: logisticConfidence((h.confidence || 0) + delta),
                 }
               : h,
           );

--- a/src/utils/__tests__/confidence.test.js
+++ b/src/utils/__tests__/confidence.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { logisticConfidence } from '../confidence.js';
+
+describe('logisticConfidence', () => {
+  it('approaches 1 with repeated large positive inputs', () => {
+    let value = 0;
+    for (let i = 0; i < 5; i += 1) {
+      value = logisticConfidence(value + 10);
+    }
+    expect(value).toBeLessThan(1);
+    expect(value).toBeCloseTo(1, 5);
+  });
+});

--- a/src/utils/confidence.js
+++ b/src/utils/confidence.js
@@ -1,0 +1,5 @@
+export const DEFAULT_CONFIDENCE_SLOPE = 1.0;
+
+export function logisticConfidence(raw, slope = DEFAULT_CONFIDENCE_SLOPE) {
+  return 1 / (1 + Math.exp(-slope * raw));
+}


### PR DESCRIPTION
## Summary
- Constrain triage evidence confidence by applying a logistic curve with tunable slope.
- Introduce `logisticConfidence` utility and document the new slope parameter.
- Add tests verifying confidence saturates near one for repeated large inputs.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa6dda6444832ba4fc5d22e36928ce