### PR TITLE
Fix Kanban layout by enabling Tailwind CSS

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+import tailwindcss from "tailwindcss";
+
+export default {
+  plugins: {
+    tailwindcss,
+  },
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+@import "tailwindcss";
+
+
 html {
   scroll-behavior: smooth;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind CSS and PostCSS
- import Tailwind in `index.css` so utility classes like `flex` and `gap-4` work

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca408c5d0832b87fdbc36dad9f0bb