### PR TITLE
feat: support extended initiative schema

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -686,7 +686,7 @@ export const processInboundEmail = onRequest(
           plugins: [googleAI({ apiKey: key })],
           model: gemini("gemini-1.5-pro"),
         });
-        const extractPrompt = `You are reading an email reply and must separate the direct answer to the question from any additional commentary. Respond only in JSON with keys \"answer\" and \"extra\".\n\nEmail Reply:\n${cleaned}`;
+        const extractPrompt = `You are reading an email reply and must separate the direct answer to the question from any additional commentary. Respond only in JSON with keys "answer" and "extra".\n\nEmail Reply:\n${cleaned}`;
         const { text: extractText } = await extractor.generate(extractPrompt);
         const parsed = JSON.parse(extractText.match(/\{[\s\S]*\}/)?.[0] || "{}");
         if (parsed.answer) answerText = String(parsed.answer).trim();

--- a/scripts/migrateInitiatives.js
+++ b/scripts/migrateInitiatives.js
@@ -1,0 +1,56 @@
+/* eslint-env node */
+/* global process */
+import admin from "firebase-admin";
+
+admin.initializeApp();
+const db = admin.firestore();
+const { FieldValue } = admin.firestore;
+
+async function migrateInitiatives() {
+  const usersSnap = await db.collection("users").get();
+  for (const user of usersSnap.docs) {
+    const initSnap = await user.ref.collection("initiatives").get();
+    for (const docSnap of initSnap.docs) {
+      const data = docSnap.data();
+
+      const projectQuestions = (data.clarifyingQuestions || []).map((q, idx) => ({
+        ...(typeof q === "object" ? q : { question: q }),
+        answer: data.clarifyingAnswers ? data.clarifyingAnswers[idx] : undefined,
+        asked: data.clarifyingAsked ? data.clarifyingAsked[idx] : undefined,
+        contacts: data.clarifyingContacts
+          ? data.clarifyingContacts[idx]
+          : undefined,
+      }));
+
+      const contacts = data.contacts || data.keyContacts || [];
+
+      const update = {
+        audienceProfile: data.audienceProfile || "",
+        brief: data.brief || data.projectBrief || "",
+        businessGoal: data.businessGoal || "",
+        contacts,
+        inquiryMap: data.inquiryMap || (data.hypotheses ? { hypotheses: data.hypotheses } : {}),
+        projectQuestions,
+        sourceMaterials: data.sourceMaterials || [],
+        updatedAt: FieldValue.serverTimestamp(),
+      };
+
+      await docSnap.ref.set(update, { merge: true });
+      await docSnap.ref.update({
+        clarifyingQuestions: FieldValue.delete(),
+        clarifyingAnswers: FieldValue.delete(),
+        clarifyingAsked: FieldValue.delete(),
+        clarifyingContacts: FieldValue.delete(),
+        keyContacts: FieldValue.delete(),
+        projectBrief: FieldValue.delete(),
+        hypotheses: FieldValue.delete(),
+      });
+    }
+  }
+  console.log("Initiative migration complete");
+}
+
+migrateInitiatives().catch((err) => {
+  console.error("Migration failed", err);
+  process.exit(1);
+});

--- a/src/utils/initiatives.js
+++ b/src/utils/initiatives.js
@@ -10,21 +10,60 @@ import {
   writeBatch,
 } from "firebase/firestore";
 
+// Ensure initiatives always expose the latest schema fields
+const DEFAULT_FIELDS = {
+  audienceProfile: "",
+  brief: "",
+  businessGoal: "",
+  contacts: [],
+  inquiryMap: {},
+  projectQuestions: [],
+  sourceMaterials: [],
+};
+
+function normalizeInitiative(docSnap) {
+  return { id: docSnap.id, ...DEFAULT_FIELDS, ...docSnap.data() };
+}
+
+function deepMerge(target = {}, source = {}) {
+  const output = { ...target };
+  for (const key of Object.keys(source)) {
+    const srcVal = source[key];
+    const tgtVal = target[key];
+    if (
+      srcVal &&
+      typeof srcVal === "object" &&
+      !Array.isArray(srcVal) &&
+      tgtVal &&
+      typeof tgtVal === "object" &&
+      !Array.isArray(tgtVal)
+    ) {
+      output[key] = deepMerge(tgtVal, srcVal);
+    } else {
+      output[key] = srcVal;
+    }
+  }
+  return output;
+}
+
 export async function loadInitiatives(uid) {
   const initiativesRef = collection(db, "users", uid, "initiatives");
   const snap = await getDocs(initiativesRef);
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  return snap.docs.map(normalizeInitiative);
 }
 
 export async function loadInitiative(uid, initiativeId) {
   const ref = doc(db, "users", uid, "initiatives", initiativeId);
   const snap = await getDoc(ref);
-  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+  return snap.exists() ? normalizeInitiative(snap) : null;
 }
 
 export async function saveInitiative(uid, initiativeId, data) {
   const ref = doc(db, "users", uid, "initiatives", initiativeId);
-  await setDoc(ref, { ...data, updatedAt: serverTimestamp() }, { merge: true });
+  const snap = await getDoc(ref);
+  const existing = snap.exists() ? snap.data() : {};
+  const merged = deepMerge(existing, data);
+  await setDoc(ref, { ...merged, updatedAt: serverTimestamp() }, { merge: true });
   return initiativeId;
 }
 


### PR DESCRIPTION
## Summary
- normalize initiative loading with default fields
- deep-merge initiative updates and keep timestamps current
- add migration script to reshape legacy initiative data

## Testing
- `npm test` *(fails: expected 0.999983298299212 to be close to 1)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4fc92d214832b952f9504024a64a9