### PR TITLE
Display active project in selector and remove hypothesis padding

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -708,6 +708,12 @@ body.pulsing::before {
   position: relative;
 }
 
+.project-switcher {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .project-switcher button,
 .add-menu button {
   background: none;

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { auth } from "../firebase";
 import { loadInitiatives } from "../utils/initiatives";
 
@@ -10,6 +10,10 @@ export default function NavBar() {
   const [addMenu, setAddMenu] = useState(false);
   const [projects, setProjects] = useState([]);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const initiativeId = searchParams.get("initiativeId");
+  const activeProject = projects.find((p) => p.id === initiativeId);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -62,8 +66,13 @@ export default function NavBar() {
           {loggedIn && (
             <>
               <div className="project-switcher">
+                <span>Project:</span>
                 <button type="button" onClick={() => setProjectMenu(!projectMenu)}>
-                  Projects
+                  {activeProject
+                    ? activeProject.projectName ||
+                      activeProject.businessGoal ||
+                      activeProject.id
+                    : "Select or Add"}
                 </button>
                 {projectMenu && (
                   <ul className="dropdown">

--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -47,7 +47,7 @@ const InquiryMapContent = () => {
   }));
 
   return (
-    <main className="min-h-screen pt-32 pb-40">
+    <main className="min-h-screen pb-40">
       <div className="flex items-center gap-4 mb-4">
         {isAnalyzing && <span>Analyzing evidence...</span>}
       </div>


### PR DESCRIPTION
## Summary
- Show "Project:" label with the active project's name or "Select or Add" in the navigation selector
- Style project selector for inline label/button and remove top padding from hypothesis page

## Testing
- ⚠️ `npm test` *(missing script)*
- ✅ `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af50ac8940832b905fc1d897a3bcd5