### PR TITLE
Use callable functions for project setup and open CORS

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -501,7 +501,7 @@ export const generateProjectQuestions = onCall(
     region: "us-central1",
     secrets: ["GOOGLE_GENAI_API_KEY"],
     invoker: "public",
-    cors: ["https://thoughtify.training"],
+    cors: true,
   },
   async (request) => {
     const {
@@ -912,7 +912,7 @@ export const generateContentAssets = onCall(
     region: "us-central1",
     secrets: ["GOOGLE_GENAI_API_KEY"],
     timeoutSeconds: 300,
-    cors: ["https://thoughtify.training"],
+    cors: true,
   },
   async (req) => {
     const { ldd, component, components, jobId } = req.data || {};

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { getFunctions, httpsCallable } from "firebase/functions";
+import { httpsCallable } from "firebase/functions";
 import { onAuthStateChanged } from "firebase/auth";
-import { app, auth } from "../firebase";
+import { functions, auth } from "../firebase";
 import { saveInitiative, loadInitiative } from "../utils/initiatives";
 import { omitEmptyStrings } from "../utils/omitEmptyStrings.js";
 import "./AIToolsGenerators.css";
@@ -12,7 +12,6 @@ const ProjectSetup = () => {
   const initiativeId = searchParams.get("initiativeId");
   const navigate = useNavigate();
 
-  const functions = getFunctions(app, "us-central1");
   const generateProjectQuestions = httpsCallable(
     functions,
     "generateProjectQuestions"


### PR DESCRIPTION
## Summary
- Use shared Firebase `functions` instance with `httpsCallable` in `ProjectSetup`
- Allow cross-origin requests by enabling CORS on `generateProjectQuestions` and `generateContentAssets`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6286ec3d8832baa9ecab449604831