### PR TITLE
Fix inquiry map confidence update parameters

### DIFF
--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -37,7 +37,7 @@ const InquiryMapContent = () => {
     (hypothesisId, confidence) => {
       const user = auth.currentUser;
       if (user && initiativeId) {
-        updateConfidence(user.uid, initiativeId, hypothesisId, confidence);
+        updateConfidence(hypothesisId, confidence);
       }
     },
     [initiativeId, updateConfidence]
@@ -46,7 +46,7 @@ const InquiryMapContent = () => {
   const handleRefresh = useCallback(() => {
     const user = auth.currentUser;
     if (user && initiativeId) {
-      refreshInquiryMap(user.uid, initiativeId);
+      refreshInquiryMap();
     }
   }, [initiativeId, refreshInquiryMap]);
 


### PR DESCRIPTION
## Summary
- call `updateConfidence` with only hypothesis ID and confidence
- invoke `refreshInquiryMap` without extraneous IDs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 6 errors, 7 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68abc7614f74832b9bdc6ebed50580f1