### PR TITLE
feat: add app shell with sidebar and canonical links

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -696,3 +696,53 @@ body.pulsing::before {
     font-size: 1.5rem;
   }
 }
+.left-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.project-switcher,
+.search-bar,
+.add-menu {
+  position: relative;
+}
+
+.project-switcher button,
+.add-menu button {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.4);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.search-bar input {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid rgba(255,255,255,0.4);
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  color: #000;
+  list-style: none;
+  padding: 0.5rem;
+  margin: 0;
+  border-radius: 4px;
+  z-index: 10;
+}
+
+.dropdown li {
+  padding: 0.25rem 0.5rem;
+}
+
+.dropdown li:hover {
+  background: rgba(0,0,0,0.05);
+}

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -1,0 +1,18 @@
+import { Outlet } from "react-router-dom";
+import NavBar from "./NavBar";
+import DiscoverySidebar from "./DiscoverySidebar";
+import "./DiscoverySidebar.css";
+import useCanonical from "../utils/useCanonical";
+
+export default function AppShell() {
+  useCanonical(window.location.href);
+  return (
+    <div className="app-shell">
+      <NavBar />
+      <DiscoverySidebar />
+      <main className="app-main">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/components/DiscoverySidebar.css
+++ b/src/components/DiscoverySidebar.css
@@ -1,0 +1,38 @@
+.discovery-sidebar {
+  width: 200px;
+  flex-shrink: 0;
+  padding: 1rem;
+  border-right: 1px solid rgba(0,0,0,0.1);
+  height: calc(100vh - 64px);
+  position: fixed;
+  left: 0;
+  top: 64px;
+  background: #fff;
+  overflow-y: auto;
+}
+
+.discovery-sidebar .sidebar-title {
+  margin: 0 0 1rem 0;
+  font-size: 1.2rem;
+}
+
+.discovery-sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.discovery-sidebar li {
+  margin: 0.5rem 0;
+}
+
+.discovery-sidebar a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.app-main {
+  margin-left: 200px;
+  margin-top: 64px;
+  padding: 1rem;
+}

--- a/src/components/DiscoverySidebar.jsx
+++ b/src/components/DiscoverySidebar.jsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom";
+import "./DiscoverySidebar.css";
+
+export default function DiscoverySidebar() {
+  return (
+    <aside className="discovery-sidebar">
+      <h2 className="sidebar-title">Discovery Hub</h2>
+      <nav>
+        <ul>
+          <li><Link to="/discovery">Overview</Link></li>
+          <li><Link to="/tasks">Tasks</Link></li>
+          <li><Link to="/inquiry-map">Inquiry Map</Link></li>
+          <li><Link to="/ai-tools">AI Tools</Link></li>
+          <li><Link to="/settings">Settings</Link></li>
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -16,7 +16,9 @@ import "reactflow/dist/style.css";
 import "@reactflow/node-resizer/dist/style.css";
 import PropTypes from "prop-types";
 import "./AIToolsGenerators.css";
-import { useInquiryMap } from "../context/InquiryMapContext"; 
+import { useInquiryMap } from "../context/InquiryMapContext";
+import useCanonical from "../utils/useCanonical";
+import { canonicalMapNodeUrl } from "../utils/canonical";
 
 // --- Helper Functions for Sizing (Unchanged) ---
 function useVisibleHeight(containerRef) {
@@ -130,6 +132,8 @@ const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefre
   const sizesRef = useRef(storedLayout.sizes || {});
 
   const [nodes, setNodes] = useNodesState([]);
+  const activeNode = nodes[0]?.id;
+  useCanonical(activeNode ? canonicalMapNodeUrl(activeNode) : window.location.href);
   const [edges, setEdges] = useState(storedLayout.edges || []);
   const edgesRef = useRef(edges);
   const [selected, setSelected] = useState(null);

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,15 +1,13 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import { onAuthStateChanged } from "firebase/auth";
 import { auth } from "../firebase";
 
-// src/components/NavBar.jsx
-// Updated header component using glass effect and profile actions
+const sampleProjects = ["Project Alpha", "Project Beta"];
 
-const NavBar = () => {
+export default function NavBar() {
   const [loggedIn, setLoggedIn] = useState(false);
-
-  const homePath = loggedIn ? "/dashboard" : "/";
+  const [projectMenu, setProjectMenu] = useState(false);
+  const [addMenu, setAddMenu] = useState(false);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
@@ -19,75 +17,93 @@ const NavBar = () => {
   }, []);
 
   return (
-    <header className="glass-header">
+    <header className="glass-header" data-header>
       <nav className="nav-container">
-        <div className="logo-section">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="28"
-            height="28"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="logo-icon"
-          >
-            <path d="m5 3 2.5 4L10 3" />
-            <path d="M14 3s2.5 4 2.5 4L19 3" />
-            <path d="M12 22v-8" />
-            <path d="M8.5 11l-3-3" />
-            <path d="M15.5 11l3-3" />
-          </svg>
-          <span className="logo-text">Thoughtify</span>
-        </div>
-
-        <div className="nav-links">
-          <Link to={homePath} className="nav-link">
-            Home
-          </Link>
-          <Link to="/ai-tools" className="nav-link">
-            Tools
-          </Link>
-          <Link to="/tasks" className="nav-link">
-            Tasks
-          </Link>
-          <Link to="#" className="nav-link">
-            Projects
-          </Link>
-          <Link to="/settings" className="nav-link">
-            Settings
-          </Link>
-        </div>
-
-        <div className="user-actions">
-          <button className="notification-btn" type="button">
+        <div className="left-nav">
+          <div className="logo-section">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
+              width="28"
+              height="28"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
+              className="logo-icon"
             >
-              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-              <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+              <path d="m5 3 2.5 4L10 3" />
+              <path d="M14 3s2.5 4 2.5 4L19 3" />
+              <path d="M12 22v-8" />
+              <path d="M8.5 11l-3-3" />
+              <path d="M15.5 11l3-3" />
             </svg>
-            <span className="indicator" />
-          </button>
-          <img
-            src="https://placehold.co/40x40/764ba2/FFFFFF?text=ID"
-            alt="User Avatar"
-            className="user-avatar"
-          />
+          </div>
+          {loggedIn && (
+            <>
+              <div className="project-switcher">
+                <button type="button" onClick={() => setProjectMenu(!projectMenu)}>
+                  Projects
+                </button>
+                {projectMenu && (
+                  <ul className="dropdown">
+                    <li>Add New Project</li>
+                    {sampleProjects.map((p) => (
+                      <li key={p}>{p}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div className="search-bar">
+                <input type="text" placeholder="Search projects" />
+              </div>
+              <div className="add-menu">
+                <button type="button" onClick={() => setAddMenu(!addMenu)}>
+                  ADD +
+                </button>
+                {addMenu && (
+                  <ul className="dropdown">
+                    <li>Question</li>
+                    <li>Document</li>
+                    <li>Hypothesis</li>
+                    <li>Task</li>
+                    <li>Update</li>
+                  </ul>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+        <div className="user-actions">
+          {loggedIn && (
+            <>
+              <button className="notification-btn" type="button">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+                  <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+                </svg>
+                <span className="indicator" />
+              </button>
+              <img
+                src="https://placehold.co/40x40/764ba2/FFFFFF?text=ID"
+                alt="User Avatar"
+                className="user-avatar"
+              />
+            </>
+          )}
         </div>
       </nav>
     </header>
   );
-};
-
-export default NavBar;
+}

--- a/src/components/PastUpdateView.jsx
+++ b/src/components/PastUpdateView.jsx
@@ -1,6 +1,9 @@
 import PropTypes from "prop-types";
+import useCanonical from "../utils/useCanonical";
+import { canonicalUpdateUrl } from "../utils/canonical";
 
 const PastUpdateView = ({ update }) => {
+  useCanonical(update?.id ? canonicalUpdateUrl(update.id) : window.location.href);
   if (!update) return null;
   const copy = () => {
     if (navigator.clipboard) {
@@ -24,6 +27,7 @@ const PastUpdateView = ({ update }) => {
 
 PastUpdateView.propTypes = {
   update: PropTypes.shape({
+    id: PropTypes.string,
     date: PropTypes.string.isRequired,
     summary: PropTypes.string.isRequired,
   }),

--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -16,6 +16,8 @@ import { httpsCallable } from "firebase/functions";
 import { getToken as getAppCheckToken } from "firebase/app-check";
 import ai from "../ai";
 import PropTypes from "prop-types";
+import useCanonical from "../utils/useCanonical";
+import { canonicalProjectUrl } from "../utils/canonical";
 
 const ProjectStatus = ({
   contacts = [],
@@ -44,6 +46,8 @@ const ProjectStatus = ({
     const unsub = onAuthStateChanged(auth, (u) => setUser(u));
     return () => unsub();
   }, []);
+
+  useCanonical(canonicalProjectUrl(initiativeId));
 
   useEffect(() => {
     if (!user) return;

--- a/src/components/Tasks.jsx
+++ b/src/components/Tasks.jsx
@@ -5,12 +5,16 @@ import { auth, db } from "../firebase";
 import TaskQueue from "./TaskQueue";
 import TaskSidebar from "./TaskSidebar";
 import "../pages/admin.css";
+import useCanonical from "../utils/useCanonical";
+import { canonicalTaskUrl } from "../utils/canonical";
 
 const Tasks = () => {
   const [user, setUser] = useState(null);
   const [tasks, setTasks] = useState([]);
   const [inquiries, setInquiries] = useState([]);
   const [statusFilter, setStatusFilter] = useState("all");
+
+  useCanonical(tasks[0]?.id ? canonicalTaskUrl(tasks[0].id) : window.location.href);
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, setUser);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -31,6 +31,7 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import Settings from "./components/Settings";
 import Tasks from "./components/Tasks";
 import InquiryMapPage from "./pages/InquiryMapPage";
+import AppShell from "./components/AppShell";
 
 window.PropTypes = PropTypes;
 
@@ -70,7 +71,7 @@ function Root() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<App />}>
+        <Route element={<App />}> 
           <Route path="/login" element={<Login />} />
           <Route path="/" element={<ComingSoonPage />} />
           <Route path="/privacy" element={<PrivacyPolicy />} />
@@ -84,6 +85,8 @@ function Root() {
               )
             }
           />
+        </Route>
+        <Route element={<AppShell />}> 
           <Route
             path="/admin-dashboard"
             element={
@@ -94,7 +97,10 @@ function Root() {
               )
             }
           />
-          <Route path="/dashboard" element={<CustomDashboard />} />
+          <Route
+            path="/dashboard"
+            element={user ? <CustomDashboard /> : <Navigate to="/login" />}
+          />
           <Route
             path="/project-setup"
             element={user ? <ProjectSetup /> : <Navigate to="/login" />}
@@ -129,8 +135,8 @@ function Root() {
             <Route path="storyboard" element={<StoryboardGenerator />} />
             <Route path="content-assets" element={<ContentAssetGenerator />} />
           </Route>
-          <Route path="*" element={<Navigate to="/" />} />
         </Route>
+        <Route path="*" element={<Navigate to="/dashboard" />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/utils/canonical.js
+++ b/src/utils/canonical.js
@@ -1,0 +1,4 @@
+export const canonicalProjectUrl = (id) => `${window.location.origin}/projects/${id}`;
+export const canonicalMapNodeUrl = (id) => `${window.location.origin}/map/${id}`;
+export const canonicalTaskUrl = (id) => `${window.location.origin}/tasks/${id}`;
+export const canonicalUpdateUrl = (id) => `${window.location.origin}/updates/${id}`;

--- a/src/utils/useCanonical.js
+++ b/src/utils/useCanonical.js
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+export default function useCanonical(url) {
+  useEffect(() => {
+    if (!url) return;
+    let link = document.querySelector("link[rel='canonical']");
+    if (!link) {
+      link = document.createElement("link");
+      link.setAttribute("rel", "canonical");
+      document.head.appendChild(link);
+    }
+    link.setAttribute("href", url);
+  }, [url]);
+}


### PR DESCRIPTION
## Summary
- add SPA shell with left-anchored discovery sidebar and canonical link handling
- redesign navigation bar with project switcher, search, and add menu
- centralize authenticated routing in app shell and expose canonical URL utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adddeb6218832bb0cb01ab89c6c0f6