### PR TITLE
Enhance inquiry map interactions

### DIFF
--- a/src/context/InquiryMapContext.jsx
+++ b/src/context/InquiryMapContext.jsx
@@ -155,6 +155,32 @@ export const InquiryMapProvider = ({ children }) => {
     [currentUser, currentInitiative, triageEvidence]
   );
 
+  const addHypothesis = useCallback(
+    async (statement) => {
+      if (!currentUser || !currentInitiative) return;
+      const ref = doc(db, "users", currentUser, "initiatives", currentInitiative);
+      try {
+        const snap = await getDoc(ref);
+        if (!snap.exists()) throw new Error("Initiative not found");
+        const currentHypotheses = snap.data()?.inquiryMap?.hypotheses || [];
+        const newHypothesis = {
+          id: `hyp-${Date.now()}`,
+          statement,
+          confidence: 0,
+          supportingEvidence: [],
+          refutingEvidence: [],
+          sourceContributions: [],
+        };
+        await updateDoc(ref, {
+          "inquiryMap.hypotheses": [...currentHypotheses, newHypothesis],
+        });
+      } catch (err) {
+        console.error("Error adding hypothesis:", err);
+      }
+    },
+    [currentUser, currentInitiative]
+  );
+
   const addQuestion = useCallback(
     async (hypothesisId, question) => {
       if (!currentUser || !currentInitiative) return;
@@ -223,6 +249,7 @@ export const InquiryMapProvider = ({ children }) => {
     businessGoal,
     recommendations,
     loadHypotheses,
+    addHypothesis,
     addQuestion,
     addEvidence,
     triageEvidence,


### PR DESCRIPTION
## Summary
- Fix refresh button to trigger inquiry map refresh
- Allow adding hypotheses via context
- Persist node layout and enable custom connections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars errors in unrelated files)*
- `npx eslint src/components/InquiryMap.jsx src/context/InquiryMapContext.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68abb94d1f94832b84f4c6aed180422d