### PR TITLE
Fix inquiry map confidence update parameters

### DIFF
--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -118,6 +118,7 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
 
   const [nodes, setNodes] = useNodesState([]);
   const [edges, setEdges] = useState(storedLayout.edges || []);
+  const edgesRef = useRef(edges);
   const [selected, setSelected] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [newHypothesis, setNewHypothesis] = useState("");
@@ -146,11 +147,11 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
       sizesRef.current[id] = { width, height };
       setNodes((nds) => {
         const next = nds.map((n) => (n.id === id ? { ...n, style: { ...n.style, width, height } } : n));
-        saveLayout(next, edges);
+        saveLayout(next, edgesRef.current);
         return next;
       });
     },
-    [setNodes, edges, saveLayout]
+    [setNodes, saveLayout]
   );
 
   const baseLayout = useMemo(() => {
@@ -195,13 +196,15 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
     });
     setEdges((eds) => {
       const existing = new Set(eds.map((e) => e.id));
-      const merged = [...eds];
-      baseLayout.edges.forEach((e) => {
-        if (!existing.has(e.id)) merged.push(e);
-      });
-      return merged;
+      const toAdd = baseLayout.edges.filter((e) => !existing.has(e.id));
+      if (toAdd.length === 0) return eds;
+      return [...eds, ...toAdd];
     });
   }, [baseLayout, setNodes]);
+
+  useEffect(() => {
+    edgesRef.current = edges;
+  }, [edges]);
 
   const onNodesChange = useCallback(
     (changes) => {

--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import InquiryMap from "../components/InquiryMap";
 import { useInquiryMap } from "../context/InquiryMapContext.jsx";
 import { auth } from "../firebase";
+import { onAuthStateChanged } from "firebase/auth";
 
 const InquiryMapContent = () => {
   const {
@@ -16,12 +17,30 @@ const InquiryMapContent = () => {
   const [searchParams] = useSearchParams();
   const initiativeId = searchParams.get("initiativeId");
 
+  const [user, setUser] = useState(() => auth.currentUser);
+
+  // Track auth state separately so we only load data when a user is available
   useEffect(() => {
-    const user = auth.currentUser;
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      console.log("Auth state changed", u?.uid);
+      setUser(u);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  // Load hypotheses once both user and initiative ID are known
+  useEffect(() => {
     if (user && initiativeId) {
+      console.log("Loading hypotheses for", user.uid, initiativeId);
       loadHypotheses(user.uid, initiativeId);
+    } else {
+      console.log("Waiting for user or initiativeId", { user, initiativeId });
     }
-  }, [initiativeId, loadHypotheses]);
+  }, [user, initiativeId, loadHypotheses]);
+
+  useEffect(() => {
+    console.log("Hypotheses state updated", hypotheses);
+  }, [hypotheses]);
 
   const parsedHypotheses = (Array.isArray(hypotheses) ? hypotheses : []).map((h) => ({
     id: h.id,
@@ -35,20 +54,14 @@ const InquiryMapContent = () => {
 
   const handleUpdateConfidence = useCallback(
     (hypothesisId, confidence) => {
-      const user = auth.currentUser;
-      if (user && initiativeId) {
-        updateConfidence(user.uid, initiativeId, hypothesisId, confidence);
-      }
+      updateConfidence(hypothesisId, confidence);
     },
-    [initiativeId, updateConfidence]
+    [updateConfidence]
   );
 
   const handleRefresh = useCallback(() => {
-    const user = auth.currentUser;
-    if (user && initiativeId) {
-      refreshInquiryMap(user.uid, initiativeId);
-    }
-  }, [initiativeId, refreshInquiryMap]);
+    refreshInquiryMap();
+  }, [refreshInquiryMap]);
 
   return (
     <main className="min-h-screen pt-32 pb-40">


### PR DESCRIPTION
## Summary
- track Firebase auth state locally and trigger hypothesis load only once user and initiative are resolved
- add console logging across auth, hypothesis loading, and Firestore snapshots to trace inquiry map behavior
- prevent React Flow edge churn by storing the edge list in a ref and only adding newly discovered edges

## Testing
- `npm run lint` *(fails: 6 errors, 7 warnings)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abc7614f74832b9bdc6ebed50580f1