### PR TITLE
Allow drafting and sending emails from any provider

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -173,7 +173,7 @@ const DiscoveryHub = () => {
   const [viewingStatus] = useState("");
   const setStatusHistory = () => {};
   const [qaModal, setQaModal] = useState(null);
-  const emailConnected = emailProvider === "gmail";
+  const emailConnected = Boolean(emailProvider);
   const providerLabel =
     emailProvider === "imap"
       ? "IMAP"
@@ -583,10 +583,6 @@ const DiscoveryHub = () => {
 
   const sendEmail = async () => {
     if (!emailDraft) return;
-    if (emailProvider !== "gmail") {
-      alert("Sending emails is only supported for Gmail accounts.");
-      return;
-    }
     const emails = emailDraft.recipients
       .map((n) => contacts.find((c) => c.name === n)?.email)
       .filter((e) => e);
@@ -1708,12 +1704,17 @@ Respond ONLY in this JSON format:
         const popSnap = await getDoc(
           doc(db, "users", user.uid, "emailTokens", "pop3"),
         );
+        const outlookSnap = await getDoc(
+          doc(db, "users", user.uid, "emailTokens", "outlook"),
+        );
         const provider = gmailSnap.exists()
           ? "gmail"
           : imapSnap.exists()
           ? "imap"
           : popSnap.exists()
           ? "pop3"
+          : outlookSnap.exists()
+          ? "outlook"
           : null;
         setEmailProvider(provider);
         if (initiativeId) {

--- a/src/components/ProjectStatus.jsx
+++ b/src/components/ProjectStatus.jsx
@@ -223,10 +223,6 @@ ${JSON.stringify({recommendations, tasks})}
       alert("Missing email address for selected contact");
       return;
     }
-    if (emailProvider !== "gmail") {
-      alert("Sending emails is only supported for Gmail accounts.");
-      return;
-    }
     try {
       if (appCheck) await getToken(appCheck);
       await auth.currentUser.getIdToken(true);


### PR DESCRIPTION
## Summary
- Normalize provider string and support IMAP/POP3/Outlook SMTP sending via Nodemailer
- Re-throw existing HttpsErrors so clients receive accurate failure reasons
- Remove Gmail-only restriction when sending messages

## Testing
- `npm test` *(fails: logisticConfidence precision mismatch; fetch failed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b236cf8e48832b91410c57ef92d663