### PR TITLE
feat: handle postmark inbound replies

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1837,6 +1837,7 @@ export {
   getEmailAuthUrl,
   emailOAuthCallback,
   sendQuestionEmail,
+  processInboundEmail,
   saveEmailCredentials,
 } from "./emailProviders.js";
 export { mcpServer } from "./mcpServer.js";


### PR DESCRIPTION
## Summary
- support Postmark inbound webhook by parsing `MailboxHash`, `ToFull`, and `StrippedTextReply`
- validate signed reply address, store answer, and forward reply to the user
- allow Postmark verification requests via non-POST methods to succeed

## Testing
- `npm test` (fails: expected 0.999983298299212 to be close to 1)
- `npm run lint` (fails: ✖ 14 problems (5 errors, 9 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68b27bf13730832b9ffbbdbefffabfc0