### PR TITLE
feat: add MCP client and route xAPI via tools

### DIFF
--- a/functions/mcpServer.js
+++ b/functions/mcpServer.js
@@ -131,7 +131,9 @@ export const mcpServer = onRequest(async (req, res) => {
 
         transport.onclose = () => {
           if (transport.sessionId) {
-            try { servers.get(transport.sessionId)?.close?.(); } catch {}
+            try { servers.get(transport.sessionId)?.close?.(); } catch {
+              /* ignore */
+            }
             servers.delete(transport.sessionId);
             transports.delete(transport.sessionId);
           }
@@ -157,7 +159,9 @@ export const mcpServer = onRequest(async (req, res) => {
         return void res.status(400).send("Invalid or missing session ID");
       }
       const t = transports.get(sessionId);
-      try { t?.close(); } catch {}
+      try { t?.close(); } catch {
+        /* ignore */
+      }
       transports.delete(sessionId);
       servers.delete(sessionId);
       return void res.status(204).end();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.1.5",
     "reactflow": "^11.10.0",
-    "tailwindcss": "^4.0.3"
+    "tailwindcss": "^4.0.3",
+    "@modelcontextprotocol/sdk": "*"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/Inquiries.jsx
+++ b/src/components/Inquiries.jsx
@@ -14,8 +14,15 @@ import {
 import { db } from "../firebase";
 import { classifyTask, isQuestionTask } from "../utils/taskUtils";
 import { loadInitiative, saveInitiative } from "../utils/initiatives";
+import { runTool } from "../mcp/client";
 
 const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
+const LRS_SERVER = "https://cloud.scorm.com/lrs/8FKK4XRIED";
+const LRS_HEADERS = {
+  "Content-Type": "application/json",
+  "X-Experience-API-Version": "1.0.3",
+  Authorization: LRS_AUTH,
+};
 
 export default function NewInquiries({ user, openReplyModal }) {
   const [selectedItem, setSelectedItem] = useState(null);
@@ -79,15 +86,7 @@ export default function NewInquiries({ user, openReplyModal }) {
         timestamp: new Date().toISOString(),
       };
 
-      await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPIDeleteInquiry),
-      });
+      await runTool(LRS_SERVER, "statements", xAPIDeleteInquiry, LRS_HEADERS);
     } catch (error) {
       console.error("Error deleting inquiry:", error);
     }
@@ -166,15 +165,7 @@ export default function NewInquiries({ user, openReplyModal }) {
         timestamp: new Date().toISOString(),
       };
 
-      await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPIMoveInquiry),
-      });
+      await runTool(LRS_SERVER, "statements", xAPIMoveInquiry, LRS_HEADERS);
     } catch (error) {
       console.error("Error moving inquiry to task queue:", error);
     }

