### PR TITLE
Refactor project question status storage

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -587,23 +587,19 @@ Source Material: ${sourceMaterial}${contactsInfo}`;
           );
           return match ? match.id : name;
         });
-        const contactStatus = {};
-        contacts.forEach((cid) => {
-          contactStatus[cid] = {
-            current: "Ask",
-            history: [
-              { status: "Ask", timestamp: new Date().toISOString() },
-            ],
-            answers: [],
-          };
-        });
+        const contactStatus = contacts.map((cid) => ({
+          contactId: cid,
+          currentStatus: "Ask",
+          askedAt: new Date().toISOString(),
+          askedBy: request.auth?.uid || null,
+          answers: [],
+        }));
         return {
           id: q.id || `Q${idx + 1}`,
           phase: q.phase || "General",
           question: typeof q === "string" ? q : q.question,
           contacts,
           contactStatus,
-          answers: [],
         };
       });
 
@@ -652,11 +648,13 @@ export const generateProjectBrief = onCall(
         : "";
     const clarificationsBlock = (() => {
       const pairs = projectQuestions.map((q) => {
-        const answersArray = Array.isArray(q.answers)
-          ? q.answers.map((a) => (typeof a === "string" ? a : a.text || ""))
-          : Object.values(q.answers || {}).map((a) =>
-              typeof a === "string" ? a : a?.text || "",
-            );
+        const answersArray = Array.isArray(q.contactStatus)
+          ? q.contactStatus.flatMap((cs) =>
+              (cs.answers || []).map((a) =>
+                typeof a === "string" ? a : a?.text || "",
+              ),
+            )
+          : [];
         return `Q: ${q?.question || ""}\nA: ${answersArray.join("; ")}`;
       });
       return pairs.length ? `\nClarifications:\n${pairs.join("\n")}` : "";
@@ -852,11 +850,13 @@ export const generateLearningStrategy = onCall(
 
     const clarificationsBlock = (() => {
       const pairs = projectQuestions.map((q) => {
-        const answersArray = Array.isArray(q.answers)
-          ? q.answers.map((a) => (typeof a === "string" ? a : a.text || ""))
-          : Object.values(q.answers || {}).map((a) =>
-              typeof a === "string" ? a : a?.text || "",
-            );
+        const answersArray = Array.isArray(q.contactStatus)
+          ? q.contactStatus.flatMap((cs) =>
+              (cs.answers || []).map((a) =>
+                typeof a === "string" ? a : a?.text || "",
+              ),
+            )
+          : [];
         return `Q: ${q?.question || ""}\nA: ${answersArray.join("; ")}`;
       });
       return pairs.length ? `\nClarifications:\n${pairs.join("\n")}` : "";

--- a/functions/mcpSchemas.js
+++ b/functions/mcpSchemas.js
@@ -19,20 +19,23 @@ export const projectQuestionSchema = z.object({
   question: nonEmptyText,
   stakeholders: z.array(z.string()).optional(),
   phase: optionalText.optional(),
-  answer: optionalText.optional(),
-  asked: z.record(z.boolean()).optional(),
   contacts: z.array(z.string()).optional(),
   contactStatus: z
-    .record(
+    .array(
       z.object({
-        current: nonEmptyText,
-        history: z
+        contactId: z.string(),
+        currentStatus: nonEmptyText,
+        askedAt: optionalText.optional(),
+        askedBy: optionalText.optional(),
+        answers: z
           .array(
-            z.object({ status: nonEmptyText, timestamp: nonEmptyText })
+            z.object({
+              text: nonEmptyText,
+              answeredAt: optionalText.optional(),
+            })
           )
           .optional(),
-        answers: z.array(z.any()).optional(),
-      }),
+      })
     )
     .optional(),
 });

--- a/src/components/AnswerSlideOver.jsx
+++ b/src/components/AnswerSlideOver.jsx
@@ -113,13 +113,15 @@ const AnswerSlideOver = ({
         {stage === "loading" && <p>Analyzing answer...</p>}
         {stage === "results" && (
           <>
-            {question.contactStatus?.[contact]?.answers?.length > 0 && (
+            {question.contactStatus?.find((cs) => cs.contactId === contact)?.answers?.length > 0 && (
               <details open>
                 <summary>Previous Answers</summary>
                 <ul>
-                  {question.contactStatus[contact].answers.map((a, i) => (
-                    <li key={i}>{a.text}</li>
-                  ))}
+                  {question.contactStatus
+                    .find((cs) => cs.contactId === contact)
+                    .answers.map((a, i) => (
+                      <li key={i}>{a.text}</li>
+                    ))}
                 </ul>
               </details>
             )}

--- a/src/components/InitiativesNew.jsx
+++ b/src/components/InitiativesNew.jsx
@@ -557,20 +557,19 @@ const InitiativesNew = () => {
           const match = keyContacts.find((c) => c.name === name || c.id === name);
           return match ? match.id : name;
         });
-        const statusMap = {};
-        contactIds.forEach((cid) => {
-          statusMap[cid] = {
-            current: "Ask",
-            history: [{ status: "Ask", timestamp: new Date().toISOString() }],
-            answers: [],
-          };
-        });
+        const statusArr = contactIds.map((cid) => ({
+          contactId: cid,
+          currentStatus: "Ask",
+          askedAt: new Date().toISOString(),
+          askedBy: auth.currentUser?.uid || null,
+          answers: [],
+        }));
         return {
           id: `Q${idx + 1}`,
           question: q.question || q,
           phase: q.phase || "General",
           contacts: contactIds,
-          contactStatus: statusMap,
+          contactStatus: statusArr,
         };
       });
       await saveInitiative(uid, initiativeId, {

--- a/src/components/Inquiries.jsx
+++ b/src/components/Inquiries.jsx
@@ -107,15 +107,15 @@ export default function NewInquiries({ user, openReplyModal }) {
             phase: "General",
             question: inquiry.message,
             contacts: [cid],
-            contactStatus: {
-              [cid]: {
-                current: "Ask",
-                history: [
-                  { status: "Ask", timestamp: new Date().toISOString() },
-                ],
+            contactStatus: [
+              {
+                contactId: cid,
+                currentStatus: "Ask",
+                askedAt: new Date().toISOString(),
+                askedBy: user.uid,
                 answers: [],
               },
-            },
+            ],
           });
         await saveInitiative(user.uid, project, { projectQuestions });
         await deleteDoc(doc(db, "inquiries", inquiry.id));

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -242,16 +242,19 @@ const ProjectSetup = () => {
           const match = keyContacts.find((c) => c.name === name || c.id === name);
           return match ? match.id : name;
         });
-        const statusMap = {};
-        contactIds.forEach((cid) => {
-          statusMap[cid] = { current: "Ask", history: [{ status: "Ask", timestamp: new Date().toISOString() }], answers: [] };
-        });
+        const statusArr = contactIds.map((cid) => ({
+          contactId: cid,
+          currentStatus: "Ask",
+          askedAt: new Date().toISOString(),
+          askedBy: auth.currentUser?.uid || null,
+          answers: [],
+        }));
         return {
           id: generateQuestionId(),
           question: typeof q === "string" ? q : q.question,
           phase: q.phase || "General",
           contacts: contactIds,
-          contactStatus: statusMap,
+          contactStatus: statusArr,
         };
       });
       const uid = auth.currentUser?.uid;


### PR DESCRIPTION
## Summary
- store per-contact question status in `contactStatus` array and remove top-level answer/status fields
- update schemas, server functions, and UI setup flows for new structure
- adjust email provider to update per-contact status entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b646b36a14832b8f99b542747a9a4a