### PR TITLE
Handle clarifyingAsked migration

### DIFF
--- a/scripts/migrateAskedField.js
+++ b/scripts/migrateAskedField.js
@@ -1,0 +1,48 @@
+/* eslint-env node */
+/* global process */
+import admin from "firebase-admin";
+
+admin.initializeApp();
+const db = admin.firestore();
+
+async function migrateAskedField() {
+  const usersSnap = await db.collection("users").get();
+  for (const user of usersSnap.docs) {
+    const initsSnap = await user.ref.collection("initiatives").get();
+    for (const docSnap of initsSnap.docs) {
+      const data = docSnap.data();
+      const contacts = (data.contacts || data.keyContacts || []).map(
+        (c, i) => ({ id: c.id || `C${i + 1}`, ...c }),
+      );
+      const nameToId = Object.fromEntries(
+        contacts.map((c) => [c.name, c.id]),
+      );
+      const projectQuestions = data.projectQuestions || [];
+      let changed = false;
+      for (const q of projectQuestions) {
+        if (!q.asked) continue;
+        const newAsked = {};
+        let qChanged = false;
+        for (const [key, val] of Object.entries(q.asked)) {
+          const id = nameToId[key] || key;
+          newAsked[id] = val;
+          if (id !== key) qChanged = true;
+        }
+        if (qChanged) {
+          q.asked = newAsked;
+          changed = true;
+        }
+      }
+      if (changed) {
+        await docSnap.ref.update({ projectQuestions });
+        console.log(`Updated asked field for ${user.id}/${docSnap.id}`);
+      }
+    }
+  }
+  console.log("Asked field migration complete");
+}
+
+migrateAskedField().catch((err) => {
+  console.error("Migration failed", err);
+  process.exit(1);
+});

--- a/scripts/migrateInitiatives.js
+++ b/scripts/migrateInitiatives.js
@@ -34,12 +34,22 @@ async function migrateInitiatives() {
           contactId: contacts.find((c) => c.name === name)?.id || name,
           text: typeof val === "string" ? val : val?.text || "",
         }));
+        const rawAsked = data.clarifyingAsked
+          ? data.clarifyingAsked[idx] || {}
+          : {};
+        const asked = Object.fromEntries(
+          Object.entries(rawAsked).map(([name, val]) => [
+            contacts.find((c) => c.name === name)?.id || name,
+            val,
+          ]),
+        );
         return {
           id: questionObj.id || `Q${idx + 1}`,
           phase: questionObj.phase || "General",
           question: questionObj.question,
           contacts: contactsIds,
           answers,
+          asked,
         };
       });
 


### PR DESCRIPTION
## Summary
- map `clarifyingAsked` names to contact IDs when building `projectQuestions`
- fallback to contact name in email reply processing when asked entry lacks an ID
- add one-time script to convert existing `asked` entries from names to IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b61904bcb8832ba9c738004a44e016