### PR TITLE
feat: add MCP context provider

### DIFF
--- a/src/components/Inquiries.jsx
+++ b/src/components/Inquiries.jsx
@@ -14,10 +14,9 @@ import {
 import { db } from "../firebase";
 import { classifyTask, isQuestionTask } from "../utils/taskUtils";
 import { loadInitiative, saveInitiative } from "../utils/initiatives";
-import { runTool } from "../mcp/client";
+import { useMcp } from "../context/McpContext";
 
 const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
-const LRS_SERVER = "https://cloud.scorm.com/lrs/8FKK4XRIED";
 const LRS_HEADERS = {
   "Content-Type": "application/json",
   "X-Experience-API-Version": "1.0.3",
@@ -25,6 +24,7 @@ const LRS_HEADERS = {
 };
 
 export default function NewInquiries({ user, openReplyModal }) {
+  const { runTool } = useMcp();
   const [selectedItem, setSelectedItem] = useState(null);
   const [replyData, setReplyData] = useState("");
   const [allInquiries, setAllInquiries] = useState([]);
@@ -86,7 +86,7 @@ export default function NewInquiries({ user, openReplyModal }) {
         timestamp: new Date().toISOString(),
       };
 
-      await runTool(LRS_SERVER, "statements", xAPIDeleteInquiry, LRS_HEADERS);
+      await runTool("statements", xAPIDeleteInquiry, LRS_HEADERS);
     } catch (error) {
       console.error("Error deleting inquiry:", error);
     }
@@ -165,7 +165,7 @@ export default function NewInquiries({ user, openReplyModal }) {
         timestamp: new Date().toISOString(),
       };
 
-      await runTool(LRS_SERVER, "statements", xAPIMoveInquiry, LRS_HEADERS);
+      await runTool("statements", xAPIMoveInquiry, LRS_HEADERS);
     } catch (error) {
       console.error("Error moving inquiry to task queue:", error);
     }

--- a/src/context/McpContext.jsx
+++ b/src/context/McpContext.jsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useMemo } from "react";
+import PropTypes from "prop-types";
+import { connect, runTool as runToolClient, listTools as listToolsClient } from "../mcp/client";
+
+const McpContext = createContext();
+
+export const McpProvider = ({ children }) => {
+  const serverUrl = import.meta.env.VITE_MCP_URL;
+
+  useEffect(() => {
+    if (serverUrl) {
+      connect(serverUrl).catch((err) => {
+        console.error("MCP connection failed", err);
+      });
+    }
+  }, [serverUrl]);
+
+  const value = useMemo(
+    () => ({
+      serverUrl,
+      runTool: (toolName, args = {}, extraHeaders) =>
+        runToolClient(serverUrl, toolName, args, extraHeaders),
+      listTools: (extraHeaders) => listToolsClient(serverUrl, extraHeaders),
+    }),
+    [serverUrl]
+  );
+
+  return <McpContext.Provider value={value}>{children}</McpContext.Provider>;
+};
+
+McpProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useMcp = () => {
+  const context = useContext(McpContext);
+  if (!context) {
+    throw new Error("useMcp must be used within a McpProvider");
+  }
+  return context;
+};
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import "./index.css";
 import App from "./App.jsx";
 import { ProjectProvider } from "./context/ProjectContext.jsx";
 import { InquiryMapProvider } from "./context/InquiryMapContext";
+import { McpProvider } from "./context/McpContext.jsx";
 import PropTypes from "prop-types";
 import { initAnalytics, getAnalyticsConsent } from "./utils/analytics.js";
 import { onAuthStateChanged } from "firebase/auth";
@@ -156,10 +157,12 @@ function Root() {
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <ProjectProvider>
-      <InquiryMapProvider>
-        <Root />
-      </InquiryMapProvider>
-    </ProjectProvider>
+    <McpProvider>
+      <ProjectProvider>
+        <InquiryMapProvider>
+          <Root />
+        </InquiryMapProvider>
+      </ProjectProvider>
+    </McpProvider>
   </StrictMode>
 );

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -16,10 +16,9 @@ import { db, auth } from "../firebase";
 import TaskQueue from "../components/TaskQueue";
 import Inquiries from "../components/Inquiries";
 import "./admin.css";
-import { runTool } from "../mcp/client";
+import { useMcp } from "../context/McpContext";
 
 const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
