### PR TITLE
feat: add user settings slide-over

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -1,11 +1,12 @@
 
-import { Buffer } from "node:buffer";
-import crypto from "node:crypto";
+import { Buffer } from "buffer";
+import crypto from "crypto";
 
 import { initializeApp, getApps } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
 import { google } from "googleapis";
+import nodemailer from "nodemailer";
 
 // --- Firebase Functions v2 (https) ---
 import {
@@ -196,6 +197,60 @@ async function getStoredProviderToken(uid, provider, keyHex) {
 }
 
 // ==============================
+// 3) Save SMTP/Outlook credentials (CALLABLE)
+// ==============================
+export const saveEmailCredentials = onCall(
+  {
+    region: "us-central1",
+    enforceAppCheck: true,
+    secrets: [TOKEN_ENCRYPTION_KEY],
+  },
+  async (request) => {
+    const uid = (request.auth && request.auth.uid) || null;
+    if (!uid) {
+      throw new HttpsError("unauthenticated", "Sign in required.");
+    }
+
+    const { provider, host, port, user, pass } = request.data || {};
+
+    if (provider !== "smtp" && provider !== "outlook") {
+      throw new HttpsError("invalid-argument", "Unknown provider");
+    }
+
+    const trimmedUser = (user || "").trim();
+    const trimmedPass = (pass || "").trim();
+
+    if (!trimmedUser || !trimmedPass) {
+      throw new HttpsError("invalid-argument", "Missing credentials");
+    }
+
+    const data = {
+      user: trimmedUser,
+      pass: encrypt(trimmedPass, TOKEN_ENCRYPTION_KEY.value()),
+    };
+
+    if (provider === "smtp") {
+      const trimmedHost = (host || "").trim();
+      const normalizedPort = Number(port) || 587;
+      if (!trimmedHost || !normalizedPort) {
+        throw new HttpsError("invalid-argument", "Missing SMTP fields");
+      }
+      data.host = trimmedHost;
+      data.port = normalizedPort;
+    }
+
+    await db
+      .collection("users")
+      .doc(uid)
+      .collection("emailTokens")
+      .doc(provider)
+      .set(data);
+
+    return { ok: true };
+  }
+);
+
+// ==============================
 // 3) Send email (CALLABLE with App Check)
 // ==============================
 export const sendQuestionEmail = onCall(
@@ -230,40 +285,79 @@ export const sendQuestionEmail = onCall(
       throw new HttpsError("invalid-argument", "Missing fields");
     }
 
-    if (provider !== "gmail") {
-      throw new HttpsError("invalid-argument", "Unknown provider");
-    }
-
     try {
-      const gmailClient = createGmailClient(
-        GMAIL_CLIENT_ID.value(),
-        GMAIL_CLIENT_SECRET.value(),
-        GMAIL_REDIRECT_URI.value()
-      );
-      const tokens = await getStoredProviderToken(
-        uid,
-        "gmail",
-        TOKEN_ENCRYPTION_KEY.value()
-      );
-      gmailClient.setCredentials(tokens);
+      let messageId = "";
 
-      const gmail = google.gmail({ version: "v1", auth: gmailClient });
+      if (provider === "gmail") {
+        const gmailClient = createGmailClient(
+          GMAIL_CLIENT_ID.value(),
+          GMAIL_CLIENT_SECRET.value(),
+          GMAIL_REDIRECT_URI.value()
+        );
+        const tokens = await getStoredProviderToken(
+          uid,
+          "gmail",
+          TOKEN_ENCRYPTION_KEY.value()
+        );
+        gmailClient.setCredentials(tokens);
 
-      const raw = Buffer.from(
-        `To: ${recipientEmail}\r\nSubject: ${subject}\r\n\r\n${message}`
-      )
-        .toString("base64")
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=+$/, "");
+        const gmail = google.gmail({ version: "v1", auth: gmailClient });
 
-      const resp = await gmail.users.messages.send({
-        userId: "me",
-        requestBody: { raw },
-      });
-      const messageId = resp.data.id || "";
+        const raw = Buffer.from(
+          `To: ${recipientEmail}\r\nSubject: ${subject}\r\n\r\n${message}`
+        )
+          .toString("base64")
+          .replace(/\+/g, "-")
+          .replace(/\//g, "_")
+          .replace(/=+$/, "");
 
-      // Ensure user document exists so the questions subcollection is visible
+        const resp = await gmail.users.messages.send({
+          userId: "me",
+          requestBody: { raw },
+        });
+        messageId = resp.data.id || "";
+      } else if (provider === "smtp" || provider === "outlook") {
+        const snap = await db
+          .collection("users")
+          .doc(uid)
+          .collection("emailTokens")
+          .doc(provider)
+          .get();
+        if (!snap.exists) {
+          throw new HttpsError("failed-precondition", "No credentials stored");
+        }
+        const data = snap.data() || {};
+        const { host, port, user } = data;
+        let pass = data.pass || "";
+        const smtpHost = host || (provider === "outlook" ? "smtp.office365.com" : null);
+        const smtpPort = port || 587;
+        if (!smtpHost || !user || !pass) {
+          throw new HttpsError("failed-precondition", "Incomplete SMTP credentials");
+        }
+        if (typeof pass === "string") {
+          try {
+            pass = decrypt(pass, TOKEN_ENCRYPTION_KEY.value());
+          } catch (_) {
+            // assume pass stored plaintext
+          }
+        }
+        const transporter = nodemailer.createTransport({
+          host: smtpHost,
+          port: Number(smtpPort),
+          secure: Number(smtpPort) === 465,
+          auth: { user, pass },
+        });
+        const info = await transporter.sendMail({
+          from: user,
+          to: recipientEmail,
+          subject,
+          text: message,
+        });
+        messageId = info.messageId || "";
+      } else {
+        throw new HttpsError("invalid-argument", "Unknown provider");
+      }
+
       await db.collection("users").doc(uid).set({}, { merge: true });
 
       await db
@@ -275,7 +369,22 @@ export const sendQuestionEmail = onCall(
 
       return { messageId };
     } catch (err) {
-      console.error("sendQuestionEmail error", (err && err.response && err.response.data) || err);
+      console.error(
+        "sendQuestionEmail error",
+        (err && err.response && err.response.data) || err
+      );
+      if (
+        err &&
+        (err.code === "EAUTH" ||
+          err.responseCode === 535 ||
+          (typeof err.message === "string" &&
+            err.message.toLowerCase().includes("invalid login")))
+      ) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Invalid email credentials"
+        );
+      }
       const msg =
         (err && err.response && err.response.data && JSON.stringify(err.response.data)) ||
         (err && err.message) ||

--- a/functions/index.js
+++ b/functions/index.js
@@ -1833,5 +1833,10 @@ export const triggerZap = onCall(async (req) => {
   }
 });
 
-export { getEmailAuthUrl, emailOAuthCallback, sendQuestionEmail } from "./emailProviders.js";
+export {
+  getEmailAuthUrl,
+  emailOAuthCallback,
+  sendQuestionEmail,
+  saveEmailCredentials,
+} from "./emailProviders.js";
 export { mcpServer } from "./mcpServer.js";

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -3,11 +3,13 @@ import { onAuthStateChanged } from "firebase/auth";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { auth } from "../firebase";
 import { loadInitiatives } from "../utils/initiatives";
+import UserSettingsSlideOver from "./UserSettingsSlideOver";
 
 export default function NavBar() {
   const [loggedIn, setLoggedIn] = useState(false);
   const [projectMenu, setProjectMenu] = useState(false);
   const [addMenu, setAddMenu] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [projects, setProjects] = useState([]);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -26,6 +28,12 @@ export default function NavBar() {
       }
     });
     return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    const handler = () => setSettingsOpen(true);
