### PR TITLE
Process inbound answers

### DIFF
--- a/functions/mcpSchemas.js
+++ b/functions/mcpSchemas.js
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
 const contactSchema = z.object({
+  id: z.string().optional(),
   name: z.string(),
   role: z.string(),
+  email: z.string().email().optional(),
 });
 
 const toolSchemas = {


### PR DESCRIPTION
## Summary
- Normalize inbound sender email to match contacts reliably
- Capture contact id when mapping replies and log it with questions and messages
- Allow contacts to include optional id and email fields in schema

## Testing
- `npm test` *(fails: fetch failed, invalid API key)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4660f3a5c832bb0a4ee4e3ef0d300