### PR TITLE
Replace SMTP with IMAP/POP account support

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -6,7 +6,6 @@ import { initializeApp, getApps } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
 import { google } from "googleapis";
-import nodemailer from "nodemailer";
 
 // --- Firebase Functions v2 (https) ---
 import {
@@ -197,7 +196,7 @@ async function getStoredProviderToken(uid, provider, keyHex) {
 }
 
 // ==============================
-// 3) Save SMTP/Outlook credentials (CALLABLE)
+// 3) Save IMAP/POP credentials (CALLABLE)
 // ==============================
 export const saveEmailCredentials = onCall(
   {
@@ -211,33 +210,39 @@ export const saveEmailCredentials = onCall(
       throw new HttpsError("unauthenticated", "Sign in required.");
     }
 
-    const { provider, host, port, user, pass } = request.data || {};
+    const {
+      provider,
+      host,
+      port,
+      smtpHost,
+      smtpPort,
+      user,
+      pass,
+    } = request.data || {};
 
-    if (provider !== "smtp" && provider !== "outlook") {
+    if (provider !== "imap" && provider !== "pop3") {
       throw new HttpsError("invalid-argument", "Unknown provider");
     }
 
     const trimmedUser = (user || "").trim();
     const trimmedPass = (pass || "").trim();
+    const trimmedHost = (host || "").trim();
+    const normalizedPort = Number(port) || 0;
+    const trimmedSmtpHost = (smtpHost || "").trim();
+    const normalizedSmtpPort = Number(smtpPort) || 0;
 
-    if (!trimmedUser || !trimmedPass) {
+    if (!trimmedUser || !trimmedPass || !trimmedHost || !normalizedPort) {
       throw new HttpsError("invalid-argument", "Missing credentials");
     }
 
     const data = {
       user: trimmedUser,
       pass: encrypt(trimmedPass, TOKEN_ENCRYPTION_KEY.value()),
+      host: trimmedHost,
+      port: normalizedPort,
     };
-
-    if (provider === "smtp") {
-      const trimmedHost = (host || "").trim();
-      const normalizedPort = Number(port) || 587;
-      if (!trimmedHost || !normalizedPort) {
-        throw new HttpsError("invalid-argument", "Missing SMTP fields");
-      }
-      data.host = trimmedHost;
-      data.port = normalizedPort;
-    }
+    if (trimmedSmtpHost) data.smtpHost = trimmedSmtpHost;
+    if (normalizedSmtpPort) data.smtpPort = normalizedSmtpPort;
 
     await db
       .collection("users")
@@ -316,46 +321,11 @@ export const sendQuestionEmail = onCall(
           requestBody: { raw },
         });
         messageId = resp.data.id || "";
-      } else if (provider === "smtp" || provider === "outlook") {
-        const snap = await db
-          .collection("users")
-          .doc(uid)
-          .collection("emailTokens")
-          .doc(provider)
-          .get();
-        if (!snap.exists) {
-          throw new HttpsError("failed-precondition", "No credentials stored");
-        }
-        const data = snap.data() || {};
-        const { host, port, user } = data;
-        let pass = data.pass || "";
-        const smtpHost = host || (provider === "outlook" ? "smtp.office365.com" : null);
-        const smtpPort = port || 587;
-        if (!smtpHost || !user || !pass) {
-          throw new HttpsError("failed-precondition", "Incomplete SMTP credentials");
-        }
-        if (typeof pass === "string") {
-          try {
-            pass = decrypt(pass, TOKEN_ENCRYPTION_KEY.value());
-          } catch (_) {
-            // assume pass stored plaintext
-          }
-        }
-        const transporter = nodemailer.createTransport({
-          host: smtpHost,
-          port: Number(smtpPort),
-          secure: Number(smtpPort) === 465,
-          auth: { user, pass },
-        });
-        const info = await transporter.sendMail({
-          from: user,
-          to: recipientEmail,
-          subject,
-          text: message,
-        });
-        messageId = info.messageId || "";
       } else {
-        throw new HttpsError("invalid-argument", "Unknown provider");
+        throw new HttpsError(
+          "invalid-argument",
+          "Unsupported provider for sending"
+        );
       }
 
       await db.collection("users").doc(uid).set({}, { merge: true });

--- a/functions/integrations/zapier.js
+++ b/functions/integrations/zapier.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+import process from "node:process";
+
 export async function callZap({ zapUrl, payload = {} }) {
   const token = process.env.ZAPIER_AUTH_TOKEN;
   if (!token) {

--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -12,9 +12,8 @@ import {
   updateDoc,
   doc,
 } from "firebase/firestore";
-import { auth, db, functions, appCheck } from "../firebase";
+import { auth, db, functions } from "../firebase";
 import { httpsCallable } from "firebase/functions";
-import { getToken as getAppCheckToken } from "firebase/app-check";
 import ai from "../ai";
 import PropTypes from "prop-types";
 import useCanonical from "../utils/useCanonical";
@@ -223,11 +222,11 @@ ${JSON.stringify({recommendations, tasks})}
       alert("Missing email address for selected contact");
       return;
     }
+    if (emailProvider !== "gmail") {
+      alert("Sending emails is only supported for Gmail accounts.");
+      return;
+    }
     try {
-      if (appCheck) {
-        await getAppCheckToken(appCheck);
-      }
-      await auth.currentUser.getIdToken(true);
       const callable = httpsCallable(functions, "sendQuestionEmail");
       await callable({
         provider: emailProvider,

--- a/src/components/UserSettingsSlideOver.jsx
+++ b/src/components/UserSettingsSlideOver.jsx
@@ -20,14 +20,20 @@ export default function UserSettingsSlideOver({ onClose }) {
   const [uid, setUid] = useState("");
   const [avatarUrl, setAvatarUrl] = useState("https://placehold.co/80x80/764ba2/FFFFFF?text=ID");
   const [gmailConnected, setGmailConnected] = useState(false);
-  const [outlookConnected, setOutlookConnected] = useState(false);
-  const [smtpConnected, setSmtpConnected] = useState(false);
-  const [outlookUser, setOutlookUser] = useState("");
-  const [outlookPass, setOutlookPass] = useState("");
-  const [smtpHost, setSmtpHost] = useState("");
-  const [smtpPort, setSmtpPort] = useState("");
-  const [smtpUser, setSmtpUser] = useState("");
-  const [smtpPass, setSmtpPass] = useState("");
+  const [imapConnected, setImapConnected] = useState(false);
+  const [popConnected, setPopConnected] = useState(false);
+  const [imapHost, setImapHost] = useState("");
+  const [imapPort, setImapPort] = useState("");
+  const [imapSmtpHost, setImapSmtpHost] = useState("");
+  const [imapSmtpPort, setImapSmtpPort] = useState("");
+  const [imapUser, setImapUser] = useState("");
+  const [imapPass, setImapPass] = useState("");
+  const [popHost, setPopHost] = useState("");
+  const [popPort, setPopPort] = useState("");
+  const [popSmtpHost, setPopSmtpHost] = useState("");
+  const [popSmtpPort, setPopSmtpPort] = useState("");
+  const [popUser, setPopUser] = useState("");
+  const [popPass, setPopPass] = useState("");
   const fileInput = useRef(null);
 
   useEffect(() => {
@@ -37,16 +43,30 @@ export default function UserSettingsSlideOver({ onClose }) {
         setAvatarUrl(user.photoURL || avatarUrl);
         const gmailSnap = await getDoc(doc(db, "users", user.uid, "emailTokens", "gmail"));
         setGmailConnected(gmailSnap.exists());
-        const outlookSnap = await getDoc(
-          doc(db, "users", user.uid, "emailTokens", "outlook"),
+        const imapSnap = await getDoc(
+          doc(db, "users", user.uid, "emailTokens", "imap"),
         );
-        if (outlookSnap.exists()) {
-          const data = outlookSnap.data();
-          setOutlookConnected(true);
-          setOutlookUser(data.user || "");
+        if (imapSnap.exists()) {
+          const data = imapSnap.data();
+          setImapConnected(true);
+          setImapHost(data.host || "");
+          setImapPort(String(data.port || ""));
+          setImapSmtpHost(data.smtpHost || "");
+          setImapSmtpPort(String(data.smtpPort || ""));
+          setImapUser(data.user || "");
         }
-        const smtpSnap = await getDoc(doc(db, "users", user.uid, "emailTokens", "smtp"));
-        setSmtpConnected(smtpSnap.exists());
+        const popSnap = await getDoc(
+          doc(db, "users", user.uid, "emailTokens", "pop3"),
+        );
+        if (popSnap.exists()) {
+          const data = popSnap.data();
+          setPopConnected(true);
+          setPopHost(data.host || "");
+          setPopPort(String(data.port || ""));
+          setPopSmtpHost(data.smtpHost || "");
+          setPopSmtpPort(String(data.smtpPort || ""));
+          setPopUser(data.user || "");
+        }
       }
     });
     return () => unsub();
@@ -79,42 +99,61 @@ export default function UserSettingsSlideOver({ onClose }) {
     setGmailConnected(false);
   };
 
-  const saveOutlook = async () => {
-    if (!uid) return;
+  const saveCredentials = async (data) => {
     const saveFn = httpsCallable(functions, "saveEmailCredentials");
-    await saveFn({
-      provider: "outlook",
-      user: outlookUser.trim(),
-      pass: outlookPass,
+    await saveFn(data);
+  };
+
+  const saveImap = async () => {
+    if (!uid) return;
+    await saveCredentials({
+      provider: "imap",
+      host: imapHost.trim(),
+      port: imapPort,
+      smtpHost: imapSmtpHost.trim(),
+      smtpPort: imapSmtpPort,
+      user: imapUser.trim(),
+      pass: imapPass,
     });
-    setOutlookConnected(true);
+    setImapConnected(true);
   };
 
-  const disconnectOutlook = async () => {
+  const disconnectImap = async () => {
     if (!uid) return;
-    await deleteDoc(doc(db, "users", uid, "emailTokens", "outlook"));
-    setOutlookConnected(false);
-    setOutlookUser("");
-    setOutlookPass("");
+    await deleteDoc(doc(db, "users", uid, "emailTokens", "imap"));
+    setImapConnected(false);
+    setImapHost("");
+    setImapPort("");
+    setImapSmtpHost("");
+    setImapSmtpPort("");
+    setImapUser("");
+    setImapPass("");
   };
 
-  const saveSmtp = async () => {
+  const savePop = async () => {
     if (!uid) return;
-    const saveFn = httpsCallable(functions, "saveEmailCredentials");
-    await saveFn({
-      provider: "smtp",
-      host: smtpHost.trim(),
-      port: smtpPort,
-      user: smtpUser.trim(),
-      pass: smtpPass,
+    await saveCredentials({
+      provider: "pop3",
+      host: popHost.trim(),
+      port: popPort,
+      smtpHost: popSmtpHost.trim(),
+      smtpPort: popSmtpPort,
+      user: popUser.trim(),
+      pass: popPass,
     });
-    setSmtpConnected(true);
+    setPopConnected(true);
   };
 
-  const disconnectSmtp = async () => {
+  const disconnectPop = async () => {
     if (!uid) return;
-    await deleteDoc(doc(db, "users", uid, "emailTokens", "smtp"));
-    setSmtpConnected(false);
+    await deleteDoc(doc(db, "users", uid, "emailTokens", "pop3"));
+    setPopConnected(false);
+    setPopHost("");
+    setPopPort("");
+    setPopSmtpHost("");
+    setPopSmtpPort("");
+    setPopUser("");
+    setPopPass("");
   };
 
   return createPortal(
@@ -144,66 +183,108 @@ export default function UserSettingsSlideOver({ onClose }) {
           ) : (
             <button onClick={connectGmail}>Connect Gmail</button>
           )}
-          {outlookConnected ? (
+          {imapConnected ? (
             <div>
-              <p>Outlook account connected.</p>
-              <button onClick={disconnectOutlook}>Disconnect Outlook</button>
+              <p>IMAP account connected.</p>
+              <button onClick={disconnectImap}>Disconnect IMAP</button>
             </div>
           ) : (
             <div className="settings-section">
               <input
                 className="generator-input"
                 type="text"
-                placeholder="Outlook Username"
-                value={outlookUser}
-                onChange={(e) => setOutlookUser(e.target.value)}
+                placeholder="IMAP Host"
+                value={imapHost}
+                onChange={(e) => setImapHost(e.target.value)}
               />
               <input
                 className="generator-input"
-                type="password"
-                placeholder="Outlook Password"
-                value={outlookPass}
-                onChange={(e) => setOutlookPass(e.target.value)}
+                type="text"
+                placeholder="IMAP Port"
+                value={imapPort}
+                onChange={(e) => setImapPort(e.target.value)}
               />
-              <button onClick={saveOutlook}>Save Outlook</button>
-            </div>
-          )}
-          {smtpConnected ? (
-            <div>
-              <p>SMTP credentials saved.</p>
-              <button onClick={disconnectSmtp}>Remove SMTP</button>
-            </div>
-          ) : (
-            <div className="settings-section">
               <input
                 className="generator-input"
                 type="text"
                 placeholder="SMTP Host"
-                value={smtpHost}
-                onChange={(e) => setSmtpHost(e.target.value)}
+                value={imapSmtpHost}
+                onChange={(e) => setImapSmtpHost(e.target.value)}
               />
               <input
                 className="generator-input"
                 type="text"
                 placeholder="SMTP Port"
-                value={smtpPort}
-                onChange={(e) => setSmtpPort(e.target.value)}
+                value={imapSmtpPort}
+                onChange={(e) => setImapSmtpPort(e.target.value)}
               />
               <input
                 className="generator-input"
                 type="text"
-                placeholder="SMTP Username"
-                value={smtpUser}
-                onChange={(e) => setSmtpUser(e.target.value)}
+                placeholder="IMAP Username"
+                value={imapUser}
+                onChange={(e) => setImapUser(e.target.value)}
               />
               <input
                 className="generator-input"
                 type="password"
-                placeholder="SMTP Password"
-                value={smtpPass}
-                onChange={(e) => setSmtpPass(e.target.value)}
+                placeholder="IMAP Password"
+                value={imapPass}
+                onChange={(e) => setImapPass(e.target.value)}
               />
-              <button onClick={saveSmtp}>Save SMTP</button>
+              <button onClick={saveImap}>Save IMAP</button>
+            </div>
+          )}
+          {popConnected ? (
+            <div>
+              <p>POP3 account connected.</p>
+              <button onClick={disconnectPop}>Disconnect POP3</button>
+            </div>
+          ) : (
+            <div className="settings-section">
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="POP3 Host"
+                value={popHost}
+                onChange={(e) => setPopHost(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="POP3 Port"
+                value={popPort}
+                onChange={(e) => setPopPort(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="SMTP Host"
+                value={popSmtpHost}
+                onChange={(e) => setPopSmtpHost(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="SMTP Port"
+                value={popSmtpPort}
+                onChange={(e) => setPopSmtpPort(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="text"
+                placeholder="POP3 Username"
+                value={popUser}
+                onChange={(e) => setPopUser(e.target.value)}
+              />
+              <input
+                className="generator-input"
+                type="password"
+                placeholder="POP3 Password"
+                value={popPass}
+                onChange={(e) => setPopPass(e.target.value)}
+              />
+              <button onClick={savePop}>Save POP3</button>
             </div>
           )}
         </section>

--- a/src/mcp/__tests__/client.test.js
+++ b/src/mcp/__tests__/client.test.js
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import { Buffer } from 'node:buffer';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import * as client from '../client.js';

--- a/src/mcp/client.js
+++ b/src/mcp/client.js
@@ -6,8 +6,6 @@ import { MCP_SERVER_URL, MCP_HEADERS } from "./config.js";
 // Keep one live client per server URL
 const clients = new Map(); // Map<string, { client, transport, initialized }>
 
-const PROTOCOL_VERSION = "2025-03-26";
-
 /** Build a transport with optional auth headers (API key or Bearer). */
 function makeTransport(serverUrl, extraHeaders = MCP_HEADERS) {
   const headers = {
@@ -36,7 +34,7 @@ async function ensureClient(serverUrl = MCP_SERVER_URL, extraHeaders = MCP_HEADE
   return rec;
 }
 
-async function initializeIfNeeded(rec, timeoutMs = 15000) {
+async function initializeIfNeeded(rec) {
   if (rec.initialized) return;
   rec.initialized = true;
 }

--- a/src/pages/ZapierConfig.jsx
+++ b/src/pages/ZapierConfig.jsx
@@ -15,7 +15,7 @@ const ZapierConfig = () => {
     let data = {};
     try {
       data = payload.trim() ? JSON.parse(payload) : {};
-    } catch (e) {
+    } catch {
       setError("Invalid JSON payload");
       setLoading(false);
       return;


### PR DESCRIPTION
## Summary
- store IMAP or POP3 credentials instead of SMTP
- allow users to manage IMAP/POP3 accounts in settings
- limit email sending to Gmail accounts
- support separate SMTP host/port for IMAP and POP3 accounts
- invoke Firebase functions with httpsCallable to include App Check headers automatically

## Testing
- `npm run lint` (0 errors, 8 warnings)
- `npm test` (fails: logisticConfidence and MCP client tests)


------
https://chatgpt.com/codex/tasks/task_e_68b1d0026b94832b8217c4eb5ef6d8da