### PR TITLE
Enhance inquiry map interactions

### DIFF
--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -23,7 +23,7 @@ const InquiryMapContent = () => {
     }
   }, [initiativeId, loadHypotheses]);
 
-  const parsedHypotheses = hypotheses.map((h) => ({
+  const parsedHypotheses = (Array.isArray(hypotheses) ? hypotheses : []).map((h) => ({
     id: h.id,
     statement: h.statement || h.text || h.label || h.id,
     confidence: typeof h.confidence === "number" ? h.confidence : 0,


### PR DESCRIPTION
## Summary
- Fix refresh button to trigger inquiry map refresh
- Allow adding hypotheses via context
- Persist node layout and enable custom connections
- Load and save inquiry map data in both new and legacy formats so maps survive redeploys
- Normalize inquiry map data from Firestore to prevent maps from disappearing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars errors in unrelated files)*
- `npx eslint src/components/InquiryMap.jsx src/context/InquiryMapContext.jsx src/pages/InquiryMapPage.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68abb94d1f94832b84f4c6aed180422d