### PR TITLE
feat: add MCP server for Cloud Functions

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,6 +8,13 @@
     ],
     "rewrites": [
       {
+        "source": "/mcp/**",
+        "function": {
+          "codebase": "default",
+          "name": "mcpServer"
+        }
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }
@@ -25,5 +32,12 @@
         "*.local"
       ]
     }
-  ]
+  ],
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "functions": { "port": 5001 },
+    "firestore": { "port": 8080 }
+  }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Allow authenticated users to access MCP documents
+    match /mcp/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1773,3 +1773,4 @@ export const savePersona = onCall(async (request) => {
 });
 
 export { getEmailAuthUrl, emailOAuthCallback, sendQuestionEmail } from "./emailProviders.js";
+export { mcpServer } from "./mcpServer.js";

--- a/functions/mcpServer.js
+++ b/functions/mcpServer.js
@@ -1,0 +1,70 @@
+import { createServer } from "@modelcontextprotocol/server";
+import { onRequest } from "firebase-functions/v2/https";
+
+// Create MCP server instance
+const mcp = createServer();
+
+// List of callable Cloud Functions we want to expose as MCP tools
+const callableFunctions = [
+  "generateTrainingPlan",
+  "generateStudyMaterial",
+  "generateCourseOutline",
+  "generateAssessment",
+  "generateLessonContent",
+  "generateClarifyingQuestions",
+  "generateProjectBrief",
+  "generateStatusUpdate",
+  "generateLearningStrategy",
+  "generateContentAssets",
+  "generateLearnerPersona",
+  "generateHierarchicalOutline",
+  "generateLearningDesignDocument",
+  "generateStoryboard",
+  "generateInitialInquiryMap",
+  "generateAvatar",
+  "savePersona",
+  "generateInvitation",
+  "sendEmailBlast",
+  "sendEmailReply",
+];
+
+function registerCallable(name) {
+  mcp.registerTool({
+    name,
+    description: `Proxy to the ${name} Cloud Function`,
+    inputSchema: { type: "object", additionalProperties: true },
+    async handler(input) {
+      if (!input || typeof input !== "object") {
+        throw new Error("Input must be an object");
+      }
+      const mod = await import("./index.js");
+      const fn = mod[name];
+      if (!fn || typeof fn.run !== "function") {
+        throw new Error(`Function ${name} is not callable`);
+      }
+      const result = await fn.run({ data: input });
+      return result;
+    },
+  });
+}
+
+for (const name of callableFunctions) {
+  registerCallable(name);
+}
+
+export const mcpServer = onRequest(async (req, res) => {
+  // Basic CORS for local testing
+  res.set("Access-Control-Allow-Origin", "*");
+  if (req.method === "OPTIONS") {
+    res.set("Access-Control-Allow-Methods", "POST");
+    res.set("Access-Control-Allow-Headers", "Content-Type");
+    res.status(204).end();
+    return;
+  }
+  try {
+    await mcp.handleRequest(req, res);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+

--- a/functions/package.json
+++ b/functions/package.json
@@ -23,7 +23,8 @@
     "firebase-functions": "^6.4.0",
     "genkit": "^1.0.4",
     "googleapis": "^140.0.0",
-    "nodemailer": "^6.10.0"
+    "nodemailer": "^6.10.0",
+    "@modelcontextprotocol/server": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",


### PR DESCRIPTION
## Summary
- add `@modelcontextprotocol/server` dependency for Functions
- expose existing Cloud Functions as MCP tools via new `mcpServer` HTTP function
- configure Firebase hosting, emulators, and security rules for MCP server

## Testing
- `npm test` (fails: Missing script: "test")
- `(cd functions && npm test)` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_68b08a8c49d8832b88e5f6e013dbd040