### PR TITLE
feat: allow pasting text as document

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -2200,6 +2200,34 @@ Respond ONLY in this JSON format:
     });
   };
 
+  const handlePasteText = async () => {
+    const text = window.prompt("Paste your text:");
+    if (text && text.trim()) {
+      const defaultName = `pasted-${documents.length + 1}.txt`;
+      const name =
+        window.prompt("Enter a filename", defaultName) || defaultName;
+      const doc = {
+        name,
+        content: text,
+        addedAt: new Date().toISOString(),
+      };
+      if (uid && initiativeId) {
+        try {
+          await triageEvidence(`Title: ${doc.name}\n\n${doc.content}`);
+        } catch (err) {
+          console.error("triageEvidence error", err);
+        }
+      }
+      setDocuments((prev) => {
+        const updated = [...prev, doc];
+        if (uid) {
+          saveInitiative(uid, initiativeId, { sourceMaterials: updated });
+        }
+        return updated;
+      });
+    }
+  };
+
   const summarizeText = async (text) => {
     const context = `Project Name: ${projectName || "Unknown"}\nBusiness Goal: ${
       businessGoal || "Unknown"
@@ -2593,6 +2621,12 @@ Respond ONLY in this JSON format:
                 Summarize All Files
               </button>
             )}
+            <button
+              className="generator-button paste-text"
+              onClick={handlePasteText}
+            >
+              Paste Text
+            </button>
             <ul className="document-list">
               {documents.map((doc, idx) => (
                 <li key={idx} className="document-item">
@@ -3052,6 +3086,10 @@ Respond ONLY in this JSON format:
           <ActionDashboard />
         ) : (
           <>
+            <p className="mb-4 text-sm text-gray-500">
+              Click the <strong>Ask</strong> button, choose the responder, and enter
+              answer text to receive analysis and suggested tasks.
+            </p>
             <div className="filter-bar">
               <label>
                 Contact:

--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -184,7 +184,12 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
       const id = h.id || `hypothesis-${i}`;
       const conf = h.confidence;
       const pct = Math.round((conf || 0) * 100);
-      const label = `${h.statement || h.label || ""} (${pct}%)`;
+      const letter = /^[A-Z]$/.test(id)
+        ? id
+        : String.fromCharCode(65 + i);
+      const label = `Hypothesis ${letter}: ${
+        h.statement || h.label || ""
+      } (${pct}%)`;
       const offset = (i - (hypotheses.length - 1) / 2) * (CARD_W + marginX);
       return {
         id,
@@ -325,7 +330,7 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
               onClick={(e) => e.stopPropagation()}
             >
             <div className="flex items-center gap-2">
-              <span className="font-semibold truncate flex-1">
+              <span className="font-semibold flex-1 whitespace-pre-wrap break-words">
                 {selected.data.label}
               </span>
               <input

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -9,6 +9,8 @@ import { auth } from "../firebase";
 const NavBar = () => {
   const [loggedIn, setLoggedIn] = useState(false);
 
+  const homePath = loggedIn ? "/dashboard" : "/";
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setLoggedIn(!!user);
@@ -42,7 +44,7 @@ const NavBar = () => {
         </div>
 
         <div className="nav-links">
-          <Link to={loggedIn ? "/dashboard" : "/"} className="nav-link active">
+          <Link to={homePath} className="nav-link">
             Home
           </Link>
           <Link to="/ai-tools" className="nav-link">

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -161,6 +161,16 @@ const ProjectSetup = () => {
     e.preventDefault();
   };
 
+  const handlePasteText = () => {
+    const text = window.prompt("Paste your text:");
+    if (text && text.trim()) {
+      const defaultName = `pasted-${sourceMaterials.length + 1}.txt`;
+      const name =
+        window.prompt("Enter a filename", defaultName) || defaultName;
+      setSourceMaterials((prev) => [...prev, { name, content: text }]);
+    }
+  };
+
   const removeFile = (index) => {
     setSourceMaterials((prev) => prev.filter((_, i) => i !== index));
   };
@@ -364,6 +374,13 @@ const ProjectSetup = () => {
               <div className="upload-title">Upload Source Material (Optional)</div>
               <div className="upload-subtitle">Click to upload or drag and drop</div>
               <div className="upload-hint">PDF, DOCX, TXT (MAX. 10MB)</div>
+              <button
+                type="button"
+                className="generator-button paste-text"
+                onClick={handlePasteText}
+              >
+                Paste Text
+              </button>
               {sourceMaterials.length > 0 && (
                 <ul className="file-list">
                   {sourceMaterials.map((f, idx) => (


### PR DESCRIPTION
## Summary
- let users paste arbitrary text into Project intake and store it as a `.txt` source document
- allow pasting text as a new document within the Discovery Hub
- label hypotheses and wrap full text in the Inquiry Map modal
- provide instructions for submitting answers on the Questions page
- send logged-in users to the project dashboard from the Home link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(warn: React Hook dependencies and react-refresh/only-export-components)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2112d8e4832ba2424c686197eb02