### PR TITLE
Handle null merges for project questions

### DIFF
--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -2319,15 +2319,18 @@ Respond ONLY in this JSON format:
 
   async function unmarkAsked(idx, contactId) {
     let updatedQuestions = questions;
+    let removed = { asked: false, answers: false };
     setQuestions((prev) => {
       const updated = [...prev];
       const q = updated[idx];
       if (q) {
-        if (q.asked[contactId] !== undefined) {
+        if (q.asked && q.asked[contactId] !== undefined) {
           delete q.asked[contactId];
+          removed.asked = true;
         }
         if (q.answers && q.answers[contactId]) {
           delete q.answers[contactId];
+          removed.answers = true;
         }
         if (q.contactStatus && q.contactStatus[contactId]) {
           q.contactStatus[contactId] = initStatus();
@@ -2341,6 +2344,12 @@ Respond ONLY in this JSON format:
       const saveQ = { ...q, contacts: getContactIds(q) };
       delete saveQ.idx;
       delete saveQ.contactIds;
+      if (removed.asked) {
+        saveQ.asked = { ...(saveQ.asked || {}), [contactId]: null };
+      }
+      if (removed.answers) {
+        saveQ.answers = { ...(saveQ.answers || {}), [contactId]: null };
+      }
       saveQ.contactStatus = Object.entries(saveQ.contactStatus || {}).map(
         ([cid, s]) => ({ contactId: cid, ...s })
       );

--- a/src/utils/__tests__/initiatives.test.js
+++ b/src/utils/__tests__/initiatives.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock firebase module to avoid initialization during tests
+vi.mock('../../firebase.js', () => ({ db: {} }));
+
+const { deepMerge, mergeQuestionArrays } = await import('../initiatives.js');
+
+describe('deepMerge', () => {
+  it('deletes keys when source has null or undefined', () => {
+    const result = deepMerge(
+      { a: 1, b: { c: 2 }, d: 4 },
+      { b: { c: null }, d: undefined, e: 3 }
+    );
+    expect(result).toEqual({ a: 1, e: 3 });
+    expect('b' in result).toBe(false);
+    expect('d' in result).toBe(false);
+  });
+});
+
+describe('mergeQuestionArrays', () => {
+  it('updates one question without clobbering others', () => {
+    const existing = [
+      { id: 1, text: 'q1', asked: { x: true } },
+      { id: 2, text: 'q2' },
+    ];
+    const updates = [{ id: 1, asked: { x: null } }];
+    const result = mergeQuestionArrays(existing, updates);
+    expect(result).toHaveLength(2);
+    const q1 = result.find((q) => q.id === 1);
+    const q2 = result.find((q) => q.id === 2);
+    expect(q1.asked).toBeUndefined();
+    expect(q2.text).toBe('q2');
+    expect(q2.asked).toBeUndefined();
+  });
+
+  it('replaces question when _replace is true', () => {
+    const existing = [{ id: 1, text: 'old', extra: 'x' }];
+    const updates = [{ id: 1, _replace: true, text: 'new' }];
+    const result = mergeQuestionArrays(existing, updates);
+    expect(result).toEqual([{ id: 1, text: 'new' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow `deepMerge` to drop keys set to `null`/`undefined`
- Add `_replace` option when merging question arrays
- Persist unmarking questions by saving deletions
- Test merge utilities handle removals and replacements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b73081f05c832b827070e7889c98b7