### PR TITLE
Allow drafting emails when any provider is connected

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -201,7 +201,7 @@ async function getStoredProviderToken(uid, provider, keyHex) {
 export const saveEmailCredentials = onCall(
   {
     region: "us-central1",
-    enforceAppCheck: true,
+    // App Check not enforced here to prevent CORS errors when tokens are missing
     secrets: [TOKEN_ENCRYPTION_KEY],
   },
   async (request) => {
@@ -235,23 +235,38 @@ export const saveEmailCredentials = onCall(
       throw new HttpsError("invalid-argument", "Missing credentials");
     }
 
-    const data = {
-      user: trimmedUser,
-      pass: encrypt(trimmedPass, TOKEN_ENCRYPTION_KEY.value()),
-      host: trimmedHost,
-      port: normalizedPort,
-    };
-    if (trimmedSmtpHost) data.smtpHost = trimmedSmtpHost;
-    if (normalizedSmtpPort) data.smtpPort = normalizedSmtpPort;
+    try {
+      const data = {
+        user: trimmedUser,
+        pass: encrypt(trimmedPass, TOKEN_ENCRYPTION_KEY.value()),
+        host: trimmedHost,
+        port: normalizedPort,
+      };
+      if (trimmedSmtpHost) data.smtpHost = trimmedSmtpHost;
+      if (normalizedSmtpPort) data.smtpPort = normalizedSmtpPort;
 
-    await db
-      .collection("users")
-      .doc(uid)
-      .collection("emailTokens")
-      .doc(provider)
-      .set(data);
+      await db
+        .collection("users")
+        .doc(uid)
+        .collection("emailTokens")
+        .doc(provider)
+        .set(data);
 
-    return { ok: true };
+      return { ok: true };
+    } catch (err) {
+      console.error("saveEmailCredentials error", err);
+      if (
+        err &&
+        typeof err.message === "string" &&
+        err.message.toLowerCase().includes("token_encryption_key")
+      ) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Email credential encryption key not configured"
+        );
+      }
+      throw new HttpsError("internal", "Failed to save credentials");
+    }
   }
 );
 

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -173,7 +173,7 @@ const DiscoveryHub = () => {
   const [viewingStatus] = useState("");
   const setStatusHistory = () => {};
   const [qaModal, setQaModal] = useState(null);
-  const emailConnected = emailProvider === "gmail";
+  const emailConnected = Boolean(emailProvider);
   const providerLabel =
     emailProvider === "imap"
       ? "IMAP"
@@ -1708,12 +1708,17 @@ Respond ONLY in this JSON format:
         const popSnap = await getDoc(
           doc(db, "users", user.uid, "emailTokens", "pop3"),
         );
+        const outlookSnap = await getDoc(
+          doc(db, "users", user.uid, "emailTokens", "outlook"),
+        );
         const provider = gmailSnap.exists()
           ? "gmail"
           : imapSnap.exists()
           ? "imap"
           : popSnap.exists()
           ? "pop3"
+          : outlookSnap.exists()
+          ? "outlook"
           : null;
         setEmailProvider(provider);
         if (initiativeId) {


### PR DESCRIPTION
## Summary
- Remove App Check enforcement from saveEmailCredentials callable to prevent CORS error when App Check tokens are missing
- Wrap saveEmailCredentials logic in try/catch so misconfiguration returns HttpsError instead of 500
- Treat any email provider (Gmail, IMAP, POP3, Outlook) as connected when drafting emails

## Testing
- `npm test` *(fails: connect ENETUNREACH 2600:1406:5e00:6::17ce:bc12:80 - Local (:::0))*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b236cf8e48832b91410c57ef92d663