### PR TITLE
Link tasks to hypotheses and improve triage

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -640,10 +640,17 @@ const DiscoveryHub = () => {
       const taskSet = new Set(projectTasks.map((t) => t.message.toLowerCase()));
       const questionSet = new Set(questions.map((q) => q.question.toLowerCase()));
 
+      const hypothesisList = hypotheses
+        .map((h) => `${h.id}: ${h.statement || h.text || h.label || h.id}`)
+        .join("\n");
+
       const prompt = `You are an expert Instructional Designer and Performance Consultant. You are analyzing ${respondent}'s answer to a specific discovery question. Your goal is to understand what this answer means for the training project and to determine follow-up actions.
 
 Project Context:
 ${projectContext}
+
+Existing Hypotheses:
+${hypothesisList}
 
 Discovery Question:
 ${question}
@@ -655,13 +662,15 @@ Avoid suggesting tasks or questions that already exist in the provided lists.
 
 Please provide a JSON object with two fields:
 - "analysis": a concise summary of what this answer reveals about the question in the context of the project.
-- "suggestions": An array of objects for follow-up actions. Each object must have three string fields:
+- "suggestions": An array of objects for follow-up actions. Each object must have these fields:
     1. "text": The follow-up action. Do not include any names in this text.
     2. "category": One of "question", "meeting", "email", "research", or "instructional-design". Use "instructional-design" for tasks involving designing or creating instructional materials.
     3. "who": The person or group to work with. This must be either a project contact, someone explicitly mentioned in the provided materials, or the current user.
+    4. "hypothesisId": The ID of the related hypothesis, or null if exploring a new idea.
+    5. "taskType": One of "validate", "refute", or "explore".
 
 Respond ONLY in this JSON format:
-{"analysis": "...", "suggestions": [{"text": "...", "category": "...", "who": "..."}, ...]}`;
+{"analysis": "...", "suggestions": [{"text": "...", "category": "...", "who": "...", "hypothesisId": "A", "taskType": "validate"}, ...]}`;
 
       const { text: res } = await ai.generate(prompt);
 
@@ -679,6 +688,7 @@ Respond ONLY in this JSON format:
           "research",
           "instructional-design",
         ];
+        const allowedTaskTypes = ["validate", "refute", "explore"];
         const suggestions = Array.isArray(parsed.suggestions)
           ? parsed.suggestions
               .filter(
@@ -695,6 +705,15 @@ Respond ONLY in this JSON format:
                 text: s.text,
                 category: s.category.toLowerCase(),
                 who: s.who,
+                hypothesisId:
+                  typeof s.hypothesisId === "string" && s.hypothesisId.trim()
+                    ? s.hypothesisId.trim()
+                    : null,
+                taskType: allowedTaskTypes.includes(
+                  (s.taskType || "").toLowerCase(),
+                )
+                  ? s.taskType.toLowerCase()
+                  : "explore",
               }))
           : [];
 
@@ -860,12 +879,7 @@ Respond ONLY in this JSON format:
           existingQuestionSet.add(lowerText);
         } else {
           const tag = await classifyTask(s.text);
-          let taskType;
-          try {
-            taskType = await classifyTask(s.text);
-          } catch {
-            taskType = "explore";
-          }
+          const taskType = s.taskType || "explore";
           const finalAssignees = assigneeNames.length
             ? assigneeNames
             : [currentUserName];

--- a/src/context/InquiryMapContext.jsx
+++ b/src/context/InquiryMapContext.jsx
@@ -124,6 +124,29 @@ export const InquiryMapProvider = ({ children }) => {
           allNewRecommendations.push(...extraRecommendations);
         });
 
+        if (analysis.newHypothesis?.statement) {
+          const newConf = Math.min(1, Math.max(0, analysis.newHypothesis.confidence || 0));
+          const lowest = updatedHypotheses.reduce(
+            (min, h) => Math.min(min, h.confidence || 0),
+            1,
+          );
+          if (newConf > lowest) {
+            const add = window.confirm(
+              `AI suggests a new hypothesis with ${(newConf * 100).toFixed(0)}% confidence:\n"${analysis.newHypothesis.statement}"\nAdd this hypothesis?`
+            );
+            if (add) {
+              updatedHypotheses.push({
+                id: `hyp-${Date.now()}`,
+                statement: analysis.newHypothesis.statement,
+                confidence: newConf,
+                supportingEvidence: [],
+                refutingEvidence: [],
+                sourceContributions: [],
+              });
+            }
+          }
+        }
+
         const finalRecommendations = [...currentRecommendations, ...allNewRecommendations];
 
         await updateDoc(ref, {

--- a/src/utils/inquiryLogic.js
+++ b/src/utils/inquiryLogic.js
@@ -27,12 +27,14 @@ export const generateTriagePrompt = (evidenceText, hypotheses, contacts) => {
     .map((c) => `${c.name} (${c.role || "Unknown Role"})`)
     .join(", ");
 
-  // This revised prompt is more direct in asking the AI to check for refutations.
+  // This revised prompt is more direct in asking the AI to check for refutations
+  // and to propose new hypotheses when warranted.
     return `Your role is an expert Performance Consultant. Analyze the New Evidence in the context of the Existing Hypotheses.
 
 1.  **Analyze the Relationship:** For each hypothesis, determine if the new evidence directly **Supports**, directly **Refutes**, or is **Unrelated** to it. Be extremely critical. If a stakeholder says "the training was fine, but the tool is the problem," that *refutes* a hypothesis about training and *supports* a hypothesis about the tool. Do not just match keywords.
 2.  **Determine the Impact:** Classify the evidence's strategic impact (High, Medium, Low).
 3.  **Classify the Source:** Identify the source and classify its authority, type, and directness.
+4.  **Suggest New Hypothesis:** If this evidence implies a new hypothesis that could have a higher confidence than the current lowest confidence hypothesis, include it.
 
 Respond ONLY in the following JSON format:
 {
@@ -47,7 +49,11 @@ Respond ONLY in the following JSON format:
       "evidenceType": "Qualitative",
       "directness": "Direct"
     }
-  ]
+  ],
+  "newHypothesis": {
+    "statement": "Possible new hypothesis",
+    "confidence": 0.4
+  }
 }
 
 ---


### PR DESCRIPTION
## Summary
- Extend triage prompt to suggest new hypotheses alongside evidence links
- Prompt users to add new hypotheses when triage finds a stronger candidate
- Capture hypothesis and task intent (validate/refute/explore) when creating tasks from answer analysis

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68acd1a9baf0832b93daef617da55555