### PR TITLE
Handle hypothesis field fallback

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -881,7 +881,7 @@ export const processInboundEmail = onRequest(
         const projectContext = contextPieces.join("\n\n");
         const hypotheses = (init.inquiryMap && init.inquiryMap.hypotheses) || init.hypotheses || [];
         const hypothesisList = hypotheses
-          .map((h) => `${h.id}: ${h.statement || h.text || h.label || h.id}`)
+          .map((h) => `${h.id}: ${h.statement || h.hypothesis || h.text || h.label || h.id}`)
           .join("\n");
 
         const dhQuestion =
@@ -1066,7 +1066,7 @@ Respond ONLY in this JSON format:
         // Triage evidence to update hypothesis confidences and suggest new hypotheses
         const triagePrompt = (() => {
           const hypothesesList = hypotheses
-            .map((h) => `${h.id}: ${h.statement || h.text || h.label || h.id}`)
+            .map((h) => `${h.id}: ${h.statement || h.hypothesis || h.text || h.label || h.id}`)
             .join("\n");
           const contactsList = (contacts || [])
             .map((c) => `${c.name} (${c.role || "Unknown Role"})`)
@@ -1177,7 +1177,7 @@ Known Project Stakeholders:\n${contactsList}`;
               await db
                 .collection("users").doc(uid)
                 .collection("notifications").doc(`hyp-${h.id}`)
-                .set({ type: "hypothesisConfidence", message: `${h.statement || h.id} confidence now at ${(now * 100).toFixed(0)}%`, count: FieldValue.increment(1), createdAt: FieldValue.serverTimestamp() }, { merge: true });
+                .set({ type: "hypothesisConfidence", message: `${h.statement || h.hypothesis || h.id} confidence now at ${(now * 100).toFixed(0)}%`, count: FieldValue.increment(1), createdAt: FieldValue.serverTimestamp() }, { merge: true });
             }
           }
         }

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -680,7 +680,7 @@ const DiscoveryHub = () => {
       const questionSet = new Set(questions.map((q) => q.question.toLowerCase()));
 
       const hypothesisList = hypotheses
-        .map((h) => `${h.id}: ${h.statement || h.text || h.label || h.id}`)
+        .map((h) => `${h.id}: ${h.statement || h.hypothesis || h.text || h.label || h.id}`)
         .join("\n");
 
       const prompt = `You are an expert Instructional Designer and Performance Consultant. You are analyzing ${respondent}'s answer to a specific discovery question. Your goal is to understand what this answer means for the training project and to determine follow-up actions.
@@ -3270,7 +3270,7 @@ Respond ONLY in this JSON format:
                 <option value="">None</option>
                 {hypotheses.map((h) => (
                   <option key={h.id} value={h.id}>
-                    {h.statement || h.text || h.label || h.id}
+                    {h.statement || h.hypothesis || h.text || h.label || h.id}
                   </option>
                 ))}
               </select>

--- a/src/components/HypothesisCard.jsx
+++ b/src/components/HypothesisCard.jsx
@@ -11,7 +11,7 @@ const HypothesisCard = ({ hypothesis }) => {
     <div>
       <div className="font-semibold mb-1">
         {titleId ? `Hypothesis ${titleId}: ` : ""}
-        {hypothesis.statement || hypothesis.label || ""}
+        {hypothesis.statement || hypothesis.hypothesis || hypothesis.label || ""}
       </div>
       <div className="text-sm text-gray-600">
         {pct}% confidence • {evidenceCount} items of evidence

--- a/src/components/HypothesisSlideOver.jsx
+++ b/src/components/HypothesisSlideOver.jsx
@@ -294,7 +294,7 @@ const HypothesisSlideOver = ({
         </div>
         <div className="font-semibold mb-1">
           {titleId ? `Hypothesis ${titleId}: ` : ""}
-          {hypothesis.statement || hypothesis.label || ""}
+          {hypothesis.statement || hypothesis.hypothesis || hypothesis.label || ""}
         </div>
         <div
           className="text-sm text-gray-200 cursor-pointer underline"

--- a/src/components/InquiryMap.jsx
+++ b/src/components/InquiryMap.jsx
@@ -48,7 +48,7 @@ const InquiryMap = ({ hypotheses = [] }) => {
                 
               </div>
               <div className="text-white mb-2">
-                {h.statement || h.label || ""}
+                {h.statement || h.hypothesis || h.label || ""}
               </div>
               <div className="flex items-center justify-end gap-4">
                 {up && <span className="text-green-600">▲</span>}

--- a/src/components/ProjectOverview.jsx
+++ b/src/components/ProjectOverview.jsx
@@ -84,7 +84,7 @@ const ProjectOverview = ({
       arr.push({ text: `Status update (${s.audience})`, date: s.date });
     });
     hypotheses.forEach((h) => {
-      arr.push({ text: `Hypothesis added: ${h.statement || h.label}`, date: h.createdAt });
+      arr.push({ text: `Hypothesis added: ${h.statement || h.hypothesis || h.label}`, date: h.createdAt });
     });
     return arr
       .sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0))
@@ -132,7 +132,7 @@ const ProjectOverview = ({
                     <div className="font-semibold">Hypothesis {h.displayId}</div>
                   </div>
                   <div className="text-white mb-2">
-                    {h.statement || h.label || ""}
+                    {h.statement || h.hypothesis || h.label || ""}
                   </div>
                   <div className="flex items-center justify-end gap-4">
                     {h.trend > 0 && <span className="text-green-600">▲</span>}

--- a/src/context/InquiryMapContext.jsx
+++ b/src/context/InquiryMapContext.jsx
@@ -143,6 +143,7 @@ export const InquiryMapProvider = ({ children }) => {
               updatedHypotheses.push({
                 id: `hyp-${Date.now()}`,
                 statement: analysis.newHypothesis.statement,
+                hypothesis: analysis.newHypothesis.statement,
                 confidence: newConf,
                 evidence: { supporting: [], refuting: [] },
                 sourceContributions: [],
@@ -237,6 +238,7 @@ export const InquiryMapProvider = ({ children }) => {
         const newHypothesis = {
           id: `hyp-${Date.now()}`,
           statement,
+          hypothesis: statement,
           confidence: 0,
           evidence: { supporting: [], refuting: [] },
           sourceContributions: [],
@@ -358,7 +360,8 @@ export const InquiryMapProvider = ({ children }) => {
         const picked = sh.splice(idx, 1)[0];
         const newHyp = {
           id: `hyp-${Date.now()}`,
-          statement: picked.statement,
+          statement: picked.statement || picked.hypothesis,
+          hypothesis: picked.hypothesis || picked.statement,
           confidence: picked.confidence ?? 0,
           evidence: { supporting: [], refuting: [] },
           sourceContributions: [],

--- a/src/pages/InquiryMapPage.jsx
+++ b/src/pages/InquiryMapPage.jsx
@@ -45,7 +45,7 @@ const InquiryMapContent = () => {
 
   const parsedHypotheses = (Array.isArray(hypotheses) ? hypotheses : []).map((h) => ({
     id: h.id,
-    statement: h.statement || h.text || h.label || h.id,
+    statement: h.statement || h.hypothesis || h.text || h.label || h.id,
     confidence: typeof h.confidence === "number" ? h.confidence : 0,
     supportingEvidence: h.evidence?.supporting || h.supportingEvidence || [],
     refutingEvidence: h.evidence?.refuting || h.refutingEvidence || [],

--- a/src/utils/inquiryLogic.js
+++ b/src/utils/inquiryLogic.js
@@ -23,7 +23,7 @@ export const generateTriagePrompt = (evidenceText, hypotheses, contacts) => {
     .map((h) => {
       const sup = (h.evidence?.supporting || h.supportingEvidence || []).length;
       const ref = (h.evidence?.refuting || h.refutingEvidence || []).length;
-      return `${h.id}: ${h.statement || h.text || h.label || h.id} (Supports: ${sup}, Refutes: ${ref})`;
+      return `${h.id}: ${h.statement || h.hypothesis || h.text || h.label || h.id} (Supports: ${sup}, Refutes: ${ref})`;
     })
     .join("\n");
   


### PR DESCRIPTION
## Summary
- include `hypothesis` field when deriving display statements
- fall back to `hypothesis.hypothesis` in hypothesis rendering components
- store both `statement` and `hypothesis` when adding new hypotheses

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b61aeb2820832ba686d9ae5051db89