### PR TITLE
Surface notifications in sidebar with section badges

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -1025,7 +1025,7 @@ Respond ONLY in this JSON format:
                 questionId: String(questionId),
                 initiativeId,
                 href: initiativeId
-                  ? `/discovery?initiativeId=${initiativeId}`
+                  ? `/discovery?initiativeId=${initiativeId}&questionId=${questionId}&messageId=${msgRef.id}&qa=1`
                   : undefined,
                 messageId: msgRef.id,
                 createdAt: FieldValue.serverTimestamp(),

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -310,6 +310,30 @@ const DiscoveryHub = () => {
     }
   }, [searchParams, questions, openQAModal, focusQuestionCard]);
 
+  useEffect(() => {
+    const qId = searchParams.get("questionId");
+    const msgId = searchParams.get("messageId");
+    if (qId && msgId && questions.length && uid) {
+      const idx = questions.findIndex((q) => String(q.id) === String(qId));
+      if (idx !== -1) {
+        openQAModal(idx);
+        getDoc(doc(db, "users", uid, "messages", msgId)).then((snap) => {
+          const data = snap.data();
+          if (data) {
+            setAnalysisModal({
+              idx,
+              name: data.from || currentUserName,
+              loading: false,
+              analysis: data.analysis || "",
+              suggestions: data.suggestions || [],
+              selected: data.suggestions || [],
+            });
+          }
+        });
+      }
+    }
+  }, [searchParams, questions, uid, openQAModal, currentUserName]);
+
   const taskProjects = useMemo(() => {
     const set = new Set();
     projectTasks.forEach((t) => {

--- a/src/components/DiscoverySidebar.css
+++ b/src/components/DiscoverySidebar.css
@@ -27,6 +27,14 @@
   margin: 0.5rem 0;
 }
 
+.count-badge {
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 12px;
+  padding: 0 6px;
+  font-size: 0.75rem;
+  margin-left: 6px;
+}
+
 .discovery-sidebar li ul {
   margin-left: 1rem;
 }

--- a/src/components/DiscoverySidebar.jsx
+++ b/src/components/DiscoverySidebar.jsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
+import { useNotifications } from "../context/NotificationsContext.jsx";
 import "./DiscoverySidebar.css";
 
 export default function DiscoverySidebar() {
@@ -18,6 +19,14 @@ export default function DiscoverySidebar() {
   };
 
   const section = params.get("section");
+  const { unreadCounts } = useNotifications();
+  const totalUnread = Object.values(unreadCounts).reduce(
+    (sum, c) => sum + c,
+    0,
+  );
+
+  const badge = (count) =>
+    count > 0 && <span className="count-badge">{count}</span>;
   const tasksOpen =
     (pathname === "/discovery" && section === "tasks") ||
     pathname.startsWith("/action-dashboard");
@@ -31,10 +40,17 @@ export default function DiscoverySidebar() {
       <nav>
         <ul>
           <li>
+            <Link to={makeUrl("/notifications")}>
+              Notifications {badge(totalUnread)}
+            </Link>
+          </li>
+          <li>
             <Link to={makeUrl("/discovery")}>Overview</Link>
           </li>
           <li>
-            <Link to={makeUrl("/discovery", { section: "tasks" })}>Tasks</Link>
+            <Link to={makeUrl("/discovery", { section: "tasks" })}>
+              Tasks {badge(unreadCounts.tasks || 0)}
+            </Link>
             {tasksOpen && (
               <ul>
                 <li>
@@ -45,12 +61,12 @@ export default function DiscoverySidebar() {
           </li>
           <li>
             <Link to={makeUrl("/discovery", { section: "documents" })}>
-              Documents
+              Documents {badge(unreadCounts.documents || 0)}
             </Link>
           </li>
           <li>
             <Link to={makeUrl("/discovery", { section: "questions" })}>
-              Questions
+              Questions {badge(unreadCounts.questions || 0)}
             </Link>
             {questionsOpen && (
               <ul>
@@ -88,7 +104,14 @@ export default function DiscoverySidebar() {
             )}
           </li>
           <li>
-            <Link to={makeUrl("/messages")}>Messages</Link>
+            <Link to={makeUrl("/messages")}>
+              Messages {badge(unreadCounts.messages || 0)}
+            </Link>
+          </li>
+          <li>
+            <Link to={makeUrl("/inquiry-map")}>
+              Inquiry Map {badge(unreadCounts.inquiry || unreadCounts.inquiryMap || 0)}
+            </Link>
           </li>
           <li>
             <Link to={makeUrl("/project-status")}>Project Status</Link>
@@ -121,9 +144,6 @@ export default function DiscoverySidebar() {
                 </li>
               </ul>
             )}
-          </li>
-          <li>
-            <Link to={makeUrl("/inquiry-map")}>Inquiry Map</Link>
           </li>
         </ul>
       </nav>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -4,7 +4,6 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { auth } from "../firebase";
 import { loadInitiatives } from "../utils/initiatives";
 import UserSettingsSlideOver from "./UserSettingsSlideOver";
-import { useNotifications } from "../context/NotificationsContext.jsx";
 
 export default function NavBar() {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -12,15 +11,8 @@ export default function NavBar() {
   const [addMenu, setAddMenu] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [projects, setProjects] = useState([]);
-  const [notifMenu, setNotifMenu] = useState(false);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { notifications, unreadCounts, markAsRead } = useNotifications();
-
-  const totalUnread = Object.values(unreadCounts).reduce(
-    (sum, c) => sum + c,
-    0
-  );
 
   const initiativeId = searchParams.get("initiativeId");
   const activeProject = projects.find((p) => p.id === initiativeId);
@@ -131,53 +123,6 @@ export default function NavBar() {
         <div className="user-actions">
           {loggedIn && (
             <>
-              <div className="notification-menu">
-                <button
-                  className="notification-btn"
-                  type="button"
-                  onClick={() => setNotifMenu(!notifMenu)}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="24"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-                    <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-                  </svg>
-                  {totalUnread > 0 && (
-                    <span className="indicator">{totalUnread}</span>
-                  )}
-                </button>
-                {notifMenu && (
-                  <ul className="dropdown">
-                    {notifications.length === 0 ? (
-                      <li>No notifications</li>
-                    ) : (
-                      notifications.map((n) => (
-                        <li key={n.id}>
-                          <a
-                            href={n.href}
-                            onClick={() => {
-                              setNotifMenu(false);
-                              markAsRead(n.id);
-                            }}
-                          >
-                            {n.message}
-                            {n.count > 1 ? ` (${n.count})` : ""}
-                          </a>
-                        </li>
-                      ))
-                    )}
-                  </ul>
-                )}
-              </div>
               <img
                 src="https://placehold.co/40x40/764ba2/FFFFFF?text=ID"
                 alt="User Avatar"

--- a/src/components/Notifications.jsx
+++ b/src/components/Notifications.jsx
@@ -1,0 +1,28 @@
+import { useNotifications } from "../context/NotificationsContext.jsx";
+
+export default function Notifications() {
+  const { notifications, markAsRead } = useNotifications();
+
+  return (
+    <div className="notifications-page">
+      <h1>Notifications</h1>
+      {notifications.length === 0 ? (
+        <p>No notifications</p>
+      ) : (
+        <ul>
+          {notifications.map((n) => (
+            <li key={n.id} className="notification-item">
+              <a
+                href={n.href}
+                onClick={() => markAsRead(n.id)}
+              >
+                {n.message}
+                {n.count > 1 ? ` (${n.count})` : ""}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -38,6 +38,7 @@ import ProjectStatus from "./components/ProjectStatus.jsx";
 import ProjectStatusHistory from "./components/ProjectStatusHistory.jsx";
 import ZapierConfig from "./pages/ZapierConfig.jsx";
 import Messages from "./components/Messages.jsx";
+import Notifications from "./components/Notifications.jsx";
 
 window.PropTypes = PropTypes;
 
@@ -122,6 +123,10 @@ function Root() {
           <Route
             path="/messages"
             element={user ? <Messages /> : <Navigate to="/login" />}
+          />
+          <Route
+            path="/notifications"
+            element={user ? <Notifications /> : <Navigate to="/login" />}
           />
           <Route
             path="/action-dashboard"


### PR DESCRIPTION
## Summary
- Replace navbar bell with Notifications page and sidebar link
- Show live count badges for Notifications, Tasks, Documents, Questions, Messages, and Inquiry Map
- Move Project Status below Inquiry Map and fix notification links to open analysis

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b71e1a6680832ba24e09bbfc1f0700