### PR TITLE
feat: centralize MCP server configuration

### DIFF
--- a/src/context/McpContext.jsx
+++ b/src/context/McpContext.jsx
@@ -1,28 +1,26 @@
 import { createContext, useContext, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import { connect, runTool as runToolClient, listTools as listToolsClient } from "../mcp/client";
+import { MCP_SERVER_URL } from "../mcp/config";
 
 const McpContext = createContext();
 
 export const McpProvider = ({ children }) => {
-  const serverUrl = import.meta.env.VITE_MCP_URL;
-
   useEffect(() => {
-    if (serverUrl) {
-      connect(serverUrl).catch((err) => {
+    if (MCP_SERVER_URL) {
+      connect().catch((err) => {
         console.error("MCP connection failed", err);
       });
     }
-  }, [serverUrl]);
+  }, []);
 
   const value = useMemo(
     () => ({
-      serverUrl,
       runTool: (toolName, args = {}, extraHeaders) =>
-        runToolClient(serverUrl, toolName, args, extraHeaders),
-      listTools: (extraHeaders) => listToolsClient(serverUrl, extraHeaders),
+        runToolClient(undefined, toolName, args, extraHeaders),
+      listTools: (extraHeaders) => listToolsClient(undefined, extraHeaders),
     }),
-    [serverUrl]
+    []
   );
 
   return <McpContext.Provider value={value}>{children}</McpContext.Provider>;

--- a/src/mcp/config.js
+++ b/src/mcp/config.js
@@ -1,0 +1,9 @@
+// src/mcp/config.js
+// Exports MCP server configuration derived from environment variables.
+
+export const MCP_SERVER_URL = import.meta.env.VITE_MCP_URL;
+
+export const MCP_HEADERS = import.meta.env.VITE_MCP_API_KEY
+  ? { Authorization: `ApiKey ${import.meta.env.VITE_MCP_API_KEY}` }
+  : {};
+


### PR DESCRIPTION
## Summary
- add `src/mcp/config.js` to expose `MCP_SERVER_URL` and default auth headers from environment
- update MCP client to use configuration defaults for server URL and headers
- simplify context provider to rely on client defaults instead of duplicating URL constants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0e134348c832bb17f192b648b31ba