+    window.addEventListener("openUserSettings", handler);
+    return () => window.removeEventListener("openUserSettings", handler);
   }, []);
 
   const handleAddProject = () => {
@@ -136,11 +144,15 @@ export default function NavBar() {
                 src="https://placehold.co/40x40/764ba2/FFFFFF?text=ID"
                 alt="User Avatar"
                 className="user-avatar"
+                onClick={() => setSettingsOpen(true)}
               />
             </>
           )}
         </div>
       </nav>
+      {settingsOpen && (
+        <UserSettingsSlideOver onClose={() => setSettingsOpen(false)} />
+      )}
     </header>
   );
 }

--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -26,6 +26,7 @@ const ProjectStatus = ({
   emailConnected = false,
   onHistoryChange = () => {},
   initiativeId: propInitiativeId = "",
+  emailProvider = "gmail",
 }) => {
   const [searchParams] = useSearchParams();
   const initiativeId = propInitiativeId || searchParams.get("initiativeId") || "";
@@ -202,7 +203,9 @@ ${JSON.stringify({recommendations, tasks})}
   // eslint-disable-next-line no-unused-vars
   const openSendModal = () => {
     if (!emailConnected) {
-      alert("Connect your Gmail account in settings.");
+      if (window.confirm("Connect your email account?")) {
+        window.dispatchEvent(new Event("openUserSettings"));
+      }
       return;
     }
     if (!auth.currentUser) {
@@ -227,7 +230,7 @@ ${JSON.stringify({recommendations, tasks})}
       await auth.currentUser.getIdToken(true);
       const callable = httpsCallable(functions, "sendQuestionEmail");
       await callable({
-        provider: "gmail",
+        provider: emailProvider,
         recipientEmail: emails.join(","),
         subject: `Project Status Update - ${new Date().toDateString()}`,
         message: summary,
@@ -332,6 +335,7 @@ ProjectStatus.propTypes = {
   contacts: PropTypes.array,
   setContacts: PropTypes.func,
   emailConnected: PropTypes.bool,
+  emailProvider: PropTypes.string,
   onHistoryChange: PropTypes.func,
   initiativeId: PropTypes.string,
   businessGoal: PropTypes.string,

--- a/src/components/UserSettingsSlideOver.css
+++ b/src/components/UserSettingsSlideOver.css
@@ -1,0 +1,40 @@
+.slide-over-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.slide-over-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(90vw, 400px);
+  height: 100%;
+  background: #201863;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
+  padding: 1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings-section h3 {
+  margin-bottom: 0.25rem;
+}
+

--- a/src/components/UserSettingsSlideOver.jsx
+++ b/src/components/UserSettingsSlideOver.jsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { onAuthStateChanged, updateProfile } from "firebase/auth";
+import { auth, db, app, functions } from "../firebase";
+import { doc, getDoc, deleteDoc } from "firebase/firestore";
+import { httpsCallable } from "firebase/functions";
+import {
+  getStorage,
+  ref as storageRef,
+  uploadBytes,
+  getDownloadURL,
+} from "firebase/storage";
+import "./UserSettingsSlideOver.css";
+
+const functionsBaseUrl =
+  import.meta.env.VITE_FUNCTIONS_BASE_URL ||
+  `https://us-central1-${import.meta.env.VITE_FIREBASE_PROJECT_ID}.cloudfunctions.net`;
+
+export default function UserSettingsSlideOver({ onClose }) {
+  const [uid, setUid] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState("https://placehold.co/80x80/764ba2/FFFFFF?text=ID");
+  const [gmailConnected, setGmailConnected] = useState(false);
+  const [outlookConnected, setOutlookConnected] = useState(false);
+  const [smtpConnected, setSmtpConnected] = useState(false);
+  const [outlookUser, setOutlookUser] = useState("");
+  const [outlookPass, setOutlookPass] = useState("");
+  const [smtpHost, setSmtpHost] = useState("");
+  const [smtpPort, setSmtpPort] = useState("");
+  const [smtpUser, setSmtpUser] = useState("");
+  const [smtpPass, setSmtpPass] = useState("");
+  const fileInput = useRef(null);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        setUid(user.uid);
+        setAvatarUrl(user.photoURL || avatarUrl);
+        const gmailSnap = await getDoc(doc(db, "users", user.uid, "emailTokens", "gmail"));
+        setGmailConnected(gmailSnap.exists());
+        const outlookSnap = await getDoc(
+          doc(db, "users", user.uid, "emailTokens", "outlook"),
+        );
+        if (outlookSnap.exists()) {
+          const data = outlookSnap.data();
+          setOutlookConnected(true);
+          setOutlookUser(data.user || "");
+        }
+        const smtpSnap = await getDoc(doc(db, "users", user.uid, "emailTokens", "smtp"));
+        setSmtpConnected(smtpSnap.exists());
+      }
+    });
+    return () => unsub();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleAvatarChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file || !uid) return;
+    const storage = getStorage(app);
+    const ref = storageRef(storage, `avatars/${uid}`);
+    await uploadBytes(ref, file);
+    const url = await getDownloadURL(ref);
+    await updateProfile(auth.currentUser, { photoURL: url });
+    setAvatarUrl(url);
+  };
+
+  const connectGmail = () => {
+    if (!uid) return;
+    window.open(
+      `${functionsBaseUrl}/getEmailAuthUrl?provider=gmail&state=${uid}`,
+      "_blank",
+      "width=500,height=600"
+    );
+  };
+
+  const disconnectGmail = async () => {
+    if (!uid) return;
+    await deleteDoc(doc(db, "users", uid, "emailTokens", "gmail"));
+    setGmailConnected(false);
+  };
+
+  const saveOutlook = async () => {
+    if (!uid) return;
+    const saveFn = httpsCallable(functions, "saveEmailCredentials");
+    await saveFn({
+      provider: "outlook",
+      user: outlookUser.trim(),
+      pass: outlookPass,
+    });
+    setOutlookConnected(true);
+  };
+
+  const disconnectOutlook = async () => {
+    if (!uid) return;
+    await deleteDoc(doc(db, "users", uid, "emailTokens", "outlook"));
+    setOutlookConnected(false);
+    setOutlookUser("");
+    setOutlookPass("");
+  };
+
+  const saveSmtp = async () => {
+    if (!uid) return;
+    const saveFn = httpsCallable(functions, "saveEmailCredentials");
+    await saveFn({
+      provider: "smtp",
+      host: smtpHost.trim(),
+      port: smtpPort,
+      user: smtpUser.trim(),
+      pass: smtpPass,
+    });
+    setSmtpConnected(true);
+  };
+
+  const disconnectSmtp = async () => {
+    if (!uid) return;
+    await deleteDoc(doc(db, "users", uid, "emailTokens", "smtp"));
+    setSmtpConnected(false);
+  };
+
+  return createPortal(
+    <div className="slide-over-overlay" onClick={onClose}>
+      <div className="slide-over-panel" onClick={(e) => e.stopPropagation()}>
+        <h2>User Settings</h2>
+        <section className="settings-section">
+          <img src={avatarUrl} alt="User Avatar" className="settings-avatar" />
+          <button type="button" onClick={() => fileInput.current?.click()}>
+            Edit Avatar
+          </button>
+          <input
+            ref={fileInput}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={handleAvatarChange}
+          />
+        </section>
+        <section className="settings-section">
+          <h3>Email Accounts</h3>
+          {gmailConnected ? (
+            <div>
+              <p>Gmail account connected.</p>
+              <button onClick={disconnectGmail}>Disconnect Gmail</button>
+            </div>
+          ) : (
+            <button onClick={connectGmail}>Connect Gmail</button>
+          )}
+          {outlookConnected ? (
+            <div>
+              <p>Outlook account connected.</p>
+              <button onClick={disconnectOutlook}>Disconnect Outlook</button>
+            </div>
+          ) : (
+            <div className="settings-section">
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="Outlook Username"
+                value={outlookUser}
+                onChange={(e) => setOutlookUser(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="password"
+                placeholder="Outlook Password"
+                value={outlookPass}
+                onChange={(e) => setOutlookPass(e.target.value)}
+              />
+              <button onClick={saveOutlook}>Save Outlook</button>
+            </div>
+          )}
+          {smtpConnected ? (
+            <div>
+              <p>SMTP credentials saved.</p>
+              <button onClick={disconnectSmtp}>Remove SMTP</button>
+            </div>
+          ) : (
+            <div className="settings-section">
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="SMTP Host"
+                value={smtpHost}
+                onChange={(e) => setSmtpHost(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="SMTP Port"
+                value={smtpPort}
+                onChange={(e) => setSmtpPort(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="SMTP Username"
+                value={smtpUser}
+                onChange={(e) => setSmtpUser(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="password"
+                placeholder="SMTP Password"
+                value={smtpPass}
+                onChange={(e) => setSmtpPass(e.target.value)}
+              />
+              <button onClick={saveSmtp}>Save SMTP</button>
+            </div>
+          )}
+        </section>
+        <div>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+


### PR DESCRIPTION
## Summary
- open a slide-over from avatar to manage user settings
- allow avatar upload and choose Gmail, Outlook, or SMTP email connections
- fix slide-over layering by rendering in a portal above main content
- update Draft Email flow to use the connected Gmail/Outlook/SMTP account and prompt for setup when missing
- support SMTP and Outlook credentials and handle all providers when sending question emails
- surface invalid email credentials as a failed precondition instead of a 500
- treat SMTP 'Invalid login' failures as credential issues rather than internal errors
- encrypt stored SMTP/Outlook passwords and save via a callable function
- replace Node-prefixed crypto/buffer imports with standard modules to ensure deploy compatibility

## Testing
- `npm test` *(fails: logisticConfidence precision, fetch failed in MCP client)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aea10934832bac2f906da2a8f4b8