--- a/src/mcp/client.js
+++ b/src/mcp/client.js
@@ -1,0 +1,119 @@
+// src/mcp/client.js
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+// Keep one live client per server URL
+const clients = new Map(); // Map<string, { client, transport, initialized }>
+
+const PROTOCOL_VERSION = "2025-03-26";
+
+/** Build a transport with optional auth headers (API key or Bearer). */
+function makeTransport(serverUrl, extraHeaders) {
+  const headers = {
+    // Streamable HTTP expects both
+    Accept: "application/json, text/event-stream",
+    ...(extraHeaders || {}),
+  };
+  return new StreamableHTTPClientTransport(new URL(serverUrl), {
+    requestInit: { headers },
+  });
+}
+
+async function ensureClient(serverUrl, extraHeaders) {
+  let rec = clients.get(serverUrl);
+  if (rec) return rec;
+
+  const client = new Client(
+    { name: "app", version: "1.0.0" },
+    { capabilities: {} }
+  );
+  const transport = makeTransport(serverUrl, extraHeaders);
+  await client.connect(transport);
+
+  rec = { client, transport, initialized: false };
+  clients.set(serverUrl, rec);
+  return rec;
+}
+
+async function initializeIfNeeded(rec, timeoutMs = 15000) {
+  if (rec.initialized) return;
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    await rec.client.initialize(
+      { protocolVersion: PROTOCOL_VERSION, capabilities: {} },
+      { signal: ctrl.signal }
+    );
+    rec.initialized = true;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function isNotInitializedErr(err) {
+  const msg = String(err?.message || err);
+  // Matches server's “Bad Request: Server not initialized” or similar
+  return /not initialized/i.test(msg);
+}
+
+/** Retry once if the serverless hop lost the session. */
+async function withInitRetry(serverUrl, extraHeaders, fn) {
+  let rec = await ensureClient(serverUrl, extraHeaders);
+  try {
+    await initializeIfNeeded(rec);
+    return await fn(rec);
+  } catch (e) {
+    if (isNotInitializedErr(e)) {
+      // Recreate client (new transport/session), re-init, then retry once
+      clients.delete(serverUrl);
+      rec = await ensureClient(serverUrl, extraHeaders);
+      await initializeIfNeeded(rec);
+      return await fn(rec);
+    }
+    throw e;
+  }
+}
+
+/** Public API (JS) **/
+
+export async function connect(serverUrl, extraHeaders) {
+  await withInitRetry(serverUrl, extraHeaders, async () => undefined);
+}
+
+export async function listTools(serverUrl, extraHeaders) {
+  return withInitRetry(serverUrl, extraHeaders, async (rec) => {
+    const { tools } = await rec.client.listTools();
+    return tools; // [{ name, title, description, inputSchema }, ...]
+  });
+}
+
+export async function runTool(serverUrl, toolName, args = {}, extraHeaders) {
+  return withInitRetry(serverUrl, extraHeaders, async (rec) => {
+    const res = await rec.client.callTool({ name: toolName, arguments: args });
+    if (res && res.isError) {
+      const txt = res.content?.[0]?.text || "Unknown tool error";
+      throw new Error(txt);
+    }
+    return res; // { content: [...], isError?: false }
+  });
+}
+
+export async function close(serverUrl) {
+  const rec = clients.get(serverUrl);
+  if (!rec) return;
+  try {
+    await rec.client.close();
+  } finally {
+    // Optional: tell server to drop the session it created
+    try {
+      const sid = rec.transport?.sessionId;
+      if (sid) {
+        await fetch(serverUrl, { method: "DELETE", headers: { "Mcp-Session-Id": sid } });
+      }
+      } catch {
+        /* ignore */
+      }
+    clients.delete(serverUrl);
+  }
+}
+

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -16,8 +16,15 @@ import { db, auth } from "../firebase";
 import TaskQueue from "../components/TaskQueue";
 import Inquiries from "../components/Inquiries";
 import "./admin.css";
+import { runTool } from "../mcp/client";
 
 const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
+const LRS_SERVER = "https://cloud.scorm.com/lrs/8FKK4XRIED";
+const LRS_HEADERS = {
+  "Content-Type": "application/json",
+  "X-Experience-API-Version": "1.0.3",
+  Authorization: LRS_AUTH,
+};
 
 export default function AdminDashboard({ user }) {
   const functionsInstance = getFunctions();
@@ -175,15 +182,7 @@ Thoughtify Training Team`;
         },
         timestamp: new Date().toISOString(),
       };
-      await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPIInvitation),
-      });
+      await runTool(LRS_SERVER, "statements", xAPIInvitation, LRS_HEADERS);
   
       setNewInvitation({ businessName: "", businessEmail: "" });
       fetchInvitations();
@@ -259,23 +258,8 @@ Thoughtify Training Team`;
           timestamp: new Date().toISOString(),
         };
     
-        const lrsResponse = await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Experience-API-Version": "1.0.3",
-            Authorization: LRS_AUTH,
-          },
-          body: JSON.stringify(xAPIBlast),
-        });
-    
-        const lrsResponseData = await lrsResponse.json();
-        console.log("xAPI Response:", lrsResponseData);
-    
-        if (!lrsResponse.ok) {
-          console.error("SCORM Cloud LRS Error:", lrsResponseData);
-          throw new Error(`Failed to send xAPI statement: ${JSON.stringify(lrsResponseData)}`);
-        }
+        await runTool(LRS_SERVER, "statements", xAPIBlast, LRS_HEADERS);
+        console.log("xAPI Response: sent");
         closeBlastModal();
       } else {
         alert("Error sending email blast: " + response.data.error);
@@ -332,18 +316,8 @@ Thoughtify Training Team`;
         timestamp: new Date().toISOString(),
       };
   
-      const lrsResponse = await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPIReplyTask),
-      });
-  
-      const lrsResponseData = await lrsResponse.json();
-      console.log("xAPI Response for task reply:", lrsResponseData);
+      await runTool(LRS_SERVER, "statements", xAPIReplyTask, LRS_HEADERS);
+      console.log("xAPI Response for task reply: sent");
     } catch (error) {
       console.error("Error replying to task:", error);
     }
@@ -381,22 +355,8 @@ Thoughtify Training Team`;
         timestamp: new Date().toISOString(),
       };
   
