### PR TITLE
feat: add zapier integration

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -35,6 +35,7 @@ import AppShell from "./components/AppShell";
 import ActionDashboard from "./components/ActionDashboard.jsx";
 import ProjectStatus from "./components/ProjectStatus.jsx";
 import ProjectStatusHistory from "./components/ProjectStatusHistory.jsx";
+import ZapierConfig from "./pages/ZapierConfig.jsx";
 
 window.PropTypes = PropTypes;
 
@@ -131,6 +132,10 @@ function Root() {
             }
           />
           <Route path="/settings" element={<Settings />} />
+          <Route
+            path="/zapier-config"
+            element={user ? <ZapierConfig /> : <Navigate to="/login" />}
+          />
           <Route
             path="/leadership-assessment"
             element={user ? <LeadershipAssessmentWizard /> : <Navigate to="/login" />}

--- a/src/mcp/client.js
+++ b/src/mcp/client.js
@@ -106,6 +106,20 @@ export async function runTool(serverUrl = MCP_SERVER_URL, toolName, args = {}, e
   });
 }
 
+export async function runZap(
+  { zapUrl, payload },
+  serverUrl = MCP_SERVER_URL,
+  extraHeaders = MCP_HEADERS
+) {
+  const result = await runTool(
+    serverUrl,
+    "triggerZap",
+    { zapUrl, payload },
+    extraHeaders
+  );
+  return result.content?.[0]?.text;
+}
+
 export async function* runToolStream(serverUrl = MCP_SERVER_URL, toolName, args = {}, extraHeaders = MCP_HEADERS) {
   const queue = [];
   let resolve;

--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, Link } from "react-router-dom";
 import InquiryMap from "../components/InquiryMap";
 import { useInquiryMap } from "../context/InquiryMapContext.jsx";
 import { auth } from "../firebase";
@@ -50,6 +50,9 @@ const InquiryMapContent = () => {
     <main className="min-h-screen pb-40">
       <div className="flex items-center gap-4 mb-4">
         {isAnalyzing && <span>Analyzing evidence...</span>}
+        <Link to="/zapier-config" className="generator-button">
+          Use Zapier
+        </Link>
       </div>
       <InquiryMap hypotheses={parsedHypotheses} />
     </main>

--- a/src/pages/ZapierConfig.jsx
+++ b/src/pages/ZapierConfig.jsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { runZap } from "../mcp/client.js";
+
+const ZapierConfig = () => {
+  const [zapUrl, setZapUrl] = useState("");
+  const [payload, setPayload] = useState("{}\n");
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleTest = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    let data = {};
+    try {
+      data = payload.trim() ? JSON.parse(payload) : {};
+    } catch (e) {
+      setError("Invalid JSON payload");
+      setLoading(false);
+      return;
+    }
+    try {
+      const res = await runZap({ zapUrl, payload: data });
+      setResult(res);
+    } catch (e) {
+      setError(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Zapier Configuration</h1>
+      <div>
+        <label className="block mb-1">Zap URL</label>
+        <input
+          type="url"
+          value={zapUrl}
+          onChange={(e) => setZapUrl(e.target.value)}
+          className="w-full p-2 border rounded"
+          placeholder="https://hooks.zapier.com/..."
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Payload (JSON)</label>
+        <textarea
+          value={payload}
+          onChange={(e) => setPayload(e.target.value)}
+          className="w-full p-2 border rounded"
+          rows={5}
+        />
+      </div>
+      <button
+        type="button"
+        className="generator-button"
+        onClick={handleTest}
+        disabled={loading}
+      >
+        {loading ? "Testing..." : "Test Zap"}
+      </button>
+      {error && <div className="text-red-600">{error}</div>}
+      {result && (
+        <pre className="bg-gray-100 p-2 rounded overflow-auto">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </main>
+  );
+};
+
+export default ZapierConfig;


### PR DESCRIPTION
## Summary
- add runZap wrapper for triggerZap tool
- add ZapierConfig page to test Zap URLs
- surface Zapier option from Inquiry Map

## Testing
- `npm test` *(fails: Firebase auth/invalid-api-key and network errors)*
- `npm test -- src/mcp/__tests__/client.test.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1203ffd40832bb1bf5203c32e34be