### PR TITLE
Add Action Dashboard to Discovery Hub

### DIFF
--- a/src/components/ActionDashboard.jsx
+++ b/src/components/ActionDashboard.jsx
@@ -1,0 +1,89 @@
+import { useNavigate } from "react-router-dom";
+import { auth, db } from "../firebase";
+import { doc, updateDoc } from "firebase/firestore";
+import PropTypes from "prop-types";
+import { getPriority } from "../utils/priorityMatrix";
+
+export default function ActionDashboard({ tasks = [], hypotheses = [] }) {
+  const navigate = useNavigate();
+
+  const handleDragStart = (e, id) => {
+    e.dataTransfer.setData("text/plain", id);
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = async (e, priority) => {
+    e.preventDefault();
+    const id = e.dataTransfer.getData("text/plain");
+    const task = tasks.find((t) => t.id === id);
+    const user = auth.currentUser;
+    if (!task || !user) return;
+    const conf = task.hypothesisId
+      ? hypotheses.find((h) => h.id === task.hypothesisId)?.confidence || 0
+      : 0;
+    const newPriority = priority || getPriority(task.taskType ?? "explore", conf);
+    await updateDoc(doc(db, "profiles", user.uid, "taskQueue", id), {
+      priority: newPriority,
+      taskType: task.taskType ?? "explore",
+      hypothesisId: task.hypothesisId ?? null,
+    });
+  };
+
+  const priorities = ["critical", "high", "medium", "low"];
+  const grouped = priorities.reduce((acc, p) => {
+    acc[p] = tasks.filter((t) => (t.priority || "low") === p);
+    return acc;
+  }, {});
+
+  return (
+    <div className="flex gap-4">
+      {priorities.map((p) => (
+        <div
+          key={p}
+          className="flex-1"
+          onDragOver={handleDragOver}
+          onDrop={(e) => handleDrop(e, p)}
+        >
+          <h3 className="mb-2 text-center font-semibold capitalize">{p}</h3>
+          <div className="flex min-h-[100px] flex-col gap-2">
+            {grouped[p].map((t) => (
+              <div
+                key={t.id}
+                className="initiative-card task-card p-2"
+                draggable
+                onDragStart={(e) => handleDragStart(e, t.id)}
+              >
+                <div className="text-sm font-medium">{t.message}</div>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {t.hypothesisId && (
+                    <span
+                      className="tag-badge tag-hypothesis cursor-pointer"
+                      onClick={() =>
+                        navigate(
+                          `/inquiry-map?initiativeId=${t.project || "General"}&hypothesisId=${t.hypothesisId}`
+                        )
+                      }
+                    >
+                      {t.hypothesisId}
+                    </span>
+                  )}
+                  {t.taskType && (
+                    <span className={`tag-badge tag-${t.taskType}`}>{t.taskType}</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+ActionDashboard.propTypes = {
+  tasks: PropTypes.arrayOf(PropTypes.object),
+  hypotheses: PropTypes.arrayOf(PropTypes.object),
+};

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -27,6 +27,7 @@ import {
 import { getPriority } from "../utils/priorityMatrix";
 import ProjectStatus from "./ProjectStatus.jsx";
 import PastUpdateView from "./PastUpdateView.jsx";
+import ActionDashboard from "./ActionDashboard.jsx";
 import "./AIToolsGenerators.css";
 import "./DiscoveryHub.css";
 
@@ -169,6 +170,12 @@ const DiscoveryHub = () => {
   const [viewingStatus, setViewingStatus] = useState("");
   const [qaModal, setQaModal] = useState(null);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (searchParams.has("actionDashboard")) {
+      setActive("actionDashboard");
+    }
+  }, [searchParams]);
 
   const normalizeAssignee = useCallback(
     (a) => normalizeAssigneeName(a, currentUserName),
@@ -2474,6 +2481,12 @@ Respond ONLY in this JSON format:
             )}
           </li>
           <li
+            className={active === "actionDashboard" ? "active" : ""}
+            onClick={() => setActive("actionDashboard")}
+          >
+            Action Dashboard
+          </li>
+          <li
             className={active === "status" && !viewingStatus ? "active" : ""}
             onClick={() => {
               setActive("status");
@@ -2971,6 +2984,8 @@ Respond ONLY in this JSON format:
         document.body
       )}
   </div>
+        ) : active === "actionDashboard" ? (
+          <ActionDashboard tasks={projectTasks} hypotheses={hypotheses} />
         ) : (
           <>
             <div className="filter-bar">


### PR DESCRIPTION
## Summary
- integrate ActionDashboard into DiscoveryHub sidebar and routing
- implement kanban-style ActionDashboard with drag-and-drop priority updates

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac9e04a9f8832ba0a66ef2ce3039ed