### PR TITLE
feat: add Zapier integration trigger

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -13,6 +13,7 @@ import crypto from "crypto";
 import { Buffer } from "buffer";
 import express from "express";
 import cors from "cors";
+import { callZap } from "./integrations/zapier.js";
 
 const FIREBASE_CONFIG = JSON.parse(process.env.FIREBASE_CONFIG || "{}");
 const PROJECT_ID =
@@ -1770,6 +1771,19 @@ export const savePersona = onCall(async (request) => {
     .doc(personaId)
     .set(persona, { merge: true });
   return { id: personaId };
+});
+
+export const triggerZap = onCall(async (req) => {
+  const { zapUrl, payload } = req.data || {};
+  if (!zapUrl) {
+    throw new HttpsError("invalid-argument", "zapUrl is required");
+  }
+  try {
+    return await callZap({ zapUrl, payload });
+  } catch (err) {
+    console.error("Zapier call failed", err);
+    throw new HttpsError("internal", err.message || "Zapier call failed");
+  }
 });
 
 export { getEmailAuthUrl, emailOAuthCallback, sendQuestionEmail } from "./emailProviders.js";

--- a/functions/integrations/zapier.js
+++ b/functions/integrations/zapier.js
@@ -1,0 +1,26 @@
+export async function callZap({ zapUrl, payload = {} }) {
+  const token = process.env.ZAPIER_AUTH_TOKEN;
+  if (!token) {
+    throw new Error("Missing Zapier auth token");
+  }
+
+  const res = await fetch(zapUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload ?? {}),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Zapier request failed: ${res.status} ${text}`);
+  }
+
+  try {
+    return await res.json();
+  } catch {
+    return { ok: true };
+  }
+}

--- a/functions/mcpSchemas.js
+++ b/functions/mcpSchemas.js
@@ -132,6 +132,10 @@ const toolSchemas = {
     subject: z.string(),
     message: z.string(),
   }),
+  triggerZap: z.object({
+    zapUrl: z.string().url(),
+    payload: z.any().optional(),
+  }),
 };
 
 export default toolSchemas;

--- a/functions/mcpServer.js
+++ b/functions/mcpServer.js
@@ -64,6 +64,7 @@ const callableFunctions = [
   "generateInvitation",
   "sendEmailBlast",
   "sendEmailReply",
+  "triggerZap",
 ];
 
 const anyObject = z.record(z.any());


### PR DESCRIPTION
## Summary
- add Zapier webhook helper using auth token
- expose triggerZap callable and register in MCP server
- define schema for triggerZap tool

## Testing
- `npm test` *(fails: auth/invalid-api-key, logisticConfidence precision)*
- `npm run lint` *(fails: Buffer not defined, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b10b6e5c54832b8ada504908917f54