### PR TITLE
Avoid App Check CORS failure when saving IMAP credentials

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -201,7 +201,7 @@ async function getStoredProviderToken(uid, provider, keyHex) {
 export const saveEmailCredentials = onCall(
   {
     region: "us-central1",
-    enforceAppCheck: true,
+    // App Check not enforced here to prevent CORS errors when tokens are missing
     secrets: [TOKEN_ENCRYPTION_KEY],
   },
   async (request) => {


### PR DESCRIPTION
## Summary
- Remove App Check enforcement from saveEmailCredentials callable to prevent CORS error when App Check tokens are missing

## Testing
- `npm test` *(fails: auth/invalid-api-key, fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b236cf8e48832b91410c57ef92d663