### PR TITLE
feat: implement priority matrix engine for task prioritization

### DIFF
--- a/src/utils/priorityMatrix.js
+++ b/src/utils/priorityMatrix.js
@@ -1,0 +1,31 @@
+export function getPriority(taskType = "explore", confidence = 0) {
+  const pct = confidence > 1 ? confidence : confidence * 100;
+  if (pct <= 40) {
+    switch (taskType) {
+      case "validate":
+        return "critical";
+      case "refute":
+        return "low";
+      default:
+        return "high";
+    }
+  }
+  if (pct <= 75) {
+    switch (taskType) {
+      case "validate":
+        return "high";
+      case "refute":
+        return "medium";
+      default:
+        return "low";
+    }
+  }
+  switch (taskType) {
+    case "refute":
+      return "medium";
+    default:
+      return "low";
+  }
+}
+
+export default { getPriority };


### PR DESCRIPTION
## Summary
- add `getPriority` utility to compute task priority from hypothesis confidence and task type
- update DiscoveryHub to recompute priorities on hypothesis confidence or task type changes
- ensure new and edited tasks set priority using the priority matrix before saving

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac98a7058c832b9095be715b99283f