### PR TITLE
feat: allow pasting text as document

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -2200,6 +2200,34 @@ Respond ONLY in this JSON format:
     });
   };
 
+  const handlePasteText = async () => {
+    const text = window.prompt("Paste your text:");
+    if (text && text.trim()) {
+      const defaultName = `pasted-${documents.length + 1}.txt`;
+      const name =
+        window.prompt("Enter a filename", defaultName) || defaultName;
+      const doc = {
+        name,
+        content: text,
+        addedAt: new Date().toISOString(),
+      };
+      if (uid && initiativeId) {
+        try {
+          await triageEvidence(`Title: ${doc.name}\n\n${doc.content}`);
+        } catch (err) {
+          console.error("triageEvidence error", err);
+        }
+      }
+      setDocuments((prev) => {
+        const updated = [...prev, doc];
+        if (uid) {
+          saveInitiative(uid, initiativeId, { sourceMaterials: updated });
+        }
+        return updated;
+      });
+    }
+  };
+
   const summarizeText = async (text) => {
     const context = `Project Name: ${projectName || "Unknown"}\nBusiness Goal: ${
       businessGoal || "Unknown"
@@ -2593,6 +2621,12 @@ Respond ONLY in this JSON format:
                 Summarize All Files
               </button>
             )}
+            <button
+              className="generator-button paste-text"
+              onClick={handlePasteText}
+            >
+              Paste Text
+            </button>
             <ul className="document-list">
               {documents.map((doc, idx) => (
                 <li key={idx} className="document-item">

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -161,6 +161,16 @@ const ProjectSetup = () => {
     e.preventDefault();
   };
 
+  const handlePasteText = () => {
+    const text = window.prompt("Paste your text:");
+    if (text && text.trim()) {
+      const defaultName = `pasted-${sourceMaterials.length + 1}.txt`;
+      const name =
+        window.prompt("Enter a filename", defaultName) || defaultName;
+      setSourceMaterials((prev) => [...prev, { name, content: text }]);
+    }
+  };
+
   const removeFile = (index) => {
     setSourceMaterials((prev) => prev.filter((_, i) => i !== index));
   };
@@ -364,6 +374,13 @@ const ProjectSetup = () => {
               <div className="upload-title">Upload Source Material (Optional)</div>
               <div className="upload-subtitle">Click to upload or drag and drop</div>
               <div className="upload-hint">PDF, DOCX, TXT (MAX. 10MB)</div>
+              <button
+                type="button"
+                className="generator-button paste-text"
+                onClick={handlePasteText}
+              >
+                Paste Text
+              </button>
               {sourceMaterials.length > 0 && (
                 <ul className="file-list">
                   {sourceMaterials.map((f, idx) => (


### PR DESCRIPTION
## Summary
- let users paste arbitrary text into Project intake and store it as a `.txt` source document
- allow pasting text as a new document within the Discovery Hub

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ad2112d8e4832ba2424c686197eb02