### PR TITLE
fix: accept URL-safe UIDs in reply handler

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -493,7 +493,7 @@ export const processInboundEmail = onRequest(
       return;
     }
 
-    const match = to.match(/QID(\d+)_UID([A-Za-z0-9]+)_SIG([a-f0-9]{16})/i);
+    const match = to.match(/QID(\d+)_UID([A-Za-z0-9_-]+)_SIG([a-f0-9]{16})/i);
     if (!match) {
       res.status(400).send({ status: "error", message: "Invalid reply" });
       return;


### PR DESCRIPTION
## Summary
- broaden inbound email UID regex to include URL-safe Base64 characters

## Testing
- `npm test` *(fails: expected 0.999983298299212 to be close to 1; fetch failed; Firebase Error auth/invalid-api-key)*
- `npm run lint` *(fails: 5 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3161aad5c832bb311d03f9622aefd