### PR TITLE
Ensure inbound email processing completes before exit

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -799,8 +799,10 @@ export const processInboundEmail = onRequest(
     // Respond quickly to Postmark
     res.status(200).send({ status: "ok" });
 
-    // Continue heavy processing asynchronously
-    (async () => {
+    // Continue heavy processing asynchronously and ensure completion.
+    // If this work risks exceeding the function timeout, move it to a
+    // background trigger or queue.
+    await (async () => {
       if (initiativeId && GOOGLE_GENAI_API_KEY.value()) {
         try {
           const initSnap = await db


### PR DESCRIPTION
## Summary
- await Postmark reply processing so notifications and AI analysis finish
- note that long-running work should move to a background trigger or queue

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b742fcdb8c832ba404b431553f0110