### PR TITLE
Fix question status after sending email

### DIFF
--- a/functions/emailProviders.js
+++ b/functions/emailProviders.js
@@ -447,7 +447,9 @@ export const sendQuestionEmail = onCall(
           const q = qArr[qIdx] || {};
           const statusEntry = Array.isArray(q.contactStatus)
             ? q.contactStatus
-            : [];
+            : Object.entries(q.contactStatus || {}).map(
+                ([contactId, status]) => ({ contactId, ...status })
+              );
           const now = new Date().toISOString();
           matched.forEach((contact) => {
             if (!contact.id) return;
@@ -458,7 +460,10 @@ export const sendQuestionEmail = onCall(
             }
             entry.askedAt = now;
             entry.askedBy = asker;
-            entry.currentStatus = "asked";
+            entry.currentStatus = "Asked";
+            entry.history = Array.isArray(entry.history)
+              ? [...entry.history, { status: "Asked", timestamp: now }]
+              : [{ status: "Asked", timestamp: now }];
           });
           q.contactStatus = statusEntry;
           qArr[qIdx] = q;

--- a/src/components/DiscoveryHub.jsx
+++ b/src/components/DiscoveryHub.jsx
@@ -668,6 +668,10 @@ const DiscoveryHub = () => {
         message: emailDraft.body,
         questionId: emailDraft.questionIds[0],
       });
+      const qIdx = questions.findIndex(
+        (q) => q.id === emailDraft.questionIds[0],
+      );
+      if (qIdx >= 0) await markAsked(qIdx, emailDraft.recipients);
       alert("Email sent");
       nextDraft();
     } catch (err) {


### PR DESCRIPTION
## Summary
- Ensure sendQuestionEmail marks contact status as Asked and records history
- Normalize existing contactStatus entries to avoid missed matches
- Update Discovery Hub to mark local status as asked after sending email so filters and labels reflect backend changes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8541f052c832b91fcbe6db50f6f7d