### PR TITLE
Fix inquiry map confidence update parameters

### DIFF
--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import InquiryMap from "../components/InquiryMap";
 import { useInquiryMap } from "../context/InquiryMapContext.jsx";
 import { auth } from "../firebase";
+import { onAuthStateChanged } from "firebase/auth";
 
 const InquiryMapContent = () => {
   const {
@@ -16,12 +17,20 @@ const InquiryMapContent = () => {
   const [searchParams] = useSearchParams();
   const initiativeId = searchParams.get("initiativeId");
 
+  const [user, setUser] = useState(() => auth.currentUser);
+
+  // Track auth state separately so we only load data when a user is available
   useEffect(() => {
-    const user = auth.currentUser;
+    const unsubscribe = onAuthStateChanged(auth, (u) => setUser(u));
+    return () => unsubscribe();
+  }, []);
+
+  // Load hypotheses once both user and initiative ID are known
+  useEffect(() => {
     if (user && initiativeId) {
       loadHypotheses(user.uid, initiativeId);
     }
-  }, [initiativeId, loadHypotheses]);
+  }, [user, initiativeId, loadHypotheses]);
 
   const parsedHypotheses = (Array.isArray(hypotheses) ? hypotheses : []).map((h) => ({
     id: h.id,
@@ -35,20 +44,14 @@ const InquiryMapContent = () => {
 
   const handleUpdateConfidence = useCallback(
     (hypothesisId, confidence) => {
-      const user = auth.currentUser;
-      if (user && initiativeId) {
-        updateConfidence(user.uid, initiativeId, hypothesisId, confidence);
-      }
+      updateConfidence(hypothesisId, confidence);
     },
-    [initiativeId, updateConfidence]
+    [updateConfidence]
   );
 
   const handleRefresh = useCallback(() => {
-    const user = auth.currentUser;
-    if (user && initiativeId) {
-      refreshInquiryMap(user.uid, initiativeId);
-    }
-  }, [initiativeId, refreshInquiryMap]);
+    refreshInquiryMap();
+  }, [refreshInquiryMap]);
 
   return (
     <main className="min-h-screen pt-32 pb-40">


### PR DESCRIPTION
## Summary
- track Firebase auth state locally and trigger hypothesis load only once user and initiative are resolved

## Testing
- `npm run lint` *(fails: 6 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68abc7614f74832b9bdc6ebed50580f1