### PR TITLE
feat: add notifications context and messages view

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,5 +5,11 @@ service cloud.firestore {
     match /mcp/{document=**} {
       allow read, write: if request.auth != null;
     }
+    match /users/{userId}/notifications/{notificationId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    match /users/{userId}/messages/{messageId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }

--- a/src/components/DiscoverySidebar.jsx
+++ b/src/components/DiscoverySidebar.jsx
@@ -88,6 +88,9 @@ export default function DiscoverySidebar() {
             )}
           </li>
           <li>
+            <Link to={makeUrl("/messages")}>Messages</Link>
+          </li>
+          <li>
             <Link to={makeUrl("/project-status")}>Project Status</Link>
             {statusOpen && (
               <ul>

--- a/src/components/Messages.jsx
+++ b/src/components/Messages.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { onAuthStateChanged } from "firebase/auth";
+import { collection, onSnapshot, orderBy, query } from "firebase/firestore";
+import { auth, db } from "../firebase";
+
+export default function Messages() {
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    let unsubAuth = null;
+    let unsubMsgs = null;
+
+    unsubAuth = onAuthStateChanged(auth, (user) => {
+      if (unsubMsgs) unsubMsgs();
+      if (user) {
+        const q = query(
+          collection(db, "users", user.uid, "messages"),
+          orderBy("createdAt", "desc")
+        );
+        unsubMsgs = onSnapshot(q, (snap) => {
+          const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+          setMessages(data);
+        });
+      } else {
+        setMessages([]);
+      }
+    });
+
+    return () => {
+      if (unsubAuth) unsubAuth();
+      if (unsubMsgs) unsubMsgs();
+    };
+  }, []);
+
+  return (
+    <div className="messages-page">
+      <h1>Messages</h1>
+      {messages.length === 0 ? (
+        <p>No messages</p>
+      ) : (
+        <ul>
+          {messages.map((m) => (
+            <li key={m.id} className="message-item">
+              <p><strong>{m.subject || "(no subject)"}</strong></p>
+              <p>{m.body}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { auth } from "../firebase";
 import { loadInitiatives } from "../utils/initiatives";
 import UserSettingsSlideOver from "./UserSettingsSlideOver";
+import { useNotifications } from "../context/NotificationsContext.jsx";
 
 export default function NavBar() {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -11,8 +12,15 @@ export default function NavBar() {
   const [addMenu, setAddMenu] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [projects, setProjects] = useState([]);
+  const [notifMenu, setNotifMenu] = useState(false);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { notifications, unreadCounts, markAsRead } = useNotifications();
+
+  const totalUnread = Object.values(unreadCounts).reduce(
+    (sum, c) => sum + c,
+    0
+  );
 
   const initiativeId = searchParams.get("initiativeId");
   const activeProject = projects.find((p) => p.id === initiativeId);
@@ -123,23 +131,53 @@ export default function NavBar() {
         <div className="user-actions">
           {loggedIn && (
             <>
-              <button className="notification-btn" type="button">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+              <div className="notification-menu">
+                <button
+                  className="notification-btn"
+                  type="button"
+                  onClick={() => setNotifMenu(!notifMenu)}
                 >
-                  <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-                  <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-                </svg>
-                <span className="indicator" />
-              </button>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+                    <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+                  </svg>
+                  {totalUnread > 0 && (
+                    <span className="indicator">{totalUnread}</span>
+                  )}
+                </button>
+                {notifMenu && (
+                  <ul className="dropdown">
+                    {notifications.length === 0 ? (
+                      <li>No notifications</li>
+                    ) : (
+                      notifications.map((n) => (
+                        <li key={n.id}>
+                          <a
+                            href={n.href}
+                            onClick={() => {
+                              setNotifMenu(false);
+                              markAsRead(n.id);
+                            }}
+                          >
+                            {n.message}
+                            {n.count > 1 ? ` (${n.count})` : ""}
+                          </a>
+                        </li>
+                      ))
+                    )}
+                  </ul>
+                )}
+              </div>
               <img
                 src="https://placehold.co/40x40/764ba2/FFFFFF?text=ID"
                 alt="User Avatar"

--- a/src/context/NotificationsContext.jsx
+++ b/src/context/NotificationsContext.jsx
@@ -1,0 +1,69 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { onAuthStateChanged } from "firebase/auth";
+import { collection, onSnapshot, query, orderBy, updateDoc, doc } from "firebase/firestore";
+import { auth, db } from "../firebase";
+
+const NotificationsContext = createContext();
+
+export const NotificationsProvider = ({ children }) => {
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCounts, setUnreadCounts] = useState({});
+
+  useEffect(() => {
+    let unsubAuth = null;
+    let unsubNotif = null;
+
+    unsubAuth = onAuthStateChanged(auth, (user) => {
+      if (unsubNotif) {
+        unsubNotif();
+      }
+      if (user) {
+        const q = query(
+          collection(db, "users", user.uid, "notifications"),
+          orderBy("createdAt", "desc")
+        );
+        unsubNotif = onSnapshot(q, (snap) => {
+          const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+          setNotifications(data);
+          const counts = data.reduce((acc, n) => {
+            const c = n.count || 0;
+            if (c > 0) {
+              acc[n.type] = (acc[n.type] || 0) + c;
+            }
+            return acc;
+          }, {});
+          setUnreadCounts(counts);
+        });
+      } else {
+        setNotifications([]);
+        setUnreadCounts({});
+      }
+    });
+
+    return () => {
+      if (unsubAuth) unsubAuth();
+      if (unsubNotif) unsubNotif();
+    };
+  }, []);
+
+  const markAsRead = async (id) => {
+    const user = auth.currentUser;
+    if (!user) return;
+    const ref = doc(db, "users", user.uid, "notifications", id);
+    await updateDoc(ref, { count: 0 });
+  };
+
+  const value = { notifications, unreadCounts, markAsRead };
+  return (
+    <NotificationsContext.Provider value={value}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+NotificationsProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useNotifications = () => useContext(NotificationsContext);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import App from "./App.jsx";
 import { ProjectProvider } from "./context/ProjectContext.jsx";
 import { InquiryMapProvider } from "./context/InquiryMapContext";
 import { McpProvider } from "./context/McpContext.jsx";
+import { NotificationsProvider } from "./context/NotificationsContext.jsx";
 import PropTypes from "prop-types";
 import { initAnalytics, getAnalyticsConsent } from "./utils/analytics.js";
 import { onAuthStateChanged } from "firebase/auth";
@@ -36,6 +37,7 @@ import ActionDashboard from "./components/ActionDashboard.jsx";
 import ProjectStatus from "./components/ProjectStatus.jsx";
 import ProjectStatusHistory from "./components/ProjectStatusHistory.jsx";
 import ZapierConfig from "./pages/ZapierConfig.jsx";
+import Messages from "./components/Messages.jsx";
 
 window.PropTypes = PropTypes;
 
@@ -118,6 +120,10 @@ function Root() {
             element={user ? <InquiryMapPage /> : <Navigate to="/login" />}
           />
           <Route
+            path="/messages"
+            element={user ? <Messages /> : <Navigate to="/login" />}
+          />
+          <Route
             path="/action-dashboard"
             element={user ? <ActionDashboard /> : <Navigate to="/login" />}
           />
@@ -165,7 +171,9 @@ createRoot(document.getElementById("root")).render(
     <McpProvider>
       <ProjectProvider>
         <InquiryMapProvider>
-          <Root />
+          <NotificationsProvider>
+            <Root />
+          </NotificationsProvider>
         </InquiryMapProvider>
       </ProjectProvider>
     </McpProvider>


### PR DESCRIPTION
## Summary
- add NotificationsContext to monitor user notification collection
- show grouped notifications dropdown in NavBar
- add messages archive page and sidebar link
- update Firestore security rules for user notifications and messages

## Testing
- `npm test` *(fails: Firebase auth/invalid-api-key, network errors)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b24e45d0d4832b9d04ab6752afa0dd