### PR TITLE
Include key contact suggestions in generated questions

### DIFF
--- a/functions/mcpSchemas.js
+++ b/functions/mcpSchemas.js
@@ -16,6 +16,17 @@ export const projectQuestionSchema = z.object({
   answer: z.string().optional(),
   asked: z.record(z.boolean()).optional(),
   contacts: z.array(z.string()).optional(),
+  contactStatus: z
+    .record(
+      z.object({
+        current: z.string(),
+        history: z
+          .array(z.object({ status: z.string(), timestamp: z.string() }))
+          .optional(),
+        answers: z.array(z.any()).optional(),
+      }),
+    )
+    .optional(),
 });
 
 export const projectQuestionsSchema = z.array(projectQuestionSchema);


### PR DESCRIPTION
## Summary
- Generate project questions with recommended contacts based on key contacts
- Map contact names to IDs and initialize contact status as "Ask"
- Expand schema to support persisted contact status metadata

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5326a7c60832bafdd5d6fc40543e6