### PR TITLE
Handle blank optional text fields

### DIFF
--- a/functions/mcpSchemas.js
+++ b/functions/mcpSchemas.js
@@ -1,27 +1,35 @@
 import { z } from "zod";
 
+const optionalText = z.string().transform((s) => s.trim() || undefined);
+const nonEmptyText = z
+  .string()
+  .transform((s) => s.trim())
+  .pipe(z.string().min(1));
+
 export const contactSchema = z.object({
   id: z.string().optional(),
-  name: z.string(),
-  role: z.string(),
+  name: nonEmptyText,
+  role: nonEmptyText,
   email: z.string().email().optional(),
 });
 
 export const contactsSchema = z.array(contactSchema);
 
 export const projectQuestionSchema = z.object({
-  question: z.string(),
+  question: nonEmptyText,
   stakeholders: z.array(z.string()).optional(),
-  phase: z.string().optional(),
-  answer: z.string().optional(),
+  phase: optionalText.optional(),
+  answer: optionalText.optional(),
   asked: z.record(z.boolean()).optional(),
   contacts: z.array(z.string()).optional(),
   contactStatus: z
     .record(
       z.object({
-        current: z.string(),
+        current: nonEmptyText,
         history: z
-          .array(z.object({ status: z.string(), timestamp: z.string() }))
+          .array(
+            z.object({ status: nonEmptyText, timestamp: nonEmptyText })
+          )
           .optional(),
         answers: z.array(z.any()).optional(),
       }),
@@ -32,15 +40,15 @@ export const projectQuestionSchema = z.object({
 export const projectQuestionsSchema = z.array(projectQuestionSchema);
 
 export const sourceMaterialSchema = z.object({
-  name: z.string(),
-  content: z.string(),
+  name: nonEmptyText,
+  content: nonEmptyText,
 });
 
 export const sourceMaterialsSchema = z.array(sourceMaterialSchema);
 
-export const audienceProfileSchema = z.string().min(1);
-export const briefSchema = z.string().min(1);
-export const businessGoalSchema = z.string().min(1);
+export const audienceProfileSchema = optionalText;
+export const briefSchema = nonEmptyText;
+export const businessGoalSchema = nonEmptyText;
 
 /**
  * Utility types derived from schemas
@@ -53,129 +61,129 @@ export const businessGoalSchema = z.string().min(1);
  */
 
 const toolSchemas = {
-  generateTrainingPlan: z.object({ prompt: z.string() }),
-  generateStudyMaterial: z.object({ topic: z.string() }),
-  generateCourseOutline: z.object({ topic: z.string() }),
-  generateAssessment: z.object({ topic: z.string() }),
-  generateLessonContent: z.object({ topic: z.string() }),
+  generateTrainingPlan: z.object({ prompt: nonEmptyText }),
+  generateStudyMaterial: z.object({ topic: nonEmptyText }),
+  generateCourseOutline: z.object({ topic: nonEmptyText }),
+  generateAssessment: z.object({ topic: nonEmptyText }),
+  generateLessonContent: z.object({ topic: nonEmptyText }),
   generateProjectQuestions: z.object({
     businessGoal: businessGoalSchema,
     audienceProfile: audienceProfileSchema.optional(),
-    sourceMaterial: z.string().optional(),
-    projectConstraints: z.string().optional(),
+    sourceMaterial: optionalText.optional(),
+    projectConstraints: optionalText.optional(),
     keyContacts: contactsSchema.optional(),
   }),
   generateProjectBrief: z.object({
     businessGoal: businessGoalSchema,
     audienceProfile: audienceProfileSchema.optional(),
-    sourceMaterial: z.string().optional(),
-    projectConstraints: z.string().optional(),
+    sourceMaterial: optionalText.optional(),
+    projectConstraints: optionalText.optional(),
     keyContacts: contactsSchema.optional(),
     projectQuestions: projectQuestionsSchema.optional(),
   }),
   generateStatusUpdate: z.object({
-    audience: z.string().optional(),
-    today: z.string().optional(),
-    previousUpdateSummary: z.string().optional(),
-    newStakeholderAnswers: z.string().optional(),
-    newDocuments: z.string().optional(),
-    projectBaseline: z.string().optional(),
-    allOutstandingTasks: z.string().optional(),
+    audience: optionalText.optional(),
+    today: optionalText.optional(),
+    previousUpdateSummary: optionalText.optional(),
+    newStakeholderAnswers: optionalText.optional(),
+    newDocuments: optionalText.optional(),
+    projectBaseline: optionalText.optional(),
+    allOutstandingTasks: optionalText.optional(),
   }),
   generateLearningStrategy: z.object({
     projectBrief: briefSchema,
-    businessGoal: businessGoalSchema.optional(),
+    businessGoal: optionalText.optional(),
     audienceProfile: audienceProfileSchema.optional(),
-    projectConstraints: z.string().optional(),
+    projectConstraints: optionalText.optional(),
     keyContacts: contactsSchema.optional(),
-    sourceMaterial: z.string().optional(),
+    sourceMaterial: optionalText.optional(),
     projectQuestions: projectQuestionsSchema.optional(),
     personaCount: z.number().optional(),
   }),
   generateContentAssets: z.object({
     ldd: z.any(),
-    component: z.string().optional(),
+    component: optionalText.optional(),
     components: z.array(z.string()).optional(),
-    jobId: z.string().optional(),
+    jobId: optionalText.optional(),
   }),
   generateLearnerPersona: z.object({
     projectBrief: briefSchema,
-    businessGoal: businessGoalSchema.optional(),
+    businessGoal: optionalText.optional(),
     audienceProfile: audienceProfileSchema.optional(),
-    projectConstraints: z.string().optional(),
+    projectConstraints: optionalText.optional(),
     keyContacts: contactsSchema.optional(),
-    sourceMaterial: z.string().optional(),
+    sourceMaterial: optionalText.optional(),
     existingMotivationKeywords: z.array(z.string()).optional(),
     existingChallengeKeywords: z.array(z.string()).optional(),
     existingLearningPreferenceKeywords: z.array(z.string()).optional(),
-    refreshField: z.string().optional(),
-    personaType: z.string().optional(),
+    refreshField: optionalText.optional(),
+    personaType: optionalText.optional(),
     existingTypes: z.array(z.string()).optional(),
     selectedTraits: z.array(z.string()).optional(),
   }),
   generateHierarchicalOutline: z.object({
     projectBrief: briefSchema,
     learningObjectives: z.any(),
-    businessGoal: businessGoalSchema.optional(),
+    businessGoal: optionalText.optional(),
     audienceProfile: audienceProfileSchema.optional(),
-    projectConstraints: z.string().optional(),
-    selectedModality: z.string().optional(),
+    projectConstraints: optionalText.optional(),
+    selectedModality: optionalText.optional(),
     blendModalities: z.array(z.string()).optional(),
-    sourceMaterial: z.string().optional(),
+    sourceMaterial: optionalText.optional(),
     keyContacts: contactsSchema.optional(),
   }),
   generateLearningDesignDocument: z.object({
     projectBrief: briefSchema,
-    businessGoal: businessGoalSchema.optional(),
+    businessGoal: optionalText.optional(),
     audienceProfile: audienceProfileSchema.optional(),
-    projectConstraints: z.string().optional(),
-    selectedModality: z.string().optional(),
+    projectConstraints: optionalText.optional(),
+    selectedModality: optionalText.optional(),
     blendModalities: z.array(z.string()).optional(),
     learningObjectives: z.any().optional(),
-    courseOutline: z.string().optional(),
-    trainingPlan: z.string().optional(),
-    sourceMaterial: z.string().optional(),
+    courseOutline: optionalText.optional(),
+    trainingPlan: optionalText.optional(),
+    sourceMaterial: optionalText.optional(),
     keyContacts: contactsSchema.optional(),
   }),
   generateStoryboard: z.object({
-    topic: z.string(),
-    targetAudience: z.string().optional(),
+    topic: nonEmptyText,
+    targetAudience: optionalText.optional(),
   }),
   generateInitialInquiryMap: z.object({
     brief: briefSchema,
-    uid: z.string(),
-    initiativeId: z.string(),
-    documents: z.string().optional(),
-    answers: z.string().optional(),
+    uid: nonEmptyText,
+    initiativeId: nonEmptyText,
+    documents: optionalText.optional(),
+    answers: optionalText.optional(),
   }),
   generateAvatar: z.object({
-    name: z.string(),
-    motivation: z.string().optional(),
-    challenges: z.string().optional(),
-    ageRange: z.string().optional(),
-    techProficiency: z.string().optional(),
-    educationLevel: z.string().optional(),
-    learningPreferences: z.string().optional(),
-    seedExtra: z.string().optional(),
+    name: nonEmptyText,
+    motivation: optionalText.optional(),
+    challenges: optionalText.optional(),
+    ageRange: optionalText.optional(),
+    techProficiency: optionalText.optional(),
+    educationLevel: optionalText.optional(),
+    learningPreferences: optionalText.optional(),
+    seedExtra: optionalText.optional(),
   }),
   savePersona: z.object({
-    initiativeId: z.string(),
-    personaId: z.string(),
-    persona: z.object({ type: z.string() }).passthrough(),
+    initiativeId: nonEmptyText,
+    personaId: nonEmptyText,
+    persona: z.object({ type: nonEmptyText }).passthrough(),
   }),
   generateInvitation: z.object({
-    businessName: z.string(),
+    businessName: nonEmptyText,
     businessEmail: z.string().email(),
   }),
   sendEmailBlast: z.object({
-    subject: z.string(),
-    message: z.string(),
-    __token: z.string().optional(),
+    subject: nonEmptyText,
+    message: nonEmptyText,
+    __token: optionalText.optional(),
   }),
   sendEmailReply: z.object({
     recipientEmail: z.string().email(),
-    subject: z.string(),
-    message: z.string(),
+    subject: nonEmptyText,
+    message: nonEmptyText,
   }),
   triggerZap: z.object({
     zapUrl: z.string().url(),

--- a/src/components/HierarchicalOutlineGenerator.jsx
+++ b/src/components/HierarchicalOutlineGenerator.jsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "react-router-dom";
 import { app, auth } from "../firebase.js";
 import { saveInitiative } from "../utils/initiatives.js";
 import { useProject } from "../context/ProjectContext.jsx";
+import { omitEmptyStrings } from "../utils/omitEmptyStrings.js";
 import PropTypes from "prop-types";
 import "./AIToolsGenerators.css";
 
@@ -98,17 +99,21 @@ const HierarchicalOutlineGenerator = ({
     setError("");
     setCourseOutline("");
     try {
-      const { data } = await callGenerate({
-        projectBrief,
-        businessGoal,
-        audienceProfile,
-        projectConstraints,
-        keyContacts,
-        selectedModality,
-        blendModalities,
-        learningObjectives,
-        sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
-      });
+      const { data } = await callGenerate(
+        omitEmptyStrings({
+          projectBrief,
+          businessGoal,
+          audienceProfile,
+          projectConstraints,
+          keyContacts,
+          selectedModality,
+          blendModalities,
+          learningObjectives,
+          sourceMaterial: sourceMaterials
+            .map((f) => f.content)
+            .join("\n"),
+        })
+      );
       const outlineItems = Array.isArray(data.outline) ? data.outline : [];
       if (!outlineItems.length) {
         throw new Error("No outline returned");

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -18,6 +18,7 @@ import TrainingPlanGenerator from "./TrainingPlanGenerator.jsx";
 import { useProject } from "../context/ProjectContext.jsx";
 import "./AIToolsGenerators.css";
 import PersonaDisplay from "./PersonaDisplay.jsx";
+import { omitEmptyStrings } from "../utils/omitEmptyStrings.js";
 
 const formatKeyword = (kw = "") =>
   kw ? kw.charAt(0).toUpperCase() + kw.slice(1) : "";
@@ -904,13 +905,15 @@ const InitiativesNew = () => {
         setPersonaCount(0);
 
     try {
-      const { data } = await generateClarifyingQuestions({
-        businessGoal,
-        audienceProfile,
-        sourceMaterial: getCombinedSource(),
-        projectConstraints,
-        keyContacts,
-      });
+      const { data } = await generateClarifyingQuestions(
+        omitEmptyStrings({
+          businessGoal,
+          audienceProfile,
+          sourceMaterial: getCombinedSource(),
+          projectConstraints,
+          keyContacts,
+        })
+      );
 
       const qsRaw = (data.clarifyingQuestions || []).slice(0, 9);
       const qs = qsRaw.map((q) =>
@@ -949,15 +952,17 @@ const InitiativesNew = () => {
     setError("");
 
     try {
-      const { data } = await generateProjectBrief({
-        businessGoal,
-        audienceProfile,
-        sourceMaterial: getCombinedSource(),
-        projectConstraints,
-        keyContacts,
-        clarifyingQuestions,
-        clarifyingAnswers,
-      });
+      const { data } = await generateProjectBrief(
+        omitEmptyStrings({
+          businessGoal,
+          audienceProfile,
+          sourceMaterial: getCombinedSource(),
+          projectConstraints,
+          keyContacts,
+          clarifyingQuestions,
+          clarifyingAnswers,
+        })
+      );
 
       if (!data?.projectBrief) {
         throw new Error("No project brief returned.");
@@ -1015,17 +1020,19 @@ const InitiativesNew = () => {
     setNextError("");
 
     try {
-      const { data } = await generateLearningStrategy({
-        projectBrief,
-        businessGoal,
-        audienceProfile,
-        projectConstraints,
-        keyContacts,
-        clarifyingQuestions,
-        clarifyingAnswers,
-        personaCount: personas.length,
-        sourceMaterial: getCombinedSource(),
-      });
+      const { data } = await generateLearningStrategy(
+        omitEmptyStrings({
+          projectBrief,
+          businessGoal,
+          audienceProfile,
+          projectConstraints,
+          keyContacts,
+          clarifyingQuestions,
+          clarifyingAnswers,
+          personaCount: personas.length,
+          sourceMaterial: getCombinedSource(),
+        })
+      );
 
       if (
         !data?.modalityRecommendation ||
@@ -1093,19 +1100,21 @@ const InitiativesNew = () => {
       let usedAdjLocal = [...usedAdjectives];
       let usedNounLocal = [...usedNouns];
       for (let i = 0; i < toGenerate; i++) {
-        const personaRes = await generateLearnerPersona({
-          projectBrief,
-          businessGoal,
-          audienceProfile,
-          projectConstraints,
-          keyContacts,
-          sourceMaterial: getCombinedSource(),
-          existingMotivationKeywords: usedMotivationKeywords,
-          existingChallengeKeywords: usedChallengeKeywords,
-          existingTypes,
-          existingLearningPreferenceKeywords: usedLearningPrefKeywords,
-          selectedTraits: personaQualities,
-        });
+        const personaRes = await generateLearnerPersona(
+          omitEmptyStrings({
+            projectBrief,
+            businessGoal,
+            audienceProfile,
+            projectConstraints,
+            keyContacts,
+            sourceMaterial: getCombinedSource(),
+            existingMotivationKeywords: usedMotivationKeywords,
+            existingChallengeKeywords: usedChallengeKeywords,
+            existingTypes,
+            existingLearningPreferenceKeywords: usedLearningPrefKeywords,
+            selectedTraits: personaQualities,
+          })
+        );
         let personaData = normalizePersona(personaRes.data);
         personaData.summary =
           personaData.summary || getRandomItem(SUMMARY_OPTIONS);
@@ -1218,19 +1227,21 @@ const InitiativesNew = () => {
         ...usedTypes,
         ...existingTypesCurrent,
       ];
-      const personaRes = await generateLearnerPersona({
-        projectBrief,
-        businessGoal,
-        audienceProfile,
-        projectConstraints,
-        keyContacts,
-        sourceMaterial: getCombinedSource(),
-        existingMotivationKeywords: usedMotivationKeywords,
-        existingChallengeKeywords: usedChallengeKeywords,
-        existingTypes,
-        existingLearningPreferenceKeywords: usedLearningPrefKeywords,
-        selectedTraits: personaQualities,
-      });
+      const personaRes = await generateLearnerPersona(
+        omitEmptyStrings({
+          projectBrief,
+          businessGoal,
+          audienceProfile,
+          projectConstraints,
+          keyContacts,
+          sourceMaterial: getCombinedSource(),
+          existingMotivationKeywords: usedMotivationKeywords,
+          existingChallengeKeywords: usedChallengeKeywords,
+          existingTypes,
+          existingLearningPreferenceKeywords: usedLearningPrefKeywords,
+          selectedTraits: personaQualities,
+        })
+      );
       let personaData = normalizePersona(personaRes.data);
       personaData.summary =
         personaData.summary || getRandomItem(SUMMARY_OPTIONS);

--- a/src/components/LearningDesignDocument.jsx
+++ b/src/components/LearningDesignDocument.jsx
@@ -4,6 +4,7 @@ import { useSearchParams, useNavigate } from "react-router-dom";
 import { app, auth } from "../firebase.js";
 import { saveInitiative } from "../utils/initiatives.js";
 import { useProject } from "../context/ProjectContext.jsx";
+import { omitEmptyStrings } from "../utils/omitEmptyStrings.js";
 import PropTypes from "prop-types";
 import "./AIToolsGenerators.css";
 
@@ -64,19 +65,21 @@ const LearningDesignDocument = ({
     setError("");
     setLearningDesignDocument("");
     try {
-      const { data } = await callGenerate({
-        projectBrief,
-        businessGoal,
-        audienceProfile,
-        projectConstraints,
-        keyContacts,
-        selectedModality,
-        blendModalities,
-        learningObjectives,
-        courseOutline,
-        trainingPlan,
-        sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
-      });
+      const { data } = await callGenerate(
+        omitEmptyStrings({
+          projectBrief,
+          businessGoal,
+          audienceProfile,
+          projectConstraints,
+          keyContacts,
+          selectedModality,
+          blendModalities,
+          learningObjectives,
+          courseOutline,
+          trainingPlan,
+          sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
+        })
+      );
       setBaseDocument(data.document);
     } catch (err) {
       console.error("Error generating learning design document:", err);

--- a/src/components/LearningObjectivesGenerator.jsx
+++ b/src/components/LearningObjectivesGenerator.jsx
@@ -6,6 +6,7 @@ import { saveInitiative } from "../utils/initiatives.js";
 import { useProject } from "../context/ProjectContext.jsx";
 import PropTypes from "prop-types";
 import "./AIToolsGenerators.css";
+import { omitEmptyStrings } from "../utils/omitEmptyStrings.js";
 
 const APPROACHES = [
   { value: "Bloom", label: "Bloom's Taxonomy" },
@@ -60,18 +61,20 @@ const LearningObjectivesGenerator = ({
     setLoading(true);
     setError("");
     try {
-      const { data } = await callGenerate({
-        projectBrief,
-        businessGoal,
-        audienceProfile,
-        projectConstraints,
-        keyContacts,
-        selectedModality,
-        blendModalities,
-        sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
-        approach,
-        bloomLevel,
-      });
+      const { data } = await callGenerate(
+        omitEmptyStrings({
+          projectBrief,
+          businessGoal,
+          audienceProfile,
+          projectConstraints,
+          keyContacts,
+          selectedModality,
+          blendModalities,
+          sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
+          approach,
+          bloomLevel,
+        })
+      );
       const result = {
         approach: data.approach,
         bloomLevel: data.bloomLevel,
@@ -110,22 +113,24 @@ const LearningObjectivesGenerator = ({
     setLoading(true);
     setError("");
     try {
-        const { data } = await callGenerate({
-          projectBrief,
-          businessGoal,
-          audienceProfile,
-          projectConstraints,
-          keyContacts,
-          selectedModality,
-          blendModalities,
-          sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
-          approach: learningObjectives.approach,
-          bloomLevel: learningObjectives.bloomLevel,
-        ...(learningObjectives.category
-          ? { category: learningObjectives.category }
-          : {}),
-        refresh: { type, index, existing: getAllTexts() },
-      });
+        const { data } = await callGenerate(
+          omitEmptyStrings({
+            projectBrief,
+            businessGoal,
+            audienceProfile,
+            projectConstraints,
+            keyContacts,
+            selectedModality,
+            blendModalities,
+            sourceMaterial: sourceMaterials.map((f) => f.content).join("\n"),
+            approach: learningObjectives.approach,
+            bloomLevel: learningObjectives.bloomLevel,
+            ...(learningObjectives.category
+              ? { category: learningObjectives.category }
+              : {}),
+            refresh: { type, index, existing: getAllTexts() },
+          })
+        );
       const obj = transform(data.options || []);
       setLearningObjectives((prev) => {
         const updated = { ...prev };

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -4,6 +4,7 @@ import { getFunctions, httpsCallable } from "firebase/functions";
 import { onAuthStateChanged } from "firebase/auth";
 import { app, auth } from "../firebase";
 import { saveInitiative, loadInitiative } from "../utils/initiatives";
+import { omitEmptyStrings } from "../utils/omitEmptyStrings.js";
 import "./AIToolsGenerators.css";
 
 const ProjectSetup = () => {
@@ -220,19 +221,21 @@ const ProjectSetup = () => {
     setLoading(true);
     setError("");
     try {
-      const { data } = await generateProjectQuestions({
-        businessGoal,
-        audienceProfile,
-        sourceMaterial: getCombinedSource(),
-        projectConstraints,
-        keyContacts: keyContacts.map(({ id, name, jobTitle, profile, info }) => ({
-          id,
-          name,
-          jobTitle,
-          profile,
-          info,
-        })),
-      });
+      const { data } = await generateProjectQuestions(
+        omitEmptyStrings({
+          businessGoal,
+          audienceProfile,
+          sourceMaterial: getCombinedSource(),
+          projectConstraints,
+          keyContacts: keyContacts.map(({ id, name, jobTitle, profile, info }) => ({
+            id,
+            name,
+            jobTitle,
+            profile,
+            info,
+          })),
+        })
+      );
       const qsRaw = (data.projectQuestions || []).slice(0, 9);
       const qs = qsRaw.map((q, idx) => {
         const contactIds = (q.stakeholders || q.contacts || []).map((name) => {
@@ -265,13 +268,15 @@ const ProjectSetup = () => {
 
           const brief = `Project Name: ${projectName}\nBusiness Goal: ${businessGoal}\nAudience: ${audienceProfile}\nConstraints:${projectConstraints}`;
           try {
-            const mapResp = await generateInitialInquiryMap({
-              uid,
-              initiativeId,
-              brief,
-              documents: getCombinedSource(),
-              answers: "",
-            });
+            const mapResp = await generateInitialInquiryMap(
+              omitEmptyStrings({
+                uid,
+                initiativeId,
+                brief,
+                documents: getCombinedSource(),
+                answers: "",
+              })
+            );
             const hypotheses = mapResp?.data?.hypotheses || [];
             setToast(`Inquiry map created with ${hypotheses.length} hypotheses.`);
             await new Promise((res) => setTimeout(res, 1000));

--- a/src/utils/omitEmptyStrings.js
+++ b/src/utils/omitEmptyStrings.js
@@ -1,0 +1,6 @@
+export const omitEmptyStrings = (obj = {}) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(
+      ([, v]) => !(typeof v === "string" && v.trim() === "")
+    )
+  );


### PR DESCRIPTION
## Summary
- allow optional text schemas to accept empty strings and trim server-side
- ensure required fields enforce non-empty values
- strip blank optional fields from client payloads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b610a999cc832bbc3e32b52baacce6