### PR TITLE
Fix question filtering logic for per-contact status

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -596,7 +596,7 @@ export const processInboundEmail = onRequest(
       uid = m[2];
       sig = m[3];
     } else {
-      m = /^q([^\.]+)\.u(.+)$/i.exec(tag || "");
+      m = /^q([^.]+)\.u(.+)$/i.exec(tag || "");
       if (m) {
         questionId = m[1];
         uid = m[2];

--- a/src/utils/questionStatus.js
+++ b/src/utils/questionStatus.js
@@ -6,23 +6,28 @@ export const STATUS = {
 
 export function initStatus() {
   const timestamp = new Date().toISOString();
-  return { current: STATUS.ASK, history: [{ status: STATUS.ASK, timestamp }], answers: [] };
+  return {
+    currentStatus: STATUS.ASK,
+    history: [{ status: STATUS.ASK, timestamp }],
+    answers: [],
+  };
 }
 
 export function markAsked(state) {
   const timestamp = new Date().toISOString();
-  const next = state || initStatus();
-  if (next.current !== STATUS.ASKED) {
-    next.current = STATUS.ASKED;
+  const next = state ? { ...state } : initStatus();
+  if (next.currentStatus !== STATUS.ASKED) {
+    next.currentStatus = STATUS.ASKED;
     next.history = [...(next.history || []), { status: STATUS.ASKED, timestamp }];
   }
+  next.askedAt = timestamp;
   return next;
 }
 
 export function markAnswered(state, answer) {
   const timestamp = new Date().toISOString();
-  const next = state || initStatus();
-  next.current = STATUS.ANSWERED;
+  const next = state ? { ...state } : initStatus();
+  next.currentStatus = STATUS.ANSWERED;
   next.history = [...(next.history || []), { status: STATUS.ANSWERED, timestamp }];
   if (answer) {
     next.answers = [...(next.answers || []), { ...answer, answeredAt: timestamp }];


### PR DESCRIPTION
## Summary
- use `currentStatus` field in question status utilities
- compute question cards by inspecting each contact's current status
- fix regex escape in emailProviders to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6f7b1890c832ba9e9a73b45b87b4b