### PR TITLE
Fix inquiry map confidence update parameters

### DIFF
--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import InquiryMap from "../components/InquiryMap";
 import { useInquiryMap } from "../context/InquiryMapContext.jsx";
 import { auth } from "../firebase";
+import { onAuthStateChanged } from "firebase/auth";
 
 const InquiryMapContent = () => {
   const {
@@ -17,10 +18,12 @@ const InquiryMapContent = () => {
   const initiativeId = searchParams.get("initiativeId");
 
   useEffect(() => {
-    const user = auth.currentUser;
-    if (user && initiativeId) {
-      loadHypotheses(user.uid, initiativeId);
-    }
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user && initiativeId) {
+        loadHypotheses(user.uid, initiativeId);
+      }
+    });
+    return () => unsubscribe();
   }, [initiativeId, loadHypotheses]);
 
   const parsedHypotheses = (Array.isArray(hypotheses) ? hypotheses : []).map((h) => ({
@@ -35,20 +38,14 @@ const InquiryMapContent = () => {
 
   const handleUpdateConfidence = useCallback(
     (hypothesisId, confidence) => {
-      const user = auth.currentUser;
-      if (user && initiativeId) {
-        updateConfidence(user.uid, initiativeId, hypothesisId, confidence);
-      }
+      updateConfidence(hypothesisId, confidence);
     },
-    [initiativeId, updateConfidence]
+    [updateConfidence]
   );
 
   const handleRefresh = useCallback(() => {
-    const user = auth.currentUser;
-    if (user && initiativeId) {
-      refreshInquiryMap(user.uid, initiativeId);
-    }
-  }, [initiativeId, refreshInquiryMap]);
+    refreshInquiryMap();
+  }, [refreshInquiryMap]);
 
   return (
     <main className="min-h-screen pt-32 pb-40">


### PR DESCRIPTION
## Summary
- wait for Firebase auth state before loading hypotheses so map stays populated
- call inquiry map update helpers without redundant user and initiative IDs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 6 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68abc7614f74832b9bdc6ebed50580f1