### PR TITLE
Fix action dashboard task loading

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -2993,7 +2993,7 @@ Respond ONLY in this JSON format:
       )}
   </div>
         ) : active === "actionDashboard" ? (
-          <ActionDashboard tasks={projectTasks} hypotheses={hypotheses} />
+          <ActionDashboard />
         ) : (
           <>
             <div className="filter-bar">


### PR DESCRIPTION
## Summary
- Load tasks for the current initiative in `ActionDashboard` by reading `initiativeId` from the URL and querying Firestore at `users/<uid>/initiatives/<initiativeId>/tasks`
- Update drag-and-drop handler to write priority overrides back to the new task path
- Simplify `DiscoveryHub` usage of `ActionDashboard`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acc88e9718832bb36205d82d2fbc05