### PR TITLE
docs: document MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## MCP Server
+
+See [docs/mcp.md](docs/mcp.md) for server endpoints, authentication,
+available tools, and client examples.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,4 +1,18 @@
-# MCP Server Authentication
+# Model Context Protocol (MCP) Server
+
+The MCP server runs as a Firebase Cloud Function and exposes a thin HTTP API for
+dispatching tools over the Model Context Protocol.
+
+## Endpoints
+
+- `GET /mcpServer` – health check returning the server name and version.
+- `POST /mcpServer` – JSON‑RPC requests. Sessions are created on the
+  `initialize` request and subsequent calls must include the `Mcp-Session-Id`
+  header. All POST requests require authentication.
+- `DELETE /mcpServer` – close an existing session by providing its
+  `Mcp-Session-Id` header.
+
+## Authentication
 
 Tool requests to the MCP Cloud Function require an `Authorization` header.
 
@@ -11,7 +25,67 @@ The API key must match the `MCP_API_KEY` environment variable or secret
 configured for the function. Requests without a valid token or key receive
 `401 Unauthorized`.
 
+## Available tools
+
+The server exposes a `ping` health check and proxies the following callable
+functions:
+
+- `generateTrainingPlan`
+- `generateStudyMaterial`
+- `generateCourseOutline`
+- `generateAssessment`
+- `generateLessonContent`
+- `generateClarifyingQuestions`
+- `generateProjectBrief`
+- `generateStatusUpdate`
+- `generateLearningStrategy`
+- `generateContentAssets`
+- `generateLearnerPersona`
+- `generateHierarchicalOutline`
+- `generateLearningDesignDocument`
+- `generateStoryboard`
+- `generateInitialInquiryMap`
+- `generateAvatar`
+- `savePersona`
+- `generateInvitation`
+- `sendEmailBlast`
+- `sendEmailReply`
+
+## Client usage
+
+A lightweight client is provided in `src/mcp/client.js`:
+
+```js
+import { connect, listTools, runTool, runToolStream, close } from "./src/mcp/client.js";
+
+// Initialize the session
+await connect();
+
+// Inspect available tools
+const tools = await listTools();
+console.log(tools);
+
+// Run a tool once
+const res = await runTool("generateCourseOutline", { topic: "Photosynthesis" });
+console.log(res.content);
+
+// Stream a tool's output
+for await (const chunk of runToolStream("generateProjectBrief", { subject: "AI" })) {
+  console.log(chunk);
+}
+
+await close();
+```
+
+To authenticate with an API key:
+
+```js
+await connect("https://<FUNCTION_URL>", { Authorization: "ApiKey <API_KEY>" });
+```
+
 ## Configuration
 
-- `MCP_CALL_TIMEOUT_MS` &mdash; maximum time in milliseconds to wait for a
-  callable function to respond. Defaults to `120000` if unset.
+- `MCP_CALL_TIMEOUT_MS` — maximum time in milliseconds to wait for a callable
+  function to respond. Defaults to `120000` if unset.
+- `MCP_SESSION_TTL_MS` — how long (ms) inactive sessions are kept before they
+  are discarded.


### PR DESCRIPTION
## Summary
- document MCP server endpoints, auth and tools
- add usage examples
- link to MCP docs in the README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0e2818800832bb0f67a0f1695778d