### PR TITLE
fix: style inquiry modals and refresh button

### DIFF
--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -19,6 +19,12 @@
   margin: 0.5rem 0;
 }
 
+.sidebar li.subheading {
+  cursor: default;
+  margin-top: 1rem;
+  font-weight: bold;
+}
+
 .sidebar .sub-menu {
   margin-left: 1rem;
 }

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -2216,6 +2216,7 @@ Respond ONLY in this JSON format:
       <aside className="sidebar">
         <h2>Discovery Hub</h2>
         <ul>
+          <li className="subheading">Client Facing</li>
           <li
             className={active === "documents" ? "active" : ""}
             onClick={() => setActive("documents")}
@@ -2255,6 +2256,7 @@ Respond ONLY in this JSON format:
               </ul>
             )}
           </li>
+          <li className="subheading">Internal</li>
           <li className={active === "tasks" ? "active" : ""}>
             <span
               onClick={() => setActive("tasks")}

--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -12,6 +12,7 @@ import { NodeResizer } from "@reactflow/node-resizer";
 import "reactflow/dist/style.css";
 import "@reactflow/node-resizer/dist/style.css";
 import PropTypes from "prop-types";
+import "./AIToolsGenerators.css";
 
 /* --------- robust viewport sizing (no assumptions about <header>) --------- */
 function useVisibleHeight(containerRef) {
@@ -309,13 +310,21 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
         {/* Panels live INSIDE the canvas, never under header/footer */}
         <Panel position="top-left" className="flex items-center gap-2 bg-white/85 rounded-xl px-3 py-2 shadow">
           <button
+            type="button"
             className="px-3 py-1.5 bg-green-600 text-white rounded"
-            onClick={onRefresh}
+            onPointerDownCapture={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            onMouseDownCapture={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRefresh?.();
+            }}
             disabled={isAnalyzing}
           >
             Refresh Map
           </button>
-          {isAnalyzing && <span className="text-sm">Analyzing…</span>}
+            {isAnalyzing && <span className="text-sm">Analyzing…</span>}
         </Panel>
 
         <Panel position="top-right">
@@ -328,11 +337,28 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
       {selected &&
         createPortal(
           <div
-            className="fixed inset-0 z-[1000] bg-black/50"
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 1000,
+              background: "rgba(0,0,0,0.5)",
+            }}
             onClick={() => setSelected(null)}
           >
             <div
-              className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white p-4 rounded shadow-md w-[min(520px,90vw)] space-y-2"
+              className="initiative-card"
+              style={{
+                position: "fixed",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+                width: "min(520px, 90vw)",
+                maxHeight: "90vh",
+                overflowY: "auto",
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.5rem",
+              }}
               onClick={(e) => e.stopPropagation()}
             >
             <div className="flex items-center gap-2">
@@ -414,12 +440,29 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
       {modalOpen &&
         createPortal(
           <div
-            className="fixed inset-0 z-[1000] bg-black/50"
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 1000,
+              background: "rgba(0,0,0,0.5)",
+            }}
             onClick={() => setModalOpen(false)}
           >
             <form
               onSubmit={addHypothesis}
-              className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white p-4 rounded shadow-md space-y-2 w-[min(520px,90vw)]"
+              className="initiative-card"
+              style={{
+                position: "fixed",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+                width: "min(520px, 90vw)",
+                maxHeight: "90vh",
+                overflowY: "auto",
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.5rem",
+              }}
               onClick={(e) => e.stopPropagation()}
             >
             <label className="block">

--- a/src/index.css
+++ b/src/index.css
@@ -28,9 +28,13 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
+  min-height: 100vh;
+}
+
+#root {
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- group Discovery Hub sidebar into Client Facing and Internal sections
- style sidebar subheadings
- stop pointer/mouse propagation so Refresh Map works reliably

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab3435a08c832b80aa59514f9a84bd