### PR TITLE
Preserve contact statuses when converting objects

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -719,7 +719,9 @@ export const processInboundEmail = onRequest(
         const q = qArr[qIdx];
         const statusArr = Array.isArray(q.contactStatus)
           ? q.contactStatus
-          : [];
+          : Object.entries(q.contactStatus || {}).map(
+              ([contactId, status]) => ({ contactId, ...status })
+            );
         const key = contactId || name;
         let entry = statusArr.find(
           (cs) => cs.contactId === key || cs.contactId === name,


### PR DESCRIPTION
## Summary
- Convert non-array `contactStatus` objects into arrays of `{ contactId, ...status }` to retain existing entries
- Reassign updated status array back to `q.contactStatus` after modifications

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b738e30eec832b8bea74221db928dd