### PR TITLE
Replace hypothesis modal with slide-over

### DIFF
--- a/src/components/HypothesisCard.jsx
+++ b/src/components/HypothesisCard.jsx
@@ -1,9 +1,6 @@
-import { useState } from "react";
 import PropTypes from "prop-types";
-import EvidenceSlideOver from "./EvidenceSlideOver";
 
 const HypothesisCard = ({ hypothesis }) => {
-  const [open, setOpen] = useState(false);
   const evidenceCount =
     (hypothesis.supportingEvidence?.length || 0) +
     (hypothesis.refutingEvidence?.length || 0);
@@ -11,7 +8,7 @@ const HypothesisCard = ({ hypothesis }) => {
   const titleId = hypothesis.displayId || hypothesis.id;
 
   return (
-    <div className="cursor-pointer" onClick={() => setOpen(true)}>
+    <div>
       <div className="font-semibold mb-1">
         {titleId ? `Hypothesis ${titleId}: ` : ""}
         {hypothesis.statement || hypothesis.label || ""}
@@ -19,9 +16,6 @@ const HypothesisCard = ({ hypothesis }) => {
       <div className="text-sm text-gray-600">
         {pct}% confidence • {evidenceCount} items of evidence
       </div>
-      {open && (
-        <EvidenceSlideOver hypothesis={hypothesis} onClose={() => setOpen(false)} />
-      )}
     </div>
   );
 };

--- a/src/components/HypothesisSlideOver.jsx
+++ b/src/components/HypothesisSlideOver.jsx
@@ -1,0 +1,317 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { auth, db } from "../firebase";
+import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+import { classifyTask } from "../utils/taskUtils";
+import { getPriority } from "../utils/priorityMatrix";
+
+const formatEvidenceSummary = (e) => {
+  const base = (e.analysisSummary || e.text || "").replace(
+    /^The new evidence\s*/i,
+    ""
+  );
+  if (!e.source) return base;
+  const intro = /interview|team|lead|manager|comment|exit/i.test(e.source)
+    ? `Comments from ${e.source}`
+    : `Data from ${e.source}`;
+  const lower = base.charAt(0).toLowerCase() + base.slice(1);
+  return `${intro} ${lower}`;
+};
+
+const isLikelyPerson = (src = "") =>
+  /\b(manager|lead|director|vp|chief|officer|head|analyst|engineer|consultant|employee|supervisor|coordinator)\b/i.test(
+    src
+  );
+
+const HypothesisSlideOver = ({
+  hypothesis,
+  onClose,
+  initialView = "summary",
+}) => {
+  const [view, setView] = useState(initialView);
+  const [backView, setBackView] = useState(initialView);
+  const [selectedEvidence, setSelectedEvidence] = useState(null);
+
+  const evidenceCount =
+    (hypothesis.supportingEvidence?.length || 0) +
+    (hypothesis.refutingEvidence?.length || 0);
+  const pct = Math.round((hypothesis.confidence || 0) * 100);
+  const titleId = hypothesis.displayId || hypothesis.id;
+
+  const supports = hypothesis.supportingEvidence || [];
+  const refutes = hypothesis.refutingEvidence || [];
+  const allEvidence = [
+    ...supports.map((e) => ({ ...e, relation: "Supports" })),
+    ...refutes.map((e) => ({ ...e, relation: "Refutes" })),
+  ];
+  const sorted = allEvidence.sort(
+    (a, b) => Math.abs(b.delta) - Math.abs(a.delta)
+  );
+  const topSupport = [...supports].sort(
+    (a, b) => Math.abs(b.delta) - Math.abs(a.delta)
+  )[0];
+  const topRefute = [...refutes].sort(
+    (a, b) => Math.abs(b.delta) - Math.abs(a.delta)
+  )[0];
+  const hasConflict = topSupport && topRefute;
+
+  if (view === "detail" && selectedEvidence) {
+    return (
+      <div className="slide-over-overlay" onClick={onClose}>
+        <div
+          className="slide-over-panel"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center mb-2">
+            <button
+              className="text-white underline mr-2"
+              type="button"
+              onClick={() => setView(backView)}
+            >
+              Back
+            </button>
+            <div className="flex-1" />
+            <button className="text-white" type="button" onClick={onClose}>
+              Close
+            </button>
+          </div>
+          <h3 className="mb-2 text-white">
+            {selectedEvidence.source || "Evidence"}
+          </h3>
+          <div className="text-sm whitespace-pre-wrap">
+            {selectedEvidence.text}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (view === "evidence") {
+    return (
+      <div className="slide-over-overlay" onClick={onClose}>
+        <div
+          className="slide-over-panel"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center mb-2">
+            <button
+              className="text-white underline mr-2"
+              type="button"
+              onClick={() => setView("summary")}
+            >
+              Back
+            </button>
+            <div className="flex-1" />
+            <button className="text-white" type="button" onClick={onClose}>
+              Close
+            </button>
+          </div>
+          <h3 className="mb-2 text-white">Evidence for Hypothesis</h3>
+          {hasConflict && (
+            <div className="p-3 mb-4 bg-orange-100 border border-orange-300 text-sm text-gray-800">
+              <div className="font-medium mb-1">Conflicting Evidence</div>
+              <div className="flex gap-2 text-xs">
+                <div className="flex-1">
+                  <div className="font-semibold">Supports</div>
+                  <div>{topSupport.analysisSummary || topSupport.text}</div>
+                </div>
+                <div className="flex-1">
+                  <div className="font-semibold">Refutes</div>
+                  <div>{topRefute.analysisSummary || topRefute.text}</div>
+                </div>
+              </div>
+              <div className="mt-2 italic">
+                Suggested question: What would explain the gap between these perspectives?
+              </div>
+            </div>
+          )}
+          <ul className="text-sm">
+            {sorted.map((e, i) => (
+              <li key={i} className="mb-2">
+                <div className="font-medium">{formatEvidenceSummary(e)}</div>
+                <div className="text-gray-200">
+                  <button
+                    type="button"
+                    className="underline"
+                    onClick={() => {
+                      setSelectedEvidence(e);
+                      setBackView("evidence");
+                      setView("detail");
+                    }}
+                  >
+                    {e.source || "Unknown"}
+                  </button>{" "}• {e.timestamp ? new Date(e.timestamp).toLocaleString() : ""} • {(e.delta * 100).toFixed(1)}%
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+
+  if (view === "conflict" && hasConflict) {
+    const supportSrc = topSupport.source || "supporting source";
+    const refuteSrc = topRefute.source || "refuting source";
+    const supportSummary =
+      topSupport.analysisSummary || topSupport.text || "";
+    const refuteSummary =
+      topRefute.analysisSummary || topRefute.text || "";
+    const supportIsPerson = isLikelyPerson(supportSrc);
+    const refuteIsPerson = isLikelyPerson(refuteSrc);
+
+    const tasks = [];
+    if (supportIsPerson) {
+      tasks.push({
+        text: `Interview ${supportSrc} to clarify their supporting view: "${supportSummary}"`,
+        taskType: "validate",
+      });
+    } else {
+      tasks.push({
+        text: `Review ${supportSrc} to verify its supporting claim: "${supportSummary}"`,
+        taskType: "validate",
+      });
+    }
+
+    if (refuteIsPerson) {
+      tasks.push({
+        text: `Interview ${refuteSrc} to clarify their refuting view: "${refuteSummary}"`,
+        taskType: "validate",
+      });
+    } else {
+      tasks.push({
+        text: `Review ${refuteSrc} to verify its refuting claim: "${refuteSummary}"`,
+        taskType: "validate",
+      });
+    }
+
+    tasks.push({
+      text: `Compare findings from ${supportSrc} and ${refuteSrc} to resolve conflicting perspectives on hypothesis ${titleId}.`,
+      taskType: "validate",
+    });
+
+    const handleAddTasks = async () => {
+      const user = auth.currentUser;
+      if (!user) return;
+      for (const t of tasks) {
+        const tag = await classifyTask(t.text);
+        await addDoc(collection(db, "profiles", user.uid, "taskQueue"), {
+          message: t.text,
+          status: "open",
+          createdAt: serverTimestamp(),
+          tag,
+          hypothesisId: hypothesis.id,
+          taskType: t.taskType || "explore",
+          priority: getPriority(
+            t.taskType || "explore",
+            hypothesis.confidence || 0
+          ),
+        });
+      }
+      setView("summary");
+    };
+
+    return (
+      <div className="slide-over-overlay" onClick={onClose}>
+        <div
+          className="slide-over-panel"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center mb-2">
+            <button
+              className="text-white underline mr-2"
+              type="button"
+              onClick={() => setView("summary")}
+            >
+              Back
+            </button>
+            <div className="flex-1" />
+            <button className="text-white" type="button" onClick={onClose}>
+              Close
+            </button>
+          </div>
+          <h3 className="mb-2 text-white">Resolve Conflict</h3>
+          <div className="text-sm mb-4">
+            <div className="mb-2">
+              <div className="font-semibold">Supports</div>
+              <button
+                type="button"
+                className="underline"
+                onClick={() => {
+                  setSelectedEvidence(topSupport);
+                  setBackView("conflict");
+                  setView("detail");
+                }}
+              >
+                {formatEvidenceSummary(topSupport)}
+              </button>
+            </div>
+            <div>
+              <div className="font-semibold">Refutes</div>
+              <button
+                type="button"
+                className="underline"
+                onClick={() => {
+                  setSelectedEvidence(topRefute);
+                  setBackView("conflict");
+                  setView("detail");
+                }}
+              >
+                {formatEvidenceSummary(topRefute)}
+              </button>
+            </div>
+          </div>
+          <div>
+            <div className="font-medium mb-2">Suggested Tasks</div>
+            <ul className="list-disc ml-6 text-sm mb-2">
+              {tasks.map((t, i) => (
+                <li key={i}>{t.text}</li>
+              ))}
+            </ul>
+            <button
+              type="button"
+              className="text-white underline"
+              onClick={handleAddTasks}
+            >
+              Add to Task Queue
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="slide-over-overlay" onClick={onClose}>
+      <div
+        className="slide-over-panel"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-end mb-2">
+          <button className="text-white" type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <div className="font-semibold mb-1">
+          {titleId ? `Hypothesis ${titleId}: ` : ""}
+          {hypothesis.statement || hypothesis.label || ""}
+        </div>
+        <div
+          className="text-sm text-gray-200 cursor-pointer underline"
+          onClick={() => setView("evidence")}
+        >
+          {pct}% confidence • {evidenceCount} items of evidence
+        </div>
+      </div>
+    </div>
+  );
+};
+
+HypothesisSlideOver.propTypes = {
+  hypothesis: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  initialView: PropTypes.string,
+};
+
+export default HypothesisSlideOver;
+

--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -1,459 +1,87 @@
-import { useEffect, useMemo, useRef, useState, useCallback, useLayoutEffect } from "react";
-import { createPortal } from "react-dom";
-import ReactFlow, {
-  MiniMap,
-  Controls,
-  Background,
-  Panel,
-  useNodesState,
-  applyNodeChanges,
-  addEdge,
-  applyEdgeChanges,
-  Handle,
-} from "reactflow";
-import { NodeResizer } from "@reactflow/node-resizer";
-import "reactflow/dist/style.css";
-import "@reactflow/node-resizer/dist/style.css";
+import { useState } from "react";
 import PropTypes from "prop-types";
-import "./AIToolsGenerators.css";
-import { useInquiryMap } from "../context/InquiryMapContext";
-import useCanonical from "../utils/useCanonical";
-import { canonicalMapNodeUrl } from "../utils/canonical";
-import HypothesisCard from "./HypothesisCard";
+import HypothesisSlideOver from "./HypothesisSlideOver";
 
-// --- Helper Functions for Sizing (Unchanged) ---
-function useVisibleHeight(containerRef) {
-  const [h, setH] = useState(600);
-  useLayoutEffect(() => {
-    const calc = () => {
-      const footer = document.querySelector("footer");
-      const footerH = footer?.offsetHeight || 0;
-      const top = containerRef.current?.getBoundingClientRect().top || 0;
-      const height = Math.max(360, window.innerHeight - Math.max(0, top) - footerH);
-      setH(height);
-    };
-    calc();
-    window.addEventListener("resize", calc);
-    return () => window.removeEventListener("resize", calc);
-  }, [containerRef]);
-  return h;
-}
-
-function useHeaderOverlap(containerRef) {
-  const [mt, setMt] = useState(0);
-  useLayoutEffect(() => {
-    const calc = () => {
-      const candidates = Array.from(document.querySelectorAll("nav, header, [data-header], .app-header"));
-      const topFixed = candidates.find((el) => {
-        const s = getComputedStyle(el);
-        return s.position === "fixed" && parseInt(s.top || "0", 10) === 0 && el.offsetHeight > 0;
-      });
-      if (!topFixed || !containerRef.current) return setMt(0);
-
-      const headerRect = topFixed.getBoundingClientRect();
-      const contRect = containerRef.current.getBoundingClientRect();
-      const overlap = Math.max(0, headerRect.bottom - contRect.top);
-      setMt(overlap);
-    };
-    calc();
-    window.addEventListener("resize", calc);
-    return () => window.removeEventListener("resize", calc);
-  }, [containerRef]);
-  return mt;
-}
-
-// --- Node Rendering & Styles (Unchanged) ---
-const CARD_W = 320;
-const CARD_H = 110;
-
-const baseCardStyle = {
-  borderRadius: 16,
-  border: "1px solid rgba(0,0,0,0.08)",
-  boxShadow: "0 6px 14px rgba(0,0,0,0.06)",
-  color: "#111827",
-  overflow: "hidden",
-  width: CARD_W,
-  height: CARD_H,
-};
-
-const colorFor = (c) =>
-  typeof c !== "number" ? "#f87171" : c < 0.33 ? "#f87171" : c < 0.66 ? "#fbbf24" : "#4ade80";
-
-const ResizableNode = ({ id, data, selected }) => (
-  <div className="relative">
-    <Handle type="target" position="left" />
-    <Handle type="source" position="right" />
-    <NodeResizer
-      minWidth={240}
-      minHeight={72}
-      isVisible={selected}
-      onResizeEnd={(_, p) => data.onResize?.(id, p.width, p.height)}
-    />
-    <div
-      style={{
-        padding: 12,
-        lineHeight: 1.25,
-        background: "transparent",
-        color: "#111827",
-        whiteSpace: "pre-wrap",
-        wordBreak: "break-word",
-        overflowWrap: "anywhere",
-      }}
-    >
-      {data.label}
-    </div>
-  </div>
-);
-
-ResizableNode.propTypes = {
-  id: PropTypes.string,
-  data: PropTypes.object,
-  selected: PropTypes.bool,
-};
-
-const nodeTypes = { resizable: ResizableNode };
-
-/* --------------------------------- main ---------------------------------- */
-const InquiryMap = ({ businessGoal, hypotheses = [], onUpdateConfidence, onRefresh = () => {}, isAnalyzing }) => {
-  const wrapperRef = useRef(null);
-  const height = useVisibleHeight(wrapperRef);
-  const marginTop = useHeaderOverlap(wrapperRef);
-
-  const layoutKey = "inquiry-map-layout";
-  const storedLayout = useMemo(() => {
-    if (typeof window === "undefined") return {};
-    try {
-      return JSON.parse(localStorage.getItem(layoutKey)) || {};
-    } catch {
-      return {};
-    }
-  }, []);
-
-  const positionsRef = useRef(storedLayout.positions || {});
-  const sizesRef = useRef(storedLayout.sizes || {});
-
-  const [nodes, setNodes] = useNodesState([]);
-  const activeNode = nodes[0]?.id;
-  useCanonical(activeNode ? canonicalMapNodeUrl(activeNode) : window.location.href);
-  const [edges, setEdges] = useState(storedLayout.edges || []);
-  const edgesRef = useRef(edges);
+const InquiryMap = ({ hypotheses = [] }) => {
   const [selected, setSelected] = useState(null);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [newHypothesis, setNewHypothesis] = useState("");
+  const [conflict, setConflict] = useState(null);
 
-  const selectedPct = selected ? Math.min(100, Math.max(0, Math.round((selected.data.confidence || 0) * 100))) : 0;
-  const { addHypothesis: addHypothesisToDb } = useInquiryMap();
+  const sorted = [...hypotheses].sort((a, b) => b.confidence - a.confidence);
 
-  const saveLayout = useCallback((currentNodes, currentEdges) => {
-    const pos = {};
-    currentNodes.forEach((n) => {
-      pos[n.id] = n.position;
-    });
-    positionsRef.current = { ...pos };
-    try {
-      localStorage.setItem(
-        layoutKey,
-        JSON.stringify({ positions: pos, sizes: sizesRef.current, edges: currentEdges })
-      );
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const persistSize = useCallback(
-    (id, width, height) => {
-      sizesRef.current[id] = { width, height };
-      setNodes((nds) => {
-        const next = nds.map((n) => (n.id === id ? { ...n, style: { ...n.style, width, height } } : n));
-        saveLayout(next, edgesRef.current);
-        return next;
-      });
-    },
-    [setNodes, saveLayout]
-  );
-
-  const baseLayout = useMemo(() => {
-    const marginX = 48;
-    const rowYGoal = 40;
-    const rowYHypos = rowYGoal + CARD_H + 40;
-
-    const goal = {
-      id: "goal",
-      type: "resizable",
-      data: { label: businessGoal || "Business Goal", onResize: persistSize },
-      position: positionsRef.current["goal"] || { x: 0, y: rowYGoal },
-      style: { ...baseCardStyle, background: "#ffffff", fontWeight: 600, width: sizesRef.current["goal"]?.width ?? CARD_W, height: sizesRef.current["goal"]?.height ?? CARD_H },
-    };
-
-    const hs = hypotheses.map((h, i) => {
-      const id = h.id || `hypothesis-${i}`;
-      const conf = h.confidence;
-      const letter = /^[A-Z]$/.test(id)
-        ? id
-        : String.fromCharCode(65 + i);
-      const offset = (i - (hypotheses.length - 1) / 2) * (CARD_W + marginX);
-      return {
-        id,
-        type: "resizable",
-        data: {
-          ...h,
-          label: <HypothesisCard hypothesis={{ ...h, displayId: letter }} />,
-          onResize: persistSize,
-        },
-        position: positionsRef.current[id] || { x: offset, y: rowYHypos },
-        style: {
-          ...baseCardStyle,
-          background: h.contested ? "#fb923c" : colorFor(conf),
-          width: sizesRef.current[id]?.width ?? CARD_W,
-          height: sizesRef.current[id]?.height ?? CARD_H,
-        },
-      };
-    });
-
-    const es = hypotheses.map((h) => ({ id: `edge-${h.id}`, source: "goal", target: h.id }));
-    return { nodes: [goal, ...hs], edges: es };
-  }, [businessGoal, hypotheses, persistSize]);
-
-  useEffect(() => {
-    setNodes((prev) => {
-      const prevMap = new Map(prev.map((n) => [n.id, n]));
-      return baseLayout.nodes.map((n) => {
-        const old = prevMap.get(n.id);
-        return old ? { ...n, position: old.position, style: { ...n.style, width: old.style.width, height: old.style.height } } : n;
-      });
-    });
-    setEdges((eds) => {
-      const existing = new Set(eds.map((e) => e.id));
-      const toAdd = baseLayout.edges.filter((e) => !existing.has(e.id));
-      if (toAdd.length === 0) return eds;
-      return [...eds, ...toAdd];
-    });
-  }, [baseLayout, setNodes]);
-
-  useEffect(() => {
-    edgesRef.current = edges;
-  }, [edges]);
-
-  const onNodesChange = useCallback(
-    (changes) => {
-      setNodes((nds) => {
-        const next = applyNodeChanges(changes, nds);
-        changes.forEach((c) => {
-          if (c.type === "position" && !c.dragging) {
-            const node = next.find((n) => n.id === c.id);
-            if (node) positionsRef.current[c.id] = node.position;
-          }
-        });
-        return next;
-      });
-    },
-    [setNodes]
-  );
-
-  const onEdgesChange = useCallback(
-    (changes) => {
-      setEdges((eds) => applyEdgeChanges(changes, eds));
-    },
-    []
-  );
-
-  const onConnect = useCallback(
-    (connection) => {
-      setEdges((eds) => addEdge(connection, eds));
-    },
-    []
-  );
-
-  useEffect(() => {
-    saveLayout(nodes, edges);
-  }, [nodes, edges, saveLayout]);
-
-  const handleConfidenceChange = (id, confidence) => {
-    onUpdateConfidence(id, confidence);
+  const handleRowClick = (h, letter) => {
+    setSelected({ ...h, displayId: letter });
   };
 
-  const addHypothesis = (e) => {
-    e.preventDefault();
-    // This would call a function in the context to add the hypothesis to Firestore
-    if (!newHypothesis.trim()) return;
-    addHypothesisToDb(newHypothesis.trim());
-    setNewHypothesis("");
-    setModalOpen(false);
+  const handleConflictClick = (e, h, letter) => {
+    e.stopPropagation();
+    setConflict({ ...h, displayId: letter });
   };
-
-  const handleRefresh = useCallback(
-    (e) => {
-      e.stopPropagation();
-      onRefresh();
-    },
-    [onRefresh]
-  );
 
   return (
-    <div ref={wrapperRef} className="w-full" style={{ marginTop, height }}>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
-        onNodeClick={(_, n) => setSelected(n)}
-        nodeTypes={nodeTypes}
-        fitView
-        fitViewOptions={{ padding: 0.35, maxZoom: 0.85 }}
-        minZoom={0.3}
-        maxZoom={1.6}
-        proOptions={{ hideAttribution: true }}
-      >
-        <Background variant="dots" gap={24} size={1} />
-        <MiniMap pannable zoomable />
-        <Controls position="top-left" />
-
-        <Panel position="top-left" className="flex items-center gap-2 bg-white/85 rounded-xl px-3 py-2 shadow">
-          <button
-            type="button"
-            className="px-3 py-1.5 bg-green-600 text-white rounded"
-            // **CRITICAL FIX: This now calls the function directly from the context.**
-            onClick={handleRefresh}
-            disabled={isAnalyzing}
-          >
-            {isAnalyzing ? "Analyzing..." : "Refresh Map"}
-          </button>
-        </Panel>
-
-        <Panel position="top-right">
-          <button className="px-4 py-2 bg-blue-500 text-white rounded shadow" onClick={() => setModalOpen(true)}>
-            New Hypothesis
-          </button>
-        </Panel>
-      </ReactFlow>
-
-      {/* Portals for modals (Unchanged but confirmed complete) */}
-      {selected && createPortal(
-          <div
-            style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(0,0,0,0.5)" }}
-            onClick={() => setSelected(null)}
-          >
-            <div
-              className="initiative-card"
-              style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)", width: "min(520px, 90vw)", maxHeight: "90vh", overflowY: "auto", display: "flex", flexDirection: "column", gap: "0.5rem" }}
-              onClick={(e) => e.stopPropagation()}
+    <div className="max-w-3xl mx-auto">
+      <ul className="divide-y divide-gray-200">
+        {sorted.map((h, idx) => {
+          const letter = String.fromCharCode(65 + idx);
+          const pct = Math.round((h.confidence || 0) * 100);
+          const trend = h.trend || 0;
+          const up = trend > 0;
+          const down = trend < 0;
+          const supports = h.supportingEvidence?.length || 0;
+          const refutes = h.refutingEvidence?.length || 0;
+          return (
+            <li
+              key={h.id}
+              className="p-4 flex items-center justify-between cursor-pointer hover:bg-gray-50"
+              onClick={() => handleRowClick(h, letter)}
             >
-            <div className="flex items-center gap-2">
-              <span className="font-semibold flex-1 whitespace-pre-wrap break-words">
-                {selected.data.label}
-              </span>
-              <input
-                type="range"
-                min="0"
-                max="100"
-                value={selectedPct}
-                onChange={(e) =>
-                  handleConfidenceChange(selected.id, Number(e.target.value) / 100)
-                }
-              />
-              <span>{selectedPct}%</span>
-            </div>
-            {Array.isArray(selected.data.sourceContributions) &&
-              selected.data.sourceContributions.length > 0 && (
-                <details>
-                  <summary className="cursor-pointer">Source contributions</summary>
-                  <ul className="list-disc ml-4">
-                    {selected.data.sourceContributions.map((s, idx) => (
-                      <li key={idx}>
-                        {s.source.length > 60
-                          ? `${s.source.slice(0, 60)}…`
-                          : s.source}
-                        : {(s.percent * 100).toFixed(1)}%
-                      </li>
-                    ))}
-                  </ul>
-                </details>
-              )}
-            {(Array.isArray(selected.data.supportingEvidence) &&
-              selected.data.supportingEvidence.length > 0) ||
-            (Array.isArray(selected.data.refutingEvidence) &&
-              selected.data.refutingEvidence.length > 0) ? (
-              <details>
-                <summary className="cursor-pointer">Evidence</summary>
-                <ul className="ml-4 space-y-1">
-                  {selected.data.supportingEvidence?.map((e, idx) => (
-                    <li key={`sup-${idx}`} className="flex items-start gap-1">
-                      <span className="text-green-600 font-bold">+</span>
-                      <span>
-                        {e.analysisSummary ||
-                          (e.text.length > 60
-                            ? `${e.text.slice(0, 60)}…`
-                            : e.text)}
-                      </span>
-                    </li>
-                  ))}
-                  {selected.data.refutingEvidence?.map((e, idx) => (
-                    <li key={`ref-${idx}`} className="flex items-start gap-1">
-                      <span className="text-red-600 font-bold">-</span>
-                      <span>
-                        {e.analysisSummary ||
-                          (e.text.length > 60
-                            ? `${e.text.slice(0, 60)}…`
-                            : e.text)}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </details>
-            ) : null}
-            <div className="flex justify-end">
-              <button
-                className="px-3 py-1 bg-blue-500 text-white rounded"
-                onClick={() => setSelected(null)}
-              >
-                Close
-              </button>
-            </div>
-            </div>
-          </div>,
-          document.body
-        )}
-
-      {modalOpen && createPortal(
-          <div
-            style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(0,0,0,0.5)" }}
-            onClick={() => setModalOpen(false)}
-          >
-            <form
-              onSubmit={addHypothesis}
-              className="initiative-card"
-              style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)", width: "min(520px, 90vw)", maxHeight: "90vh", overflowY: "auto", display: "flex", flexDirection: "column", gap: "0.5rem" }}
-              onClick={(e) => e.stopPropagation()}
-            >
-            <label className="block">
-              <span className="text-sm font-medium">Hypothesis</span>
-              <input
-                className="border w-full p-2 mt-1 rounded"
-                value={newHypothesis}
-                onChange={(e) => setNewHypothesis(e.target.value)}
-              />
-            </label>
-            <div className="flex justify-end gap-2">
-              <button type="button" className="px-3 py-1 bg-gray-300 rounded" onClick={() => setModalOpen(false)}>
-                Cancel
-              </button>
-              <button type="submit" className="px-3 py-1 bg-blue-500 text-white rounded">Add</button>
-            </div>
-            </form>
-          </div>,
-          document.body
-        )}
+              <div className="flex-1">
+                <div className="font-semibold">Hypothesis {letter}</div>
+                <div className="text-sm text-gray-600">
+                  {h.statement || h.label || ""}
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                {up && <span className="text-green-600">▲</span>}
+                {down && <span className="text-red-600">▼</span>}
+                {!up && !down && <span className="text-gray-400">▶</span>}
+                <span className="w-12 text-right">{pct}%</span>
+                <span className="text-green-600">{supports}</span>
+                <span className="text-red-600">{refutes}</span>
+                {h.contested && (
+                  <button
+                    type="button"
+                    className="text-orange-600"
+                    title="Resolve conflict"
+                    onClick={(e) => handleConflictClick(e, h, letter)}
+                  >
+                    !
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      {selected && (
+        <HypothesisSlideOver
+          hypothesis={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
+      {conflict && (
+        <HypothesisSlideOver
+          hypothesis={conflict}
+          initialView="conflict"
+          onClose={() => setConflict(null)}
+        />
+      )}
     </div>
   );
 };
 
 InquiryMap.propTypes = {
-  businessGoal: PropTypes.string,
-  hypotheses: PropTypes.arrayOf(PropTypes.object),
-  onUpdateConfidence: PropTypes.func,
-  onRefresh: PropTypes.func,
-  isAnalyzing: PropTypes.bool,
+  hypotheses: PropTypes.array,
 };
 
 export default InquiryMap;
+

--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import InquiryMap from "../components/InquiryMap";
 import { useInquiryMap } from "../context/InquiryMapContext.jsx";
@@ -6,14 +6,7 @@ import { auth } from "../firebase";
 import { onAuthStateChanged } from "firebase/auth";
 
 const InquiryMapContent = () => {
-  const {
-    hypotheses,
-    businessGoal,
-    loadHypotheses,
-    updateConfidence,
-    refreshInquiryMap,
-    isAnalyzing,
-  } = useInquiryMap();
+  const { hypotheses, loadHypotheses, isAnalyzing } = useInquiryMap();
   const [searchParams] = useSearchParams();
   const initiativeId = searchParams.get("initiativeId");
 
@@ -50,31 +43,15 @@ const InquiryMapContent = () => {
     refutingEvidence: h.refutingEvidence || [],
     sourceContributions: h.sourceContributions || [],
     contested: h.contested || false,
+    trend: Math.sign(h.auditLog?.[h.auditLog.length - 1]?.weight || 0),
   }));
-
-  const handleUpdateConfidence = useCallback(
-    (hypothesisId, confidence) => {
-      updateConfidence(hypothesisId, confidence);
-    },
-    [updateConfidence]
-  );
-
-  const handleRefresh = useCallback(() => {
-    refreshInquiryMap();
-  }, [refreshInquiryMap]);
 
   return (
     <main className="min-h-screen pt-32 pb-40">
       <div className="flex items-center gap-4 mb-4">
         {isAnalyzing && <span>Analyzing evidence...</span>}
       </div>
-      <InquiryMap
-        businessGoal={businessGoal}
-        hypotheses={parsedHypotheses}
-        onUpdateConfidence={handleUpdateConfidence}
-        onRefresh={handleRefresh}
-        isAnalyzing={isAnalyzing}
-      />
+      <InquiryMap hypotheses={parsedHypotheses} />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- replace flow chart with confidence-ranked leaderboard for hypotheses
- add conflict indicator and slide-over with resolution tasks
- track latest confidence change to show up/down trend arrows
- strengthen conflict resolution tasks to interview people or review documents before comparing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeff494664832b80889c9180338853