-const LRS_SERVER = "https://cloud.scorm.com/lrs/8FKK4XRIED";
 const LRS_HEADERS = {
   "Content-Type": "application/json",
   "X-Experience-API-Version": "1.0.3",
@@ -28,6 +27,7 @@ const LRS_HEADERS = {
 
 export default function AdminDashboard({ user }) {
   const functionsInstance = getFunctions();
+  const { runTool } = useMcp();
 
   // State for invitation generation
   const [newInvitation, setNewInvitation] = useState({
@@ -182,7 +182,7 @@ Thoughtify Training Team`;
         },
         timestamp: new Date().toISOString(),
       };
-      await runTool(LRS_SERVER, "statements", xAPIInvitation, LRS_HEADERS);
+      await runTool("statements", xAPIInvitation, LRS_HEADERS);
   
       setNewInvitation({ businessName: "", businessEmail: "" });
       fetchInvitations();
@@ -258,7 +258,7 @@ Thoughtify Training Team`;
           timestamp: new Date().toISOString(),
         };
     
-        await runTool(LRS_SERVER, "statements", xAPIBlast, LRS_HEADERS);
+        await runTool("statements", xAPIBlast, LRS_HEADERS);
         console.log("xAPI Response: sent");
         closeBlastModal();
       } else {
@@ -316,7 +316,7 @@ Thoughtify Training Team`;
         timestamp: new Date().toISOString(),
       };
   
-      await runTool(LRS_SERVER, "statements", xAPIReplyTask, LRS_HEADERS);
+      await runTool("statements", xAPIReplyTask, LRS_HEADERS);
       console.log("xAPI Response for task reply: sent");
     } catch (error) {
       console.error("Error replying to task:", error);
@@ -355,7 +355,7 @@ Thoughtify Training Team`;
         timestamp: new Date().toISOString(),
       };
   
-      await runTool(LRS_SERVER, "statements", xAPICompleteTask, LRS_HEADERS);
+      await runTool("statements", xAPICompleteTask, LRS_HEADERS);
       console.log("xAPI Task Completion Response: sent");
     } catch (error) {
       console.error("Error completing task:", error);
@@ -390,7 +390,7 @@ Thoughtify Training Team`;
         timestamp: new Date().toISOString(),
       };
   
-      await runTool(LRS_SERVER, "statements", xAPIDeleteTask, LRS_HEADERS);
+      await runTool("statements", xAPIDeleteTask, LRS_HEADERS);
     } catch (error) {
       console.error("Error deleting task:", error);
     }
@@ -445,7 +445,7 @@ Thoughtify Training Team`;
           timestamp: new Date().toISOString(),
         };
   
-        await runTool(LRS_SERVER, "statements", xAPIReplyInquiry, LRS_HEADERS);
+        await runTool("statements", xAPIReplyInquiry, LRS_HEADERS);
   
         // Move the inquiry to the user's "inquiries" sub-collection with status "open"
         const userLeadsRef = collection(db, "profiles", user.uid, "inquiries");

--- a/src/pages/ComingSoonPage.jsx
+++ b/src/pages/ComingSoonPage.jsx
@@ -12,19 +12,19 @@ import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import Testimonials from "../components/Testimonials";
 import hero1 from "../assets/hero1.png";
-import { runTool } from "../mcp/client";
+import { useMcp } from "../context/McpContext";
 
 import "../App.css";
 import "../coreBenefits.css";
 
 export default function ComingSoonPage({ openSignupModal }) {
   const LRS_AUTH = "Basic " + btoa(import.meta.env.VITE_XAPI_BASIC_AUTH);
-  const LRS_SERVER = "https://cloud.scorm.com/lrs/8FKK4XRIED";
   const LRS_HEADERS = {
     "Content-Type": "application/json",
     "X-Experience-API-Version": "1.0.3",
     Authorization: LRS_AUTH,
   };
+  const { runTool } = useMcp();
   const {
     register: registerSignup,
     handleSubmit: handleSignupSubmit,
@@ -131,7 +131,7 @@ const onEmailSubmit = async (data) => {
     };
 
     // 3) Send to SCORM Cloud LRS
-    await runTool(LRS_SERVER, "statements", xAPIStatement, LRS_HEADERS);
+    await runTool("statements", xAPIStatement, LRS_HEADERS);
 
     // 6) Clear the form and reset step
     resetSignup();
@@ -172,7 +172,7 @@ const onEmailSubmit = async (data) => {
         timestamp: new Date().toISOString(),
       };
 
-      await runTool(LRS_SERVER, "statements", xAPIStatement, LRS_HEADERS);
+      await runTool("statements", xAPIStatement, LRS_HEADERS);
 
       resetInquiry();
     } catch (error) {


### PR DESCRIPTION
## Summary
- add `McpProvider` and `useMcp` hook to handle MCP server connection
- replace direct `runTool` imports with `useMcp` in AdminDashboard, Inquiries, ComingSoonPage
- wrap app in `McpProvider` so components share connection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d6bc47ac832b952c4bf534915762