### PR TITLE
test: fix vitest globals

### DIFF
--- a/functions/__tests__/mcpServer.test.ts
+++ b/functions/__tests__/mcpServer.test.ts
@@ -1,0 +1,77 @@
+import http from 'node:http';
+import functionsTest from 'firebase-functions-test';
+import { describe, test, expect, afterAll } from 'vitest';
+
+// Ensure API key for auth
+process.env.MCP_API_KEY = 'test-key';
+
+// Lazy import after env var is set
+const { mcpServer } = await import('../mcpServer.js');
+
+const fft = functionsTest();
+
+function startWrappedServer() {
+  const wrapped = fft.wrap(mcpServer);
+  const server = http.createServer((req, res) => {
+    // Express-style helper
+    // @ts-ignore
+    req.get = (name: string) => req.headers[name.toLowerCase()];
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      // @ts-ignore
+      req.body = chunks.length ? Buffer.concat(chunks).toString() : undefined;
+      wrapped(req, res);
+    });
+  });
+  return new Promise<{url: string, close: () => void}>((resolve) => {
+    server.listen(0, () => {
+      const { port } = server.address() as any;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => server.close() });
+    });
+  });
+}
+
+describe('mcpServer HTTPS function', () => {
+  afterAll(() => {
+    fft.cleanup();
+  });
+
+  test('ping tool responds', async () => {
+    const { url, close } = await startWrappedServer();
+    const initResp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'ApiKey test-key',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: { clientInfo: { name: 'test', version: '0.0.0' }, capabilities: {} },
+        id: 1,
+      }),
+    });
+    expect(initResp.status).toBe(200);
+    const sessionId = initResp.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+
+    const pingResp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'ApiKey test-key',
+        'Mcp-Session-Id': sessionId ?? '',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'call_tool',
+        params: { name: 'ping', arguments: {} },
+        id: 2,
+      }),
+    });
+    const pingJson = await pingResp.json();
+    expect(pingJson.result.content[0].text).toBe('pong');
+    close();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@firebase/ai": "^1.4.1",
@@ -41,6 +42,7 @@
     "eslint-plugin-react-refresh": "^0.4.16",
     "genkit-cli": "^1.0.4",
     "globals": "^15.14.0",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/mcp/__tests__/client.test.js
+++ b/src/mcp/__tests__/client.test.js
@@ -1,0 +1,52 @@
+import http from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { connect, listTools } from '../client.js';
+import { describe, test, expect } from 'vitest';
+
+async function startMockServer() {
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => 's1' });
+  const server = new McpServer({ name: 'mock', version: '1.0.0' });
+  server.registerTool('ping', {
+    title: 'ping',
+    description: 'Ping tool',
+    inputSchema: { type: 'object', properties: {} },
+  }, async () => ({ content: [{ type: 'text', text: 'pong' }] }));
+  await server.connect(transport);
+
+  const httpServer = http.createServer((req, res) => {
+    // @ts-ignore
+    req.get = (name) => req.headers[name.toLowerCase()];
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', async () => {
+      const body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString()) : undefined;
+      await transport.handleRequest(req, res, body);
+    });
+  });
+
+  await new Promise((resolve) => httpServer.listen(0, resolve));
+  const port = httpServer.address().port;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => httpServer.close(),
+  };
+}
+
+describe('MCP client', () => {
+  test('connect and listTools', async () => {
+    const { url, close } = await startMockServer();
+    await connect(url, { Authorization: 'ApiKey test' });
+    const tools = await listTools(url, { Authorization: 'ApiKey test' });
+    expect(tools.some(t => t.name === 'ping')).toBe(true);
+    close();
+  });
+
+  test('connect fails for bad server', async () => {
+    const badServer = http.createServer((req, res) => { res.statusCode = 500; res.end('error'); });
+    await new Promise((r) => badServer.listen(0, r));
+    const badUrl = `http://127.0.0.1:${badServer.address().port}`;
+    await expect(connect(badUrl)).rejects.toBeDefined();
+    badServer.close();
+  });
+});


### PR DESCRIPTION
## Summary
- import vitest test helpers in server and client tests

## Testing
- ⚠️ `npm install` (403 Forbidden - GET https://registry.npmjs.org/vitest)
- ✅ `npm --prefix functions install`
- ⚠️ `npm test` (vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0e3a1e014832b909023cd29b75b88