### PR TITLE
fix sidebar links and project status

### DIFF
--- a/src/components/DiscoverySidebar.jsx
+++ b/src/components/DiscoverySidebar.jsx
@@ -4,9 +4,24 @@ import "./DiscoverySidebar.css";
 export default function DiscoverySidebar() {
   const location = useLocation();
   const { pathname, search } = location;
+  const params = new URLSearchParams(search);
+  const initiativeId = params.get("initiativeId");
 
-  const tasksOpen = pathname.startsWith("/tasks") || pathname.startsWith("/action-dashboard");
-  const questionsOpen = pathname === "/discovery" && search.includes("section=questions");
+  const makeUrl = (path, extra = {}) => {
+    const newParams = new URLSearchParams();
+    if (initiativeId) newParams.set("initiativeId", initiativeId);
+    Object.entries(extra).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) newParams.set(k, v);
+    });
+    const query = newParams.toString();
+    return query ? `${path}?${query}` : path;
+  };
+
+  const section = params.get("section");
+  const tasksOpen =
+    (pathname === "/discovery" && section === "tasks") ||
+    pathname.startsWith("/action-dashboard");
+  const questionsOpen = pathname === "/discovery" && section === "questions";
   const statusOpen = pathname.startsWith("/project-status");
   const historyOpen = pathname.startsWith("/project-status/history");
 
@@ -16,50 +31,87 @@ export default function DiscoverySidebar() {
       <nav>
         <ul>
           <li>
-            <Link to="/discovery">Overview</Link>
+            <Link to={makeUrl("/discovery")}>Overview</Link>
           </li>
           <li>
-            <Link to="/tasks">Tasks</Link>
+            <Link to={makeUrl("/discovery", { section: "tasks" })}>Tasks</Link>
             {tasksOpen && (
               <ul>
                 <li>
-                  <Link to="/action-dashboard">Action Dashboard</Link>
+                  <Link to={makeUrl("/action-dashboard")}>Action Dashboard</Link>
                 </li>
               </ul>
             )}
           </li>
           <li>
-            <Link to="/discovery?section=documents">Documents</Link>
+            <Link to={makeUrl("/discovery", { section: "documents" })}>
+              Documents
+            </Link>
           </li>
           <li>
-            <Link to="/discovery?section=questions">Questions</Link>
+            <Link to={makeUrl("/discovery", { section: "questions" })}>
+              Questions
+            </Link>
             {questionsOpen && (
               <ul>
                 <li>
-                  <Link to="/discovery?section=questions&status=toask">Ask</Link>
+                  <Link
+                    to={makeUrl("/discovery", {
+                      section: "questions",
+                      status: "toask",
+                    })}
+                  >
+                    Ask
+                  </Link>
                 </li>
                 <li>
-                  <Link to="/discovery?section=questions&status=asked">Asked</Link>
+                  <Link
+                    to={makeUrl("/discovery", {
+                      section: "questions",
+                      status: "asked",
+                    })}
+                  >
+                    Asked
+                  </Link>
                 </li>
                 <li>
-                  <Link to="/discovery?section=questions&status=answered">Answered</Link>
+                  <Link
+                    to={makeUrl("/discovery", {
+                      section: "questions",
+                      status: "answered",
+                    })}
+                  >
+                    Answered
+                  </Link>
                 </li>
               </ul>
             )}
           </li>
           <li>
-            <Link to="/project-status">Project Status</Link>
+            <Link to={makeUrl("/project-status")}>Project Status</Link>
             {statusOpen && (
               <ul>
                 <li>
-                  <Link to="/project-status/history">History</Link>
+                  <Link to={makeUrl("/project-status/history")}>History</Link>
                   {historyOpen && (
                     <ul>
                       <li>
-                        <Link to="/project-status/history?type=client">Client-facing</Link>
+                        <Link
+                          to={makeUrl("/project-status/history", {
+                            type: "client",
+                          })}
+                        >
+                          Client-facing
+                        </Link>
                       </li>
                       <li>
-                        <Link to="/project-status/history?type=internal">Internal</Link>
+                        <Link
+                          to={makeUrl("/project-status/history", {
+                            type: "internal",
+                          })}
+                        >
+                          Internal
+                        </Link>
                       </li>
                     </ul>
                   )}
@@ -68,7 +120,7 @@ export default function DiscoverySidebar() {
             )}
           </li>
           <li>
-            <Link to="/inquiry-map">Inquiry Map</Link>
+            <Link to={makeUrl("/inquiry-map")}>Inquiry Map</Link>
           </li>
         </ul>
       </nav>

--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -50,15 +50,15 @@ const ProjectStatus = ({
   useCanonical(canonicalProjectUrl(initiativeId));
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || !initiativeId) return;
     const q = query(
-      collection(db, "profiles", user.uid, "taskQueue"),
+      collection(db, "users", user.uid, "initiatives", initiativeId, "tasks"),
       where("status", "!=", "done")
     );
     getDocs(q).then((snap) => {
       setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
     });
-  }, [user]);
+  }, [user, initiativeId]);
 
   useEffect(() => {
     if (!user || !initiativeId) return;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -29,7 +29,6 @@ import ComingSoonPage from "./pages/ComingSoonPage";
 import Login from "./components/Login";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import Settings from "./components/Settings";
-import Tasks from "./components/Tasks";
 import InquiryMapPage from "./pages/InquiryMapPage";
 import AppShell from "./components/AppShell";
 import ActionDashboard from "./components/ActionDashboard.jsx";
@@ -115,10 +114,6 @@ function Root() {
           <Route
             path="/inquiry-map"
             element={user ? <InquiryMapPage /> : <Navigate to="/login" />}
-          />
-          <Route
-            path="/tasks"
-            element={user ? <Tasks /> : <Navigate to="/login" />}
           />
           <Route
             path="/action-dashboard"


### PR DESCRIPTION
## Summary
- preserve initiative context in Discovery sidebar navigation
- remove obsolete tasks route to use Discovery Hub layout
- load project status tasks from project-specific collection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adf02c5908832b8deb1e2c6fbdde4d