### PR TITLE
feat: enforce auth for MCP server

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,12 @@
+# MCP Server Authentication
+
+Tool requests to the MCP Cloud Function require an `Authorization` header.
+
+Use one of the following formats:
+
+- **Firebase ID token**: `Authorization: Bearer <ID_TOKEN>`
+- **API key**: `Authorization: ApiKey <API_KEY>`
+
+The API key must match the `MCP_API_KEY` environment variable or secret
+configured for the function. Requests without a valid token or key receive
+`401 Unauthorized`.


### PR DESCRIPTION
## Summary
- verify Authorization header with Firebase ID tokens or API key before handling MCP requests
- document required Authorization formats for MCP server

## Testing
- `node --check functions/mcpServer.js`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 1 error, 7 warnings)*
- `cd functions && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0cbe251b8832bb2685f396a7e473f