### PR TITLE
Improve email question tracking

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -476,10 +476,13 @@ export const sendQuestionEmail = onCall(
           matched.forEach((contact) => {
             if (!contact.id) return;
             askedEntry[contact.id] = true;
+            const existing = ansEntry[contact.id] || {};
             ansEntry[contact.id] = {
-              ...(ansEntry[contact.id] || {}),
+              ...existing,
               askedAt: now,
               askedBy: asker,
+              currentStatus: "asked",
+              history: Array.isArray(existing.history) ? existing.history : [],
             };
           });
           q.asked = askedEntry;
@@ -736,12 +739,18 @@ export const processInboundEmail = onRequest(
 
         const answersEntry = q.answers || {};
         const existingForId = answersEntry[contactId] || {};
+        const history = Array.isArray(existingForId.history)
+          ? existingForId.history.slice()
+          : [];
+        history.push({ text: answerText, answeredAt, answeredBy: name });
         answersEntry[contactId] = {
           ...existingForId,
           text: answerText,
           answeredAt,
           answeredBy: name,
           contactId,
+          currentStatus: "answered",
+          history,
         };
         askedEntry[contactId] = true;
         q.answers = answersEntry;


### PR DESCRIPTION
## Summary
- Track question ask/answer state per contact using `projectQuestions`
- Record asked and answered timestamps and current status for each contact
- Preserve multiple responses by appending to contact answer history

## Testing
- `npm test` *(fails: logisticConfidence precision, fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51f7adb18832bb22d97d6a902928a