### PR TITLE
Use functional update when adding contacts

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -1997,30 +1997,32 @@ Respond ONLY in this JSON format:
 
   const addContactByName = (name) => {
     if (!name) return;
-    const lower = name.toLowerCase();
-    if (contacts.some((c) => c.name.toLowerCase() === lower)) return;
-    const color = colorPalette[contacts.length % colorPalette.length];
-    const newContact = {
-      id: crypto.randomUUID(),
-      name,
-      jobTitle: "",
-      profile: "",
-      info: { email: "", slack: "", teams: "" },
-      color,
-    };
-    const updated = [...contacts, newContact];
-    setContacts(updated);
-    if (uid) {
-      saveInitiative(uid, initiativeId, {
-        keyContacts: updated.map(({ id, name, jobTitle, profile, info }) => ({
-          id,
-          name,
-          jobTitle,
-          profile,
-          info,
-        })),
-      });
-    }
+    setContacts((prev) => {
+      const lower = name.toLowerCase();
+      if (prev.some((c) => c.name.toLowerCase() === lower)) return prev;
+      const color = colorPalette[prev.length % colorPalette.length];
+      const newContact = {
+        id: crypto.randomUUID(),
+        name,
+        jobTitle: "",
+        profile: "",
+        info: { email: "", slack: "", teams: "" },
+        color,
+      };
+      const updated = [...prev, newContact];
+      if (uid) {
+        saveInitiative(uid, initiativeId, {
+          keyContacts: updated.map(({ id, name, jobTitle, profile, info }) => ({
+            id,
+            name,
+            jobTitle,
+            profile,
+            info,
+          })),
+        });
+      }
+      return updated;
+    });
   };
 
   const resolveSuggestionsForContacts = async (suggestions) => {


### PR DESCRIPTION
## Summary
- prevent stale contact state by using functional setContacts
- persist updated contact list to Firestore in updater

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b61d3f15e8832ba32f376788bd502b