### PR TITLE
feat: add answer slide-over for questions

### DIFF
--- a/src/components/AnswerSlideOver.jsx
+++ b/src/components/AnswerSlideOver.jsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+
+const AnswerSlideOver = ({
+  question,
+  idx,
+  allContacts,
+  currentUserName,
+  updateAnswer,
+  analyzeAnswer,
+  createTasks,
+  addContact,
+  onClose,
+  setToast,
+  setAnalyzing,
+}) => {
+  const [contact, setContact] = useState(question.contacts[0] || "");
+  const [text, setText] = useState("");
+  const [stage, setStage] = useState("compose");
+  const [suggestions, setSuggestions] = useState([]);
+  const [selected, setSelected] = useState([]);
+  const [assignments, setAssignments] = useState({});
+
+  const handleSave = async () => {
+    if (text.trim().length < 2) return;
+    updateAnswer(idx, contact, text);
+    setStage("loading");
+    setAnalyzing(true);
+    const result = await analyzeAnswer(question.question || "", text, contact);
+    setAnalyzing(false);
+    setSuggestions(result.suggestions || []);
+    setStage("suggestions");
+  };
+
+  const toggleSelection = (i) => {
+    setSelected((prev) =>
+      prev.includes(i) ? prev.filter((x) => x !== i) : [...prev, i]
+    );
+  };
+
+  const handleAssignmentChange = async (i, value) => {
+    if (value === "__add__") {
+      const name = addContact();
+      if (name) {
+        setAssignments((prev) => ({ ...prev, [i]: name }));
+      }
+      return;
+    }
+    setAssignments((prev) => ({ ...prev, [i]: value }));
+  };
+
+  const handleConfirm = async () => {
+    const chosen = selected.map((i) => ({
+      ...suggestions[i],
+      assignees: [assignments[i] || currentUserName],
+    }));
+    if (chosen.length > 0) {
+      const added = await createTasks(idx, contact, chosen);
+      if (added > 0) {
+        setToast(`Added ${added} tasks.`);
+      }
+    }
+    onClose();
+  };
+
+  return (
+    <div className="slide-over-overlay" onClick={onClose}>
+      <div className="slide-over-panel" onClick={(e) => e.stopPropagation()}>
+        <h3>Answer Question</h3>
+        <p>{question.question}</p>
+        {stage === "compose" && (
+          <>
+            <label className="block text-sm font-medium">
+              Contact
+              <select
+                className="generator-input"
+                value={contact}
+                onChange={(e) => setContact(e.target.value)}
+              >
+                {question.contacts.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <textarea
+              className="generator-input"
+              rows={4}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+            />
+            <div className="modal-actions">
+              <button className="generator-button" onClick={handleSave}>
+                Save
+              </button>
+              <button className="generator-button" onClick={onClose}>
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+        {stage === "loading" && <p>Analyzing answer...</p>}
+        {stage === "suggestions" && (
+          <>
+            {suggestions.length > 0 ? (
+              <>
+                <p>Would you like to add any of these tasks to your task list?</p>
+                <ul className="suggestion-list">
+                  {suggestions.map((s, i) => (
+                    <li key={i}>
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={selected.includes(i)}
+                          onChange={() => toggleSelection(i)}
+                        />
+                        {s.text}
+                      </label>
+                      {selected.includes(i) && (
+                        <select
+                          value={assignments[i] || ""}
+                          onChange={(e) => handleAssignmentChange(i, e.target.value)}
+                        >
+                          <option value="">Assign to...</option>
+                          <option value={currentUserName}>Me</option>
+                          {allContacts.map((c) => (
+                            <option key={c.name} value={c.name}>
+                              {c.name}
+                            </option>
+                          ))}
+                          <option value="__add__">Add New</option>
+                        </select>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <p>No task suggestions.</p>
+            )}
+            <div className="modal-actions">
+              <button className="generator-button" onClick={handleConfirm}>
+                Confirm
+              </button>
+              <button className="generator-button" onClick={onClose}>
+                Close
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+AnswerSlideOver.propTypes = {
+  question: PropTypes.object.isRequired,
+  idx: PropTypes.number.isRequired,
+  allContacts: PropTypes.array.isRequired,
+  currentUserName: PropTypes.string.isRequired,
+  updateAnswer: PropTypes.func.isRequired,
+  analyzeAnswer: PropTypes.func.isRequired,
+  createTasks: PropTypes.func.isRequired,
+  addContact: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  setToast: PropTypes.func.isRequired,
+  setAnalyzing: PropTypes.func.isRequired,
+};
+
+export default AnswerSlideOver;

--- a/src/components/DiscoveryHub.css
+++ b/src/components/DiscoveryHub.css
@@ -393,3 +393,33 @@
   max-width: none;
 }
 
+.slide-over-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.slide-over-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(90vw, 400px);
+  height: 100%;
+  background: #fff;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
+  padding: 1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.suggestion-list {
+  margin-top: 0.5rem;
+}
+
+.suggestion-list li {
+  margin-bottom: 0.5rem;
+}
+

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -28,6 +28,7 @@ import { getPriority } from "../utils/priorityMatrix";
 import ProjectStatus from "./ProjectStatus.jsx";
 import PastUpdateView from "./PastUpdateView.jsx";
 import ActionDashboard from "./ActionDashboard.jsx";
+import AnswerSlideOver from "./AnswerSlideOver.jsx";
 import "./AIToolsGenerators.css";
 import "./DiscoveryHub.css";
 
@@ -147,6 +148,7 @@ const DiscoveryHub = () => {
   const [draftIndex, setDraftIndex] = useState(0);
   const [recipientModal, setRecipientModal] = useState(null);
   const [analysisModal, setAnalysisModal] = useState(null);
+  const [answerPanel, setAnswerPanel] = useState(null);
   const [answerDrafts, setAnswerDrafts] = useState({});
   const [activeComposer, setActiveComposer] = useState(null);
   const [restoredDraftKey, setRestoredDraftKey] = useState(null);
@@ -2837,6 +2839,23 @@ Respond ONLY in this JSON format:
         </div>,
         document.body
       )}
+    {answerPanel &&
+      createPortal(
+        <AnswerSlideOver
+          question={answerPanel.question}
+          idx={answerPanel.idx}
+          allContacts={contacts}
+          currentUserName={currentUserName}
+          updateAnswer={updateAnswer}
+          analyzeAnswer={analyzeAnswer}
+          createTasks={createTasksFromAnalysis}
+          addContact={addContact}
+          onClose={() => setAnswerPanel(null)}
+          setToast={setToast}
+          setAnalyzing={setAnalyzing}
+        />,
+        document.body
+      )}
     {qaModal &&
       createPortal(
         <div className="modal-overlay" onClick={() => setQaModal(null)}>
@@ -3130,6 +3149,16 @@ Respond ONLY in this JSON format:
                             Ask
                           </button>
                         )}
+                        <button
+                          type="button"
+                          className="generator-button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setAnswerPanel({ idx: q.idx, question: q });
+                          }}
+                        >
+                          Answer
+                        </button>
                         <button
                           className="generator-button"
                           onClick={() => draftEmail(q)}


### PR DESCRIPTION
## Summary
- introduce AnswerSlideOver component for unified answering and task assignment
- wire question cards to open slide-over when answering
- add styling for slide-over panel
- ensure Answer button opens slide-over with the correct question context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0b352b7c832b8032ddcfde33ee94