-      const lrsResponse = await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPICompleteTask),
-      });
-      const lrsResponseData = await lrsResponse.json();
-      console.log("xAPI Task Completion Response:", lrsResponseData);
-  
-      if (!lrsResponse.ok) {
-        console.error("SCORM Cloud LRS Error:", lrsResponseData);
-        throw new Error(`Failed to send xAPI statement: ${JSON.stringify(lrsResponseData)}`);
-      }
+      await runTool(LRS_SERVER, "statements", xAPICompleteTask, LRS_HEADERS);
+      console.log("xAPI Task Completion Response: sent");
     } catch (error) {
       console.error("Error completing task:", error);
     }
@@ -430,15 +390,7 @@ Thoughtify Training Team`;
         timestamp: new Date().toISOString(),
       };
   
-      await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPIDeleteTask),
-      });
+      await runTool(LRS_SERVER, "statements", xAPIDeleteTask, LRS_HEADERS);
     } catch (error) {
       console.error("Error deleting task:", error);
     }
@@ -493,15 +445,7 @@ Thoughtify Training Team`;
           timestamp: new Date().toISOString(),
         };
   
-        await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Experience-API-Version": "1.0.3",
-            Authorization: LRS_AUTH,
-          },
-          body: JSON.stringify(xAPIReplyInquiry),
-        });
+        await runTool(LRS_SERVER, "statements", xAPIReplyInquiry, LRS_HEADERS);
   
         // Move the inquiry to the user's "inquiries" sub-collection with status "open"
         const userLeadsRef = collection(db, "profiles", user.uid, "inquiries");

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -12,12 +12,19 @@ import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import Testimonials from "../components/Testimonials";
 import hero1 from "../assets/hero1.png";
+import { runTool } from "../mcp/client";
 
 import "../App.css";
 import "../coreBenefits.css";
 
 export default function ComingSoonPage({ openSignupModal }) {
   const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
+  const LRS_SERVER = "https://cloud.scorm.com/lrs/8FKK4XRIED";
+  const LRS_HEADERS = {
+    "Content-Type": "application/json",
+    "X-Experience-API-Version": "1.0.3",
+    Authorization: LRS_AUTH,
+  };
   const {
     register: registerSignup,
     handleSubmit: handleSignupSubmit,
@@ -124,35 +131,7 @@ const onEmailSubmit = async (data) => {
     };
 
     // 3) Send to SCORM Cloud LRS
-    const lrsResponse = await fetch(
-      "https://cloud.scorm.com/lrs/8FKK4XRIED/statements",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPIStatement),
-      }
-    );
-
-    // 4) Safely parse the response (JSON or plain text)
-    let lrsResponseData;
-    const contentType = lrsResponse.headers.get("content-type") || "";
-    if (contentType.includes("application/json")) {
-      lrsResponseData = await lrsResponse.json();
-    } else {
-      lrsResponseData = await lrsResponse.text();
-    }
-
-    // 5) Handle HTTP errors
-    if (!lrsResponse.ok) {
-      console.error("SCORM Cloud LRS Error:", lrsResponseData);
-      throw new Error(
-        `Failed to send xAPI statement: ${lrsResponseData}`
-      );
-    }
+    await runTool(LRS_SERVER, "statements", xAPIStatement, LRS_HEADERS);
 
     // 6) Clear the form and reset step
     resetSignup();
@@ -193,22 +172,7 @@ const onEmailSubmit = async (data) => {
         timestamp: new Date().toISOString(),
       };
 
-      const lrsResponse = await fetch("https://cloud.scorm.com/lrs/8FKK4XRIED/statements", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Experience-API-Version": "1.0.3",
-          Authorization: LRS_AUTH,
-        },
-        body: JSON.stringify(xAPIStatement),
-      });
-
-      const lrsResponseData = await lrsResponse.json();
-
-      if (!lrsResponse.ok) {
-        console.error("SCORM Cloud LRS Error:", lrsResponseData);
-        throw new Error(`Failed to send xAPI statement: ${JSON.stringify(lrsResponseData)}`);
-      }
+      await runTool(LRS_SERVER, "statements", xAPIStatement, LRS_HEADERS);
 
       resetInquiry();
     } catch (error) {


### PR DESCRIPTION
## Summary
- add reusable MCP client with initialization, retry, and session cleanup
- send xAPI statements through `runTool` instead of direct HTTP fetches
- document MCP SDK dependency in package.json

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0b7c8da04832b98f1bd9aceb4af9f