### PR TITLE
Allow CORS for sendQuestionEmail

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -279,6 +279,8 @@ export const sendQuestionEmail = onCall(
     region: "us-central1",
     enforceAppCheck: true,
     invoker: "public",
+    // Allow requests from production web app to bypass CORS preflight
+    cors: ["https://thoughtify.training"],
     secrets: [
       TOKEN_ENCRYPTION_KEY,
       GMAIL_CLIENT_ID,


### PR DESCRIPTION
## Summary
- allow requests from https://thoughtify.training to hit sendQuestionEmail without CORS preflight errors

## Testing
- `npm test` *(fails: expected 0.99998 to be close to 1; fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b269baaa78832bbded7dd17e765255