### PR TITLE
feat: add per-source confidence contributions

### DIFF
--- a/docs/api/inquiryMap.md
+++ b/docs/api/inquiryMap.md
@@ -1,0 +1,27 @@
+# Inquiry Map API
+
+This document describes the structure of the inquiry map data used throughout the application.
+
+## Hypothesis
+
+Each hypothesis in the inquiry map is represented with the following properties:
+
+- `id` (string): Identifier for the hypothesis.
+- `statement` or `label` (string): Text description of the hypothesis.
+- `confidence` (number): Overall confidence value between 0 and 1.
+- `confidenceScore` (number, optional): Internal raw score used to compute `confidence` via a logistic transform.
+- `supportingEvidence` (array): Evidence items that support the hypothesis. Each item has:
+  - `text` (string): Source text.
+  - `analysisSummary` (string): Summary from the triage analysis.
+  - `impact` ("High" | "Medium" | "Low"): Impact assessment.
+  - `delta` (number): Contribution of the evidence toward confidence.
+- `refutingEvidence` (array): Evidence items that refute the hypothesis with the same shape as `supportingEvidence`.
+- `sourceContributions` (array): Breakdown of confidence contributions per evidence source. Each entry contains:
+  - `source` (string): Text of the evidence source.
+  - `percent` (number): Signed fractional contribution of that source to the overall confidence. Positive values indicate supporting evidence while negative values indicate refuting evidence.
+
+`percent` values sum to 1 when considering absolute values. They are intended for display purposes to show how much each piece of evidence contributes to the hypothesis confidence.
+
+## Recommendations
+
+The inquiry map may also include `recommendations`, a list of strategic suggestions generated during evidence triage.

--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -159,6 +159,7 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
     const hs = hypotheses.map((h, i) => {
       const id = typeof h === "object" && h.id ? h.id : `hypothesis-${i}`;
       const conf = typeof h === "object" ? h.confidence : undefined;
+      const contribs = typeof h === "object" ? h.sourceContributions : undefined;
       const baseLabel =
         typeof h === "string"
           ? h
@@ -176,7 +177,7 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
       return {
         id,
         type: "resizable",
-        data: { label, confidence: conf, onResize: persistSize },
+        data: { label, confidence: conf, onResize: persistSize, sourceContributions: contribs },
         position: { x: offset, y: rowYHypos },
         style: {
           ...baseCardStyle,
@@ -300,7 +301,7 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
         {selected && (
           <Panel
             position="bottom-left"
-            className="bg-black/70 text-white rounded-xl px-3 py-2 shadow max-w-[42vw]"
+            className="bg-black/70 text-white rounded-xl px-3 py-2 shadow max-w-[42vw] space-y-2"
           >
             <div className="flex items-center gap-2">
               <span className="truncate">Selected: {selected.data.label}</span>
@@ -315,6 +316,22 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
               />
               <span>{selectedPct}%</span>
             </div>
+            {Array.isArray(selected.data.sourceContributions) &&
+              selected.data.sourceContributions.length > 0 && (
+                <details>
+                  <summary className="cursor-pointer">Source contributions</summary>
+                  <ul className="list-disc ml-4">
+                    {selected.data.sourceContributions.map((s, idx) => (
+                      <li key={idx}>
+                        {s.source.length > 60
+                          ? `${s.source.slice(0, 60)}…`
+                          : s.source}
+                        : {(s.percent * 100).toFixed(1)}%
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
           </Panel>
         )}
       </ReactFlow>


### PR DESCRIPTION
## Summary
- track raw confidence score and per-source contributions during evidence triage
- surface each hypothesis's source contribution breakdown in the inquiry map UI
- document inquiry map hypothesis structure and contribution fields

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa7046f2fc832b8a33525a945a04db