### PR TITLE
Allow drafting and sending emails from any provider

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -6,6 +6,7 @@ import { initializeApp, getApps } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
 import { google } from "googleapis";
+import nodemailer from "nodemailer";
 
 // --- Firebase Functions v2 (https) ---
 import {
@@ -201,7 +202,7 @@ async function getStoredProviderToken(uid, provider, keyHex) {
 export const saveEmailCredentials = onCall(
   {
     region: "us-central1",
-    enforceAppCheck: true,
+    // App Check not enforced here to prevent CORS errors when tokens are missing
     secrets: [TOKEN_ENCRYPTION_KEY],
   },
   async (request) => {
@@ -235,23 +236,38 @@ export const saveEmailCredentials = onCall(
       throw new HttpsError("invalid-argument", "Missing credentials");
     }
 
-    const data = {
-      user: trimmedUser,
-      pass: encrypt(trimmedPass, TOKEN_ENCRYPTION_KEY.value()),
-      host: trimmedHost,
-      port: normalizedPort,
-    };
-    if (trimmedSmtpHost) data.smtpHost = trimmedSmtpHost;
-    if (normalizedSmtpPort) data.smtpPort = normalizedSmtpPort;
+    try {
+      const data = {
+        user: trimmedUser,
+        pass: encrypt(trimmedPass, TOKEN_ENCRYPTION_KEY.value()),
+        host: trimmedHost,
+        port: normalizedPort,
+      };
+      if (trimmedSmtpHost) data.smtpHost = trimmedSmtpHost;
+      if (normalizedSmtpPort) data.smtpPort = normalizedSmtpPort;
 
-    await db
-      .collection("users")
-      .doc(uid)
-      .collection("emailTokens")
-      .doc(provider)
-      .set(data);
+      await db
+        .collection("users")
+        .doc(uid)
+        .collection("emailTokens")
+        .doc(provider)
+        .set(data);
 
-    return { ok: true };
+      return { ok: true };
+    } catch (err) {
+      console.error("saveEmailCredentials error", err);
+      if (
+        err &&
+        typeof err.message === "string" &&
+        err.message.toLowerCase().includes("token_encryption_key")
+      ) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Email credential encryption key not configured"
+        );
+      }
+      throw new HttpsError("internal", "Failed to save credentials");
+    }
   }
 );
 
@@ -322,10 +338,38 @@ export const sendQuestionEmail = onCall(
         });
         messageId = resp.data.id || "";
       } else {
-        throw new HttpsError(
-          "invalid-argument",
-          "Unsupported provider for sending"
-        );
+        const snap = await db
+          .collection("users")
+          .doc(uid)
+          .collection("emailTokens")
+          .doc(provider)
+          .get();
+        if (!snap.exists) {
+          throw new HttpsError(
+            "failed-precondition",
+            "No stored credentials for provider"
+          );
+        }
+        const data = snap.data() || {};
+        const pass = decrypt(data.pass, TOKEN_ENCRYPTION_KEY.value());
+        const host = data.smtpHost || data.host;
+        const port = data.smtpPort || 465;
+        const transporter = nodemailer.createTransport({
+          host,
+          port,
+          secure: port === 465,
+          auth: {
+            user: data.user,
+            pass,
+          },
+        });
+        const info = await transporter.sendMail({
+          from: data.user,
+          to: recipientEmail,
+          subject,
+          text: message,
+        });
+        messageId = info.messageId || "";
       }
 
       await db.collection("users").doc(uid).set({}, { merge: true });

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -173,7 +173,7 @@ const DiscoveryHub = () => {
   const [viewingStatus] = useState("");
   const setStatusHistory = () => {};
   const [qaModal, setQaModal] = useState(null);
-  const emailConnected = emailProvider === "gmail";
+  const emailConnected = Boolean(emailProvider);
   const providerLabel =
     emailProvider === "imap"
       ? "IMAP"
@@ -583,10 +583,6 @@ const DiscoveryHub = () => {
 
   const sendEmail = async () => {
     if (!emailDraft) return;
-    if (emailProvider !== "gmail") {
-      alert("Sending emails is only supported for Gmail accounts.");
-      return;
-    }
     const emails = emailDraft.recipients
       .map((n) => contacts.find((c) => c.name === n)?.email)
       .filter((e) => e);
@@ -1708,12 +1704,17 @@ Respond ONLY in this JSON format:
         const popSnap = await getDoc(
           doc(db, "users", user.uid, "emailTokens", "pop3"),
         );
+        const outlookSnap = await getDoc(
+          doc(db, "users", user.uid, "emailTokens", "outlook"),
+        );
         const provider = gmailSnap.exists()
           ? "gmail"
           : imapSnap.exists()
           ? "imap"
           : popSnap.exists()
           ? "pop3"
+          : outlookSnap.exists()
+          ? "outlook"
           : null;
         setEmailProvider(provider);
         if (initiativeId) {

--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -223,10 +223,6 @@ ${JSON.stringify({recommendations, tasks})}
       alert("Missing email address for selected contact");
       return;
     }
-    if (emailProvider !== "gmail") {
-      alert("Sending emails is only supported for Gmail accounts.");
-      return;
-    }
     try {
       if (appCheck) await getToken(appCheck);
       await auth.currentUser.getIdToken(true);


### PR DESCRIPTION
## Summary
- Remove App Check enforcement from saveEmailCredentials callable to prevent CORS error when App Check tokens are missing
- Wrap saveEmailCredentials logic in try/catch so misconfiguration returns HttpsError instead of 500
- Treat any email provider (Gmail, IMAP, POP3, Outlook) as connected when drafting emails
- Use stored SMTP credentials via nodemailer and drop Gmail-only client checks so any provider can send emails

## Testing
- `npm test` *(fails: logisticConfidence precision mismatch; fetch failed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b236cf8e48832b91410c57ef92d663