### PR TITLE
feat: add task prioritization metadata

### DIFF
--- a/functions/migrations/addTaskMetadata.js
+++ b/functions/migrations/addTaskMetadata.js
@@ -1,0 +1,34 @@
+import admin from "firebase-admin";
+
+admin.initializeApp();
+const db = admin.firestore();
+
+async function addTaskMetadata() {
+  const profiles = await db.collection("profiles").get();
+  for (const userDoc of profiles.docs) {
+    const tasksRef = userDoc.ref.collection("taskQueue");
+    const tasksSnap = await tasksRef.get();
+    const batch = db.batch();
+    let counter = 0;
+    tasksSnap.forEach((taskDoc) => {
+      const data = taskDoc.data();
+      const update = {};
+      if (data.hypothesisId === undefined) update.hypothesisId = null;
+      if (data.taskType === undefined) update.taskType = "explore";
+      if (data.priority === undefined) update.priority = "low";
+      if (Object.keys(update).length) {
+        batch.update(taskDoc.ref, update);
+        counter++;
+      }
+    });
+    if (counter > 0) {
+      await batch.commit();
+      console.log(`Updated ${counter} tasks for user ${userDoc.id}`);
+    }
+  }
+  console.log("Migration complete");
+}
+
+addTaskMetadata().catch((err) => {
+  console.error("Migration failed", err);
+});

--- a/src/components/TaskQueue.jsx
+++ b/src/components/TaskQueue.jsx
@@ -84,6 +84,9 @@ export default function TaskQueue({
     await updateDoc(doc(db, "profiles", user.uid, "taskQueue", task.id), {
       status,
       statusChangedAt: serverTimestamp(),
+      hypothesisId: task.hypothesisId ?? null,
+      taskType: task.taskType ?? "explore",
+      priority: task.priority ?? "low",
       ...extra,
     });
   };
@@ -132,6 +135,9 @@ export default function TaskQueue({
     await updateDoc(doc(db, "profiles", user.uid, "taskQueue", first.id), {
       message,
       provenance,
+      hypothesisId: first.hypothesisId ?? null,
+      taskType: first.taskType ?? "explore",
+      priority: first.priority ?? "low",
     });
     for (const t of rest) {
       await deleteDoc(doc(db, "profiles", user.uid, "taskQueue", t.id));

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -91,6 +91,20 @@ export async function isQuestionTask(message) {
 }
 
 /**
+ * Apply default prioritization metadata to a task.
+ * @param {object} task
+ * @returns {object}
+ */
+export function withTaskDefaults(task = {}) {
+  return {
+    hypothesisId: null,
+    taskType: "explore",
+    priority: "low",
+    ...task,
+  };
+}
+
+/**
  * Remove duplicate tasks based on their message text.
  * Comparison is case-insensitive and ignores punctuation and extra spaces.
  * Keeps the first occurrence of each unique message.
@@ -104,12 +118,14 @@ export function dedupeByMessage(tasks) {
       .replace(/[^a-z0-9]+/g, " ")
       .trim();
   const seen = new Set();
-  return tasks.filter((t) => {
-    const key = normalize(t.message);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+  return tasks
+    .filter((t) => {
+      const key = normalize(t.message);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .map(withTaskDefaults);
 }
 
 export function normalizeAssigneeName(name, currentUser) {
@@ -123,6 +139,7 @@ export function normalizeAssigneeName(name, currentUser) {
 export default {
   classifyTask,
   isQuestionTask,
+  withTaskDefaults,
   dedupeByMessage,
   normalizeAssigneeName,
 };


### PR DESCRIPTION
## Summary
- add hypothesis, type, and priority metadata to task creation and updates
- supply helper to apply default task metadata
- include migration script to backfill existing task documents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars in existing files)*
- `npx eslint src/components/TaskQueue.jsx src/components/DiscoveryHub.jsx src/utils/taskUtils.js functions/migrations/addTaskMetadata.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac8fca749c832b985d1d4c43d